### PR TITLE
fix(k8s): fix 500 in PoolPublicIPDisabled test

### DIFF
--- a/scaleway/resource_k8s_pool.go
+++ b/scaleway/resource_k8s_pool.go
@@ -487,6 +487,16 @@ func resourceScalewayK8SPoolDelete(ctx context.Context, d *schema.ResourceData, 
 		}
 	}
 
+	_, err = k8sAPI.WaitForPool(&k8s.WaitForPoolRequest{
+		PoolID: poolID,
+		Region: region,
+	}, scw.WithContext(ctx))
+	if err != nil {
+		if !is404Error(err) {
+			return diag.FromErr(err)
+		}
+	}
+
 	return nil
 }
 

--- a/scaleway/resource_k8s_pool_test.go
+++ b/scaleway/resource_k8s_pool_test.go
@@ -456,7 +456,7 @@ func TestAccScalewayK8SCluster_PoolPublicIPDisabled(t *testing.T) {
 			
 				resource "scaleway_k8s_pool" "public_ip" {
 				  cluster_id          = scaleway_k8s_cluster.public_ip.id
-				  name                = "pool"
+				  name                = "test-k8s-public-ip"
 				  node_type           = "gp1_xs"
 				  size                = 1
 				  autoscaling         = false
@@ -505,7 +505,7 @@ func TestAccScalewayK8SCluster_PoolPublicIPDisabled(t *testing.T) {
 
 				resource "scaleway_k8s_pool" "public_ip" {
 				  cluster_id          = scaleway_k8s_cluster.public_ip.id
-				  name                = "pool"
+				  name                = "test-k8s-public-ip"
 				  node_type           = "gp1_xs"
 				  size                = 1
 				  autoscaling         = false

--- a/scaleway/testdata/data-source-k8s-cluster-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-k8s-cluster-basic.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:41 GMT
+      - Tue, 07 Nov 2023 16:19:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,12 +34,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97c8ec8b-cf07-48c1-8b9b-6164b0bcb5d2
+      - 6c2883f0-105a-4b41-bbc0-508fecd7f57a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-data-source-cluster","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"test-data-source-cluster","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-18T16:35:44.914318Z","dhcp_enabled":true,"id":"b8465b8c-e70b-481d-ac66-e37207423524","name":"test-data-source-cluster","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:35:44.914318Z","id":"aae07c51-5ed7-455e-aa00-aa194556cf64","subnet":"172.16.36.0/22","updated_at":"2023-10-18T16:35:44.914318Z"},{"created_at":"2023-10-18T16:35:44.914318Z","id":"769313be-1e2f-4a8e-9769-9a14e634d57a","subnet":"fd63:256c:45f7:d638::/64","updated_at":"2023-10-18T16:35:44.914318Z"}],"tags":[],"updated_at":"2023-10-18T16:35:44.914318Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:20:00.141117Z","dhcp_enabled":true,"id":"c230f16e-9326-4410-a133-9c0ecadde48a","name":"test-data-source-cluster","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:20:00.141117Z","id":"468fafae-207a-4d71-949e-059f147d0b6f","subnet":"172.16.0.0/22","updated_at":"2023-11-07T16:20:00.141117Z"},{"created_at":"2023-11-07T16:20:00.141117Z","id":"f583383b-baff-48fb-9b60-3a3a1e23d644","subnet":"fd63:256c:45f7:d9fb::/64","updated_at":"2023-11-07T16:20:00.141117Z"}],"tags":[],"updated_at":"2023-11-07T16:20:00.141117Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "725"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:45 GMT
+      - Tue, 07 Nov 2023 16:20:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19a28c18-d7f9-4c91-91e3-82ad3e8594b3
+      - 8e2ddbf0-b919-4310-be18-baeebdc1a974
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b8465b8c-e70b-481d-ac66-e37207423524
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c230f16e-9326-4410-a133-9c0ecadde48a
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:35:44.914318Z","dhcp_enabled":true,"id":"b8465b8c-e70b-481d-ac66-e37207423524","name":"test-data-source-cluster","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:35:44.914318Z","id":"aae07c51-5ed7-455e-aa00-aa194556cf64","subnet":"172.16.36.0/22","updated_at":"2023-10-18T16:35:44.914318Z"},{"created_at":"2023-10-18T16:35:44.914318Z","id":"769313be-1e2f-4a8e-9769-9a14e634d57a","subnet":"fd63:256c:45f7:d638::/64","updated_at":"2023-10-18T16:35:44.914318Z"}],"tags":[],"updated_at":"2023-10-18T16:35:44.914318Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:20:00.141117Z","dhcp_enabled":true,"id":"c230f16e-9326-4410-a133-9c0ecadde48a","name":"test-data-source-cluster","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:20:00.141117Z","id":"468fafae-207a-4d71-949e-059f147d0b6f","subnet":"172.16.0.0/22","updated_at":"2023-11-07T16:20:00.141117Z"},{"created_at":"2023-11-07T16:20:00.141117Z","id":"f583383b-baff-48fb-9b60-3a3a1e23d644","subnet":"fd63:256c:45f7:d9fb::/64","updated_at":"2023-11-07T16:20:00.141117Z"}],"tags":[],"updated_at":"2023-11-07T16:20:00.141117Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "725"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:45 GMT
+      - Tue, 07 Nov 2023 16:20:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e568650c-7715-422e-9a3b-59e3910882f8
+      - 775bfc66-e9f4-4d9e-9d04-449725208c35
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"tf-cluster","description":"","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"tf-cluster","description":"","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a"}'
     form: {}
     headers:
       Content-Type:
@@ -118,16 +118,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992604626Z","created_at":"2023-10-18T16:35:45.992604626Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:35:46.005426784Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757107Z","created_at":"2023-11-07T16:20:01.429757107Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:20:01.443794941Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1505"
+      - "1460"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:46 GMT
+      - Tue, 07 Nov 2023 16:20:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01b1eacc-ec5d-4816-80f4-2153f1177168
+      - 2234c669-dd89-4343-829e-6a764baa4a25
     status: 200 OK
     code: 200
     duration: ""
@@ -148,19 +148,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992605Z","created_at":"2023-10-18T16:35:45.992605Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:35:46.005427Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:20:01.443795Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1496"
+      - "1451"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:46 GMT
+      - Tue, 07 Nov 2023 16:20:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d41d2bd-e73a-4fe4-822f-07a57a1a7132
+      - d53be89b-da64-4b33-930f-f642ea334604
     status: 200 OK
     code: 200
     duration: ""
@@ -181,19 +181,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992605Z","created_at":"2023-10-18T16:35:45.992605Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:35:47.815909Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:20:03.503627Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1501"
+      - "1456"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2977f0b-0b54-4197-9c2b-87790a3d32df
+      - 1970d9f1-e5f7-4179-a5ba-583c75f09109
     status: 200 OK
     code: 200
     duration: ""
@@ -214,19 +214,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992605Z","created_at":"2023-10-18T16:35:45.992605Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:35:47.815909Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:20:03.503627Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1501"
+      - "1456"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07f206e5-e709-4ae9-bd2b-0ee847dd9332
+      - ae88fe6e-923a-4c4f-b5c5-6e3333397d35
     status: 200 OK
     code: 200
     duration: ""
@@ -247,19 +247,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUWHBWTUU0eGIxaEVWRTE2VFZSQmVFNTZSVEpOZWxVd1RqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFRodENuaG9OV2RxTldWb1JVUTNMek53VEVKTVFrdFpZamgwT0hwU2RtbHZPSFJHUkdsRlIxTktOMHQzY0RsM1JHZHlSMDh3ZW5BM1lsQmtabTlhTnpNNFRHUUtjbmRuTmtFM1preExkV2hrY0d0aVZFeHpOSHBIT1RkWVdVOUhZMjF6ZEhaeWVVOXFSa2RNVTBSSFNtMVJlR2RMSzBRNU15OUtPVkpSVmtoNmFVVnNkd3AxVVZKQlRsWlRiRUpJVDJGV1VWQlpWWGR1TVVGcFRuVnpVR05vZUZaUFJIRkhiRzloWWpCc01VbEVZMDFXTTFKMldXVTRlbGh2UmtOTVVqRkdkVTh5Q25sR05VaDBaR3R2UTA5MU1saDFNQ3RuUkZkaFRqWTRTRU14VVU1b1dXVmpVVkZLWnpkMFExaE9TRzlpVkZFclFWb3lhelF6ZVdaU1RUVjNWamxVY1RBS1pteHZWRUV3WkhkSFVuRnFNbWR4UkU5MVRHcGxVbGRpU0VSTGJXRkdTekpVWWxKQ1dHRnZiRmRFVG5keVN5dG5Ua04zTDA5ME1WZzNjakpRYUdkRVpRbzBNWGNyUm5SWU1HcEZVMmhyTjBkaVJqQnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWktNMEpaZW1NdkwwRkhaak5pV1ZnMFRFbHVhak53V2tNeGVGUk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJWRmR6TkdOdlJIcFpkbGxUZEROTk1FSmtlVE5JUTJkMmVXdGxTMjlLYkhjMFIyc3ZWa0ZrVVVGRldXSkdPR2QzTVFvdlFuUTJRa3RxUjNGUksxRXJObEZoVGxSa2FWWk9UR054ZEZrek9VOTZXWGhpT0ZRMGQzbFlZMUJzVkZSUmQwTkRjRU5PYlZoMFRteHBRM2RhY1hGdUNqRmtjRUZTYW1SWk5sSlZaSFJ1TUV0TUx6aHBUV1pDVW1Sak5IQjNka0l3VG5weWNWQlJhSEpuTUhSb1NVa3ZSRkpDUVRaRk9VZGtlRWxHY3pRMFptd0tSMnRpYTI5bFZUVTVhR2xNTUZKQlQweENXVzE2TW14dFpVTkJiMnB5UVhKaVNHZFZSREZCTkZCd2NGQmpaWGh2YUdSMFRtRTBPREJwVmsxalJEaHFiUW95TlhNdlExcFhiVTlOYUZOWksxTlhVekZRVUhaeWJ6SkdjblZTTldSWFJFaFdiV3hQUW5GbVMyVnhURlJ5UlZOME1XNVdhVkUzVEVScE1rMVFSRWd3Q2sxdFl5dHFTREZ2ZFZremRpOUlaRW81UmtWMk5reERhQzloYkV3eE0yODNibWxzYmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzgwYWM4MDUxLWQ4YzgtNDRjYi04NzA3LTNlNzE1MGM3MmY1My5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBEVm12NzZJZVJRUVJJaFJqdG1LcnJrdjk2dWZLZ253RzE5M3VDRmpzQlJVMHp2aHg0V3NMVUpNQg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAweGIxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEhKYUNrZDZSbXhNTmxNeVNERkdibmxPUTBoQk1XaFVXU3N4YnpONGNFeHVkMGhMTldGaE5VbGpabk5yZDNkWmRsZHhZalJWVFhCTU0yTTBNMkl2UjNjMWNGWUtRWHBaZEhKeGJFdGlhVFIyVDBSNU9UZzJTRTFYYVRWb01FdEJWVFpWVVdab1RGcGxXVWhyZVd0ME4xSjNlSFp4UWxrME56WXdWbXQ2WkUwNVRtRTJNUXBUV0RrMGEzRjBWVTlyTlRjNFNGRkdhREpMTkZwTk9XZzNNVXQwYzNjMFpWaGtaM2t4WjI1QlIycFNWMFF5ZUd4aU5IZDVVVUZ5WTJneWFWZG1PWFp1Q21SaGFXTndkalZoUTBwd2IzQjRjV1JsWm5sMlZEVnpZMk5xUkdveVJVZDVSV2czU1ZaMFlVaFRZM1F2UTA1dEsxRnBjSEpsWWt0NU9FSTRUM0ZNV1djS1NYbERlbFJzUkZCWVdXRlNMMGx3WjJkNlJqWnVVRFJJVmxkV1FXRnVjR05ZWkZCM2R5dEVOblF4UnpoQ1oyRjRiMGxvT0hOWlIweHNZa3RNWjBZMVpRb3JhbGN3U2pWcE9YWllOSFV2VkdRck5rY3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpOMDlEYTBsVmFFUm1MMFJLZERFNVVTOW1PV2d5UkZCS1FUbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOM2w1VEhwQk4wNVVla0Z1U0c5RlZpdENaMlpXY2xGTWQxSjFOVEJxVld4eEx6QkNPV2xSWkRJMlUzTlBWWEUzV2dwNGVtRTVNR3hYY1hSRlJGVldaRUZ3WTNwTmFrMXdOVlpEUVhkUFFraGhSWGw0Y1hsaVFVNU9TWFJuVEhOUWFUbFJhMHRJYW1rM1NURmtSVU40WkdWV0NrMUpUMGxFYWtGcmNrRmFVbFkzU2xnMllrVlZjMEoxVjJka00zSTBjbVpYYUdSM2RXaHZSQ3R0VGxkaVpYVm1aekJOWm1nMGVHSlFTbkYyTVhKeFdXY0tabVZRTHpWVEsxSjFVVXhDVUhwV2REQkNVVVphVDBOaVVTdHRWVkJ6VkN0NE4zWlphblJ5YUhGUFJFNUtTbnBFZDNNMFMxVkhXR2xOTVdGcmNGQmtVZ3BGYW1Rd1ZXeEZSMmgxZERoQ1NuSmhhMkZKV1dwTFZGWmFNa2QxYVROYVUybFFXalZPVW5oMlEzbFpkbkJ1Y1ZSR1JIQnRaMEZFYjJscWJqWnlORTlWQ21Sa04yaHVXalJEWVUxb1NUVXdURnBaYUc5R2MybGlXWGt3VlZaTlJqUlJWSGRJUVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzZkNGY2YzZkLTFiYjMtNGI1ZC04YjI2LWIwMjc1MzQ2NzkyYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoZHViazl6aFhmZEFJcXBRWlpkbXMxandGeDBDTzBKWTdRdXJWSlZQWjM4SjRTSWlNOGplTEhYeg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2574"
+      - "2572"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce707739-12c5-4e8b-bc0c-c4bc99db33d6
+      - ab6ea085-ab94-41cf-9b06-09f27c7fa1e0
     status: 200 OK
     code: 200
     duration: ""
@@ -280,19 +280,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992605Z","created_at":"2023-10-18T16:35:45.992605Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:35:47.815909Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:20:03.503627Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1501"
+      - "1456"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7708d514-9ccd-4753-8e58-ad41b8a5ae7a
+      - 7a1ce982-aaed-47e7-8dd1-3a571ea5a5ee
     status: 200 OK
     code: 200
     duration: ""
@@ -316,16 +316,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters?name=tf-cluster&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992605Z","created_at":"2023-10-18T16:35:45.992605Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:35:47.815909Z","upgrade_available":false,"version":"1.28.2"}],"total_count":1}'
+    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:20:03.503627Z","upgrade_available":false,"version":"1.28.2"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1533"
+      - "1487"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -335,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99d0eea7-f2bd-45f3-9fb3-d8292b3962de
+      - 369ee6ed-c00d-4133-9546-42d2a139eeb5
     status: 200 OK
     code: 200
     duration: ""
@@ -346,19 +346,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992605Z","created_at":"2023-10-18T16:35:45.992605Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:35:47.815909Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:20:03.503627Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1501"
+      - "1456"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -368,7 +368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34b82982-f72e-4d01-a271-65ad92674671
+      - 4bb7ba8e-b8e0-452f-8df8-a41f3e605d4c
     status: 200 OK
     code: 200
     duration: ""
@@ -379,19 +379,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992605Z","created_at":"2023-10-18T16:35:45.992605Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:35:47.815909Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:20:03.503627Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1501"
+      - "1456"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -401,7 +401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73e3b644-5799-432d-a2ca-4377c5199c3c
+      - 0eab4a68-00af-4088-83dd-fed35d5dac6f
     status: 200 OK
     code: 200
     duration: ""
@@ -412,19 +412,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUWHBWTUU0eGIxaEVWRTE2VFZSQmVFNTZSVEpOZWxVd1RqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFRodENuaG9OV2RxTldWb1JVUTNMek53VEVKTVFrdFpZamgwT0hwU2RtbHZPSFJHUkdsRlIxTktOMHQzY0RsM1JHZHlSMDh3ZW5BM1lsQmtabTlhTnpNNFRHUUtjbmRuTmtFM1preExkV2hrY0d0aVZFeHpOSHBIT1RkWVdVOUhZMjF6ZEhaeWVVOXFSa2RNVTBSSFNtMVJlR2RMSzBRNU15OUtPVkpSVmtoNmFVVnNkd3AxVVZKQlRsWlRiRUpJVDJGV1VWQlpWWGR1TVVGcFRuVnpVR05vZUZaUFJIRkhiRzloWWpCc01VbEVZMDFXTTFKMldXVTRlbGh2UmtOTVVqRkdkVTh5Q25sR05VaDBaR3R2UTA5MU1saDFNQ3RuUkZkaFRqWTRTRU14VVU1b1dXVmpVVkZLWnpkMFExaE9TRzlpVkZFclFWb3lhelF6ZVdaU1RUVjNWamxVY1RBS1pteHZWRUV3WkhkSFVuRnFNbWR4UkU5MVRHcGxVbGRpU0VSTGJXRkdTekpVWWxKQ1dHRnZiRmRFVG5keVN5dG5Ua04zTDA5ME1WZzNjakpRYUdkRVpRbzBNWGNyUm5SWU1HcEZVMmhyTjBkaVJqQnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWktNMEpaZW1NdkwwRkhaak5pV1ZnMFRFbHVhak53V2tNeGVGUk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJWRmR6TkdOdlJIcFpkbGxUZEROTk1FSmtlVE5JUTJkMmVXdGxTMjlLYkhjMFIyc3ZWa0ZrVVVGRldXSkdPR2QzTVFvdlFuUTJRa3RxUjNGUksxRXJObEZoVGxSa2FWWk9UR054ZEZrek9VOTZXWGhpT0ZRMGQzbFlZMUJzVkZSUmQwTkRjRU5PYlZoMFRteHBRM2RhY1hGdUNqRmtjRUZTYW1SWk5sSlZaSFJ1TUV0TUx6aHBUV1pDVW1Sak5IQjNka0l3VG5weWNWQlJhSEpuTUhSb1NVa3ZSRkpDUVRaRk9VZGtlRWxHY3pRMFptd0tSMnRpYTI5bFZUVTVhR2xNTUZKQlQweENXVzE2TW14dFpVTkJiMnB5UVhKaVNHZFZSREZCTkZCd2NGQmpaWGh2YUdSMFRtRTBPREJwVmsxalJEaHFiUW95TlhNdlExcFhiVTlOYUZOWksxTlhVekZRVUhaeWJ6SkdjblZTTldSWFJFaFdiV3hQUW5GbVMyVnhURlJ5UlZOME1XNVdhVkUzVEVScE1rMVFSRWd3Q2sxdFl5dHFTREZ2ZFZremRpOUlaRW81UmtWMk5reERhQzloYkV3eE0yODNibWxzYmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzgwYWM4MDUxLWQ4YzgtNDRjYi04NzA3LTNlNzE1MGM3MmY1My5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBEVm12NzZJZVJRUVJJaFJqdG1LcnJrdjk2dWZLZ253RzE5M3VDRmpzQlJVMHp2aHg0V3NMVUpNQg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAweGIxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEhKYUNrZDZSbXhNTmxNeVNERkdibmxPUTBoQk1XaFVXU3N4YnpONGNFeHVkMGhMTldGaE5VbGpabk5yZDNkWmRsZHhZalJWVFhCTU0yTTBNMkl2UjNjMWNGWUtRWHBaZEhKeGJFdGlhVFIyVDBSNU9UZzJTRTFYYVRWb01FdEJWVFpWVVdab1RGcGxXVWhyZVd0ME4xSjNlSFp4UWxrME56WXdWbXQ2WkUwNVRtRTJNUXBUV0RrMGEzRjBWVTlyTlRjNFNGRkdhREpMTkZwTk9XZzNNVXQwYzNjMFpWaGtaM2t4WjI1QlIycFNWMFF5ZUd4aU5IZDVVVUZ5WTJneWFWZG1PWFp1Q21SaGFXTndkalZoUTBwd2IzQjRjV1JsWm5sMlZEVnpZMk5xUkdveVJVZDVSV2czU1ZaMFlVaFRZM1F2UTA1dEsxRnBjSEpsWWt0NU9FSTRUM0ZNV1djS1NYbERlbFJzUkZCWVdXRlNMMGx3WjJkNlJqWnVVRFJJVmxkV1FXRnVjR05ZWkZCM2R5dEVOblF4UnpoQ1oyRjRiMGxvT0hOWlIweHNZa3RNWjBZMVpRb3JhbGN3U2pWcE9YWllOSFV2VkdRck5rY3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpOMDlEYTBsVmFFUm1MMFJLZERFNVVTOW1PV2d5UkZCS1FUbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOM2w1VEhwQk4wNVVla0Z1U0c5RlZpdENaMlpXY2xGTWQxSjFOVEJxVld4eEx6QkNPV2xSWkRJMlUzTlBWWEUzV2dwNGVtRTVNR3hYY1hSRlJGVldaRUZ3WTNwTmFrMXdOVlpEUVhkUFFraGhSWGw0Y1hsaVFVNU9TWFJuVEhOUWFUbFJhMHRJYW1rM1NURmtSVU40WkdWV0NrMUpUMGxFYWtGcmNrRmFVbFkzU2xnMllrVlZjMEoxVjJka00zSTBjbVpYYUdSM2RXaHZSQ3R0VGxkaVpYVm1aekJOWm1nMGVHSlFTbkYyTVhKeFdXY0tabVZRTHpWVEsxSjFVVXhDVUhwV2REQkNVVVphVDBOaVVTdHRWVkJ6VkN0NE4zWlphblJ5YUhGUFJFNUtTbnBFZDNNMFMxVkhXR2xOTVdGcmNGQmtVZ3BGYW1Rd1ZXeEZSMmgxZERoQ1NuSmhhMkZKV1dwTFZGWmFNa2QxYVROYVUybFFXalZPVW5oMlEzbFpkbkJ1Y1ZSR1JIQnRaMEZFYjJscWJqWnlORTlWQ21Sa04yaHVXalJEWVUxb1NUVXdURnBaYUc5R2MybGlXWGt3VlZaTlJqUlJWSGRJUVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzZkNGY2YzZkLTFiYjMtNGI1ZC04YjI2LWIwMjc1MzQ2NzkyYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoZHViazl6aFhmZEFJcXBRWlpkbXMxandGeDBDTzBKWTdRdXJWSlZQWjM4SjRTSWlNOGplTEhYeg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2574"
+      - "2572"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -434,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a0e6be3-0667-4406-b8d7-31380512e9bd
+      - 7b77a1f5-c294-4f49-aadf-01178d9855d5
     status: 200 OK
     code: 200
     duration: ""
@@ -445,19 +445,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUWHBWTUU0eGIxaEVWRTE2VFZSQmVFNTZSVEpOZWxVd1RqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFRodENuaG9OV2RxTldWb1JVUTNMek53VEVKTVFrdFpZamgwT0hwU2RtbHZPSFJHUkdsRlIxTktOMHQzY0RsM1JHZHlSMDh3ZW5BM1lsQmtabTlhTnpNNFRHUUtjbmRuTmtFM1preExkV2hrY0d0aVZFeHpOSHBIT1RkWVdVOUhZMjF6ZEhaeWVVOXFSa2RNVTBSSFNtMVJlR2RMSzBRNU15OUtPVkpSVmtoNmFVVnNkd3AxVVZKQlRsWlRiRUpJVDJGV1VWQlpWWGR1TVVGcFRuVnpVR05vZUZaUFJIRkhiRzloWWpCc01VbEVZMDFXTTFKMldXVTRlbGh2UmtOTVVqRkdkVTh5Q25sR05VaDBaR3R2UTA5MU1saDFNQ3RuUkZkaFRqWTRTRU14VVU1b1dXVmpVVkZLWnpkMFExaE9TRzlpVkZFclFWb3lhelF6ZVdaU1RUVjNWamxVY1RBS1pteHZWRUV3WkhkSFVuRnFNbWR4UkU5MVRHcGxVbGRpU0VSTGJXRkdTekpVWWxKQ1dHRnZiRmRFVG5keVN5dG5Ua04zTDA5ME1WZzNjakpRYUdkRVpRbzBNWGNyUm5SWU1HcEZVMmhyTjBkaVJqQnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWktNMEpaZW1NdkwwRkhaak5pV1ZnMFRFbHVhak53V2tNeGVGUk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJWRmR6TkdOdlJIcFpkbGxUZEROTk1FSmtlVE5JUTJkMmVXdGxTMjlLYkhjMFIyc3ZWa0ZrVVVGRldXSkdPR2QzTVFvdlFuUTJRa3RxUjNGUksxRXJObEZoVGxSa2FWWk9UR054ZEZrek9VOTZXWGhpT0ZRMGQzbFlZMUJzVkZSUmQwTkRjRU5PYlZoMFRteHBRM2RhY1hGdUNqRmtjRUZTYW1SWk5sSlZaSFJ1TUV0TUx6aHBUV1pDVW1Sak5IQjNka0l3VG5weWNWQlJhSEpuTUhSb1NVa3ZSRkpDUVRaRk9VZGtlRWxHY3pRMFptd0tSMnRpYTI5bFZUVTVhR2xNTUZKQlQweENXVzE2TW14dFpVTkJiMnB5UVhKaVNHZFZSREZCTkZCd2NGQmpaWGh2YUdSMFRtRTBPREJwVmsxalJEaHFiUW95TlhNdlExcFhiVTlOYUZOWksxTlhVekZRVUhaeWJ6SkdjblZTTldSWFJFaFdiV3hQUW5GbVMyVnhURlJ5UlZOME1XNVdhVkUzVEVScE1rMVFSRWd3Q2sxdFl5dHFTREZ2ZFZremRpOUlaRW81UmtWMk5reERhQzloYkV3eE0yODNibWxzYmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzgwYWM4MDUxLWQ4YzgtNDRjYi04NzA3LTNlNzE1MGM3MmY1My5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBEVm12NzZJZVJRUVJJaFJqdG1LcnJrdjk2dWZLZ253RzE5M3VDRmpzQlJVMHp2aHg0V3NMVUpNQg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAweGIxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEhKYUNrZDZSbXhNTmxNeVNERkdibmxPUTBoQk1XaFVXU3N4YnpONGNFeHVkMGhMTldGaE5VbGpabk5yZDNkWmRsZHhZalJWVFhCTU0yTTBNMkl2UjNjMWNGWUtRWHBaZEhKeGJFdGlhVFIyVDBSNU9UZzJTRTFYYVRWb01FdEJWVFpWVVdab1RGcGxXVWhyZVd0ME4xSjNlSFp4UWxrME56WXdWbXQ2WkUwNVRtRTJNUXBUV0RrMGEzRjBWVTlyTlRjNFNGRkdhREpMTkZwTk9XZzNNVXQwYzNjMFpWaGtaM2t4WjI1QlIycFNWMFF5ZUd4aU5IZDVVVUZ5WTJneWFWZG1PWFp1Q21SaGFXTndkalZoUTBwd2IzQjRjV1JsWm5sMlZEVnpZMk5xUkdveVJVZDVSV2czU1ZaMFlVaFRZM1F2UTA1dEsxRnBjSEpsWWt0NU9FSTRUM0ZNV1djS1NYbERlbFJzUkZCWVdXRlNMMGx3WjJkNlJqWnVVRFJJVmxkV1FXRnVjR05ZWkZCM2R5dEVOblF4UnpoQ1oyRjRiMGxvT0hOWlIweHNZa3RNWjBZMVpRb3JhbGN3U2pWcE9YWllOSFV2VkdRck5rY3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpOMDlEYTBsVmFFUm1MMFJLZERFNVVTOW1PV2d5UkZCS1FUbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOM2w1VEhwQk4wNVVla0Z1U0c5RlZpdENaMlpXY2xGTWQxSjFOVEJxVld4eEx6QkNPV2xSWkRJMlUzTlBWWEUzV2dwNGVtRTVNR3hYY1hSRlJGVldaRUZ3WTNwTmFrMXdOVlpEUVhkUFFraGhSWGw0Y1hsaVFVNU9TWFJuVEhOUWFUbFJhMHRJYW1rM1NURmtSVU40WkdWV0NrMUpUMGxFYWtGcmNrRmFVbFkzU2xnMllrVlZjMEoxVjJka00zSTBjbVpYYUdSM2RXaHZSQ3R0VGxkaVpYVm1aekJOWm1nMGVHSlFTbkYyTVhKeFdXY0tabVZRTHpWVEsxSjFVVXhDVUhwV2REQkNVVVphVDBOaVVTdHRWVkJ6VkN0NE4zWlphblJ5YUhGUFJFNUtTbnBFZDNNMFMxVkhXR2xOTVdGcmNGQmtVZ3BGYW1Rd1ZXeEZSMmgxZERoQ1NuSmhhMkZKV1dwTFZGWmFNa2QxYVROYVUybFFXalZPVW5oMlEzbFpkbkJ1Y1ZSR1JIQnRaMEZFYjJscWJqWnlORTlWQ21Sa04yaHVXalJEWVUxb1NUVXdURnBaYUc5R2MybGlXWGt3VlZaTlJqUlJWSGRJUVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzZkNGY2YzZkLTFiYjMtNGI1ZC04YjI2LWIwMjc1MzQ2NzkyYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoZHViazl6aFhmZEFJcXBRWlpkbXMxandGeDBDTzBKWTdRdXJWSlZQWjM4SjRTSWlNOGplTEhYeg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2574"
+      - "2572"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 16:20:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -467,12 +467,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c30ef29-4548-489b-bb4d-47766a845470
+      - c9cb1463-bf6d-4de9-a631-2f013abdf3d7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"default","node_type":"gp1_xs","placement_group_id":null,"autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":null,"kubelet_args":{},"upgrade_policy":null,"zone":"fr-par-1","root_volume_type":"default_volume_type","root_volume_size":null,"public_ip_disabled":false}'
+    body: '{"name":"default","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":null,"kubelet_args":{},"zone":"fr-par-1","root_volume_type":"default_volume_type","public_ip_disabled":false}'
     form: {}
     headers:
       Content-Type:
@@ -480,19 +480,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429388Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855399Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "620"
+      - "597"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 16:20:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41404d31-7528-4011-b38a-4c5aac399e5a
+      - bcea6407-7376-4945-9758-92db32fdada8
     status: 200 OK
     code: 200
     duration: ""
@@ -513,19 +513,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 16:20:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b09a33c-80c6-470a-970b-4733910b585b
+      - 69335d98-2581-42e0-88fb-63612e40191e
     status: 200 OK
     code: 200
     duration: ""
@@ -546,19 +546,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:56 GMT
+      - Tue, 07 Nov 2023 16:20:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0731701-2520-4b38-a319-7db6a731e39d
+      - 7f80ceff-7b3d-484d-89da-945a205e98cc
     status: 200 OK
     code: 200
     duration: ""
@@ -579,19 +579,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:02 GMT
+      - Tue, 07 Nov 2023 16:20:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 100b03ce-86b0-4b45-9e66-bfb9d3ea7953
+      - 5d05a470-5724-4fff-8852-ddcc2a22f97c
     status: 200 OK
     code: 200
     duration: ""
@@ -612,19 +612,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:07 GMT
+      - Tue, 07 Nov 2023 16:20:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 506950f3-0754-498e-9777-e35a72802397
+      - 603f9f65-0d7b-46cc-9517-1271bca55acf
     status: 200 OK
     code: 200
     duration: ""
@@ -645,19 +645,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:13 GMT
+      - Tue, 07 Nov 2023 16:20:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 308b9739-1565-44a0-a710-a2df6129a1fa
+      - a3940957-f55b-4b68-9fa6-1bfa3ba28174
     status: 200 OK
     code: 200
     duration: ""
@@ -678,19 +678,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:18 GMT
+      - Tue, 07 Nov 2023 16:20:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5756adb1-c2bf-495a-a5da-612ebfe5d72c
+      - 8ee46eb7-d7ac-478e-b2a4-c44d628dcb0a
     status: 200 OK
     code: 200
     duration: ""
@@ -711,19 +711,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:23 GMT
+      - Tue, 07 Nov 2023 16:20:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4e64205-c2f8-4160-89c7-1959a68c8cb0
+      - 2ab59beb-83b1-4ce3-86a2-8befcfd0b0b0
     status: 200 OK
     code: 200
     duration: ""
@@ -744,19 +744,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:28 GMT
+      - Tue, 07 Nov 2023 16:20:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0928ef53-77dc-4e28-9c22-f33e2075cbe6
+      - 795158bd-768b-41f7-979d-c829ebe88fb6
     status: 200 OK
     code: 200
     duration: ""
@@ -777,19 +777,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:33 GMT
+      - Tue, 07 Nov 2023 16:20:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f1f3f0a-0fb0-4fec-ad3f-b253b90f2fae
+      - b6be204a-2e9c-48fd-bca0-f1d83aeb65f0
     status: 200 OK
     code: 200
     duration: ""
@@ -810,19 +810,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:38 GMT
+      - Tue, 07 Nov 2023 16:20:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2909e82e-a93f-43c2-8b3c-e2fb5ae67746
+      - 7ad377b5-6524-41ed-97cf-f777059e747a
     status: 200 OK
     code: 200
     duration: ""
@@ -843,19 +843,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:43 GMT
+      - Tue, 07 Nov 2023 16:20:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f175b53-bf08-408b-b1b5-d386b6997c07
+      - 835b0df3-e565-4a35-a239-76102ac070c4
     status: 200 OK
     code: 200
     duration: ""
@@ -876,19 +876,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:48 GMT
+      - Tue, 07 Nov 2023 16:21:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - adee9dec-15c6-45c6-a646-48064d5e624d
+      - 213f11f4-77e6-4e1b-b5f8-ffe6d5de7c0c
     status: 200 OK
     code: 200
     duration: ""
@@ -909,19 +909,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:53 GMT
+      - Tue, 07 Nov 2023 16:21:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e9cfce5-b3a5-4b3a-a577-c54c6aaa0e0c
+      - 50a3b175-37d3-4da4-9373-82a7d6b69eaf
     status: 200 OK
     code: 200
     duration: ""
@@ -942,19 +942,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:58 GMT
+      - Tue, 07 Nov 2023 16:21:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f3063af-38f8-4c52-b786-b1b66191654c
+      - f56aab85-ef73-431a-bb9f-f70b549236bd
     status: 200 OK
     code: 200
     duration: ""
@@ -975,19 +975,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:03 GMT
+      - Tue, 07 Nov 2023 16:21:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8a78e8d-53f8-403b-b021-7e743cce306a
+      - 0698cef1-d089-4d33-af61-d5a381c18ae3
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,19 +1008,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:08 GMT
+      - Tue, 07 Nov 2023 16:21:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9cd0dd8-b81a-4328-8cbb-65c4895f9fed
+      - 0bb2e6bc-7742-46f4-bd86-622809b2dbb7
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,19 +1041,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:13 GMT
+      - Tue, 07 Nov 2023 16:21:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 046d29fb-85b0-4624-99fc-5e3702ccc77d
+      - b53be367-2541-4c4b-b883-962ef2d6e67d
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,19 +1074,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:18 GMT
+      - Tue, 07 Nov 2023 16:21:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 47d1ad0c-4cb1-4b26-88ad-a610ab900363
+      - d73a8ec8-6ae8-47b8-b122-f3ec6cfdd113
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,19 +1107,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:24 GMT
+      - Tue, 07 Nov 2023 16:21:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1129,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7fb3452f-a94c-43d5-94d4-1b8754838eed
+      - 82b9e3a8-5c78-4127-9cca-c5c38d5e7784
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,19 +1140,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:29 GMT
+      - Tue, 07 Nov 2023 16:21:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d09a171a-8056-400a-81b4-7b412386943b
+      - 5a3cad23-9def-4800-868e-081e09f7a6d9
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,19 +1173,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:34 GMT
+      - Tue, 07 Nov 2023 16:21:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7a29ef3-d7e9-4b2b-b407-c3d113b02fdb
+      - c43172c8-b305-41fa-b395-6c14361d4a33
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,19 +1206,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:39 GMT
+      - Tue, 07 Nov 2023 16:21:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b890d01-2651-49a0-a21f-1080111f58ad
+      - 9c479a4e-7cfc-4aa4-9d93-8571b9d5f071
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,19 +1239,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:44 GMT
+      - Tue, 07 Nov 2023 16:21:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1172357-5371-4245-832d-bef3d0bb9e31
+      - fda1c472-d854-4c92-91f7-650d4fceaff4
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,19 +1272,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:49 GMT
+      - Tue, 07 Nov 2023 16:22:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d07718a-407f-448a-a6be-96afbd3cb73b
+      - 382935c4-9fd8-4b93-9180-8e18ae9ed57d
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,19 +1305,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:54 GMT
+      - Tue, 07 Nov 2023 16:22:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8bea89ed-71a4-4ec2-ae02-0967c6db4596
+      - e2ccb154-05f3-4488-852a-2a6bc7d56056
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,19 +1338,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:59 GMT
+      - Tue, 07 Nov 2023 16:22:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1360,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8878d353-5d2e-4085-aa4b-f4d81e19730b
+      - b10379a7-4c92-4774-9295-162786a1b3e8
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,19 +1371,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:04 GMT
+      - Tue, 07 Nov 2023 16:22:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1393,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ffe6257-c4eb-40e5-9f9d-35eb75b8fdb3
+      - c8621ee7-6a0b-4d9c-9c55-e0e670791c67
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,19 +1404,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:09 GMT
+      - Tue, 07 Nov 2023 16:22:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1426,7 +1426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 626503fa-5340-4e8f-b929-d98444c8095f
+      - 019e1b14-bde9-4563-94c0-075947df8992
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,19 +1437,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:14 GMT
+      - Tue, 07 Nov 2023 16:22:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1459,7 +1459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84391613-c26f-4eca-a129-f6d8da4434a4
+      - 6241920b-578d-46c8-a683-d67f27796c04
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,19 +1470,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:19 GMT
+      - Tue, 07 Nov 2023 16:22:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1492,7 +1492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55a24cca-ad95-44ee-991f-56b6be0b07c6
+      - 988665c1-1654-465a-9e69-02d99aa6bfb9
     status: 200 OK
     code: 200
     duration: ""
@@ -1503,19 +1503,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:24 GMT
+      - Tue, 07 Nov 2023 16:22:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad156188-7f8c-415e-ac90-f695877159d8
+      - 5cb7a3cd-89a2-42e0-9b89-4ee383d3c66b
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,19 +1536,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:29 GMT
+      - Tue, 07 Nov 2023 16:22:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1558,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1414471e-a6b0-42a1-8233-110dcf8e0acf
+      - 28f0eb1a-ce15-4776-947c-4dc1c66e1237
     status: 200 OK
     code: 200
     duration: ""
@@ -1569,19 +1569,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:34 GMT
+      - Tue, 07 Nov 2023 16:22:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1591,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f6c20a3-1d51-473f-8bad-126aeed8d8cc
+      - bf2db1fc-3813-41e1-8edb-3eafd402d3a2
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,19 +1602,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:39 GMT
+      - Tue, 07 Nov 2023 16:22:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 094002bb-5038-4380-a12c-c0046a19a0f7
+      - 16082489-e337-428e-a6d6-e9c15285ade9
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,19 +1635,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:44 GMT
+      - Tue, 07 Nov 2023 16:22:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1657,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2c9e711-61a4-4e81-a983-279549fc4df5
+      - b022712b-66de-447d-9b2b-dbcc3d20f9cc
     status: 200 OK
     code: 200
     duration: ""
@@ -1668,19 +1668,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:49 GMT
+      - Tue, 07 Nov 2023 16:23:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1690,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 195e71ce-ccbf-4618-a922-e639ef7e35a5
+      - 728c1ef7-2bf6-4106-9508-2e474f7d0c7d
     status: 200 OK
     code: 200
     duration: ""
@@ -1701,19 +1701,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:54 GMT
+      - Tue, 07 Nov 2023 16:23:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1723,7 +1723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88679d42-b035-4f1a-bd74-8b016caebb48
+      - 9ae1ba17-3406-4ea1-8ff3-cfd196911e3f
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,19 +1734,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:59 GMT
+      - Tue, 07 Nov 2023 16:23:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1756,7 +1756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb457d82-d40a-42f7-a6d7-374e2dbb1fb7
+      - b7406aaa-fadf-4e2a-80fe-8992bac0d437
     status: 200 OK
     code: 200
     duration: ""
@@ -1767,19 +1767,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:04 GMT
+      - Tue, 07 Nov 2023 16:23:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1789,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e99125a7-7bc3-4d26-95ef-9ad5218d31ec
+      - e0cf5c7d-80de-4f12-bebb-c8ac74109cc0
     status: 200 OK
     code: 200
     duration: ""
@@ -1800,19 +1800,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:10 GMT
+      - Tue, 07 Nov 2023 16:23:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1822,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3ca723b-4510-4a9f-8eac-2a5794cca008
+      - b164586e-722b-4a97-9678-f459a67d4361
     status: 200 OK
     code: 200
     duration: ""
@@ -1833,19 +1833,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:15 GMT
+      - Tue, 07 Nov 2023 16:23:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1855,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d0042ec-e7b9-4fb5-b296-3915c7604699
+      - 17d61080-503f-42d8-86e2-c441488d2104
     status: 200 OK
     code: 200
     duration: ""
@@ -1866,19 +1866,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:20 GMT
+      - Tue, 07 Nov 2023 16:23:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1888,7 +1888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a583dfe8-6a2f-48fa-8690-d9813c150d44
+      - a3350176-4947-401d-9671-aa541958dea8
     status: 200 OK
     code: 200
     duration: ""
@@ -1899,19 +1899,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:25 GMT
+      - Tue, 07 Nov 2023 16:23:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1921,7 +1921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0273ddc9-584a-4f3e-9ca6-baa6a4c5e77b
+      - 631aac33-bb36-4b02-a628-230bf698cb85
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,19 +1932,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:30 GMT
+      - Tue, 07 Nov 2023 16:23:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1954,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd71d73c-eb98-4c50-a65c-7851a79df8dc
+      - afd4da7a-afcc-44b5-815b-65853f1b146e
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,19 +1965,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:35 GMT
+      - Tue, 07 Nov 2023 16:23:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1987,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 949c21d6-7ced-4e20-8ac0-6362739b3142
+      - 56f3d987-da78-4a19-a909-16cd1fe08114
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,19 +1998,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:40 GMT
+      - Tue, 07 Nov 2023 16:23:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2020,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 153cbb4d-d95a-4c09-ac6b-062f8b07157a
+      - 48c28c46-875f-4d6f-bc72-4979d595bc4a
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,19 +2031,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:45 GMT
+      - Tue, 07 Nov 2023 16:23:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2053,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c768b4a-610c-4b93-ab2d-eb9961c7c20c
+      - 03835832-fc5c-4489-bc5e-6512e9b08d02
     status: 200 OK
     code: 200
     duration: ""
@@ -2064,19 +2064,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:50 GMT
+      - Tue, 07 Nov 2023 16:24:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2086,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ff96540-e149-49bc-947a-0b6df755e055
+      - 3294d60d-2f16-4673-bd6f-00d49b34b1c9
     status: 200 OK
     code: 200
     duration: ""
@@ -2097,19 +2097,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:55 GMT
+      - Tue, 07 Nov 2023 16:24:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2119,7 +2119,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0e8e613-6a78-4fb2-9e5e-c7eb0aa634ca
+      - 41a1617e-b1ff-44ab-b778-94d0813991c9
     status: 200 OK
     code: 200
     duration: ""
@@ -2130,19 +2130,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:20:06.930855Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "594"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:00 GMT
+      - Tue, 07 Nov 2023 16:24:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2152,7 +2152,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 952f800f-cf0f-491d-a13a-4da75998e6f1
+      - c244eda8-32c9-45a2-b7b5-41cdeba0e7f7
     status: 200 OK
     code: 200
     duration: ""
@@ -2163,19 +2163,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:24:18.735830Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:05 GMT
+      - Tue, 07 Nov 2023 16:24:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2185,7 +2185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5e97286-1661-4166-a1f1-0126dcc86a04
+      - 81150f28-9af3-4b2b-ae63-dc44b2c30381
     status: 200 OK
     code: 200
     duration: ""
@@ -2196,19 +2196,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "617"
+      - "1448"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:10 GMT
+      - Tue, 07 Nov 2023 16:24:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2218,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c75324e-1580-443d-8812-eb4b1aba9ecc
+      - f28f5f28-4c66-457c-90ba-dc1e6a57d17f
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,19 +2229,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:24:18.735830Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:15 GMT
+      - Tue, 07 Nov 2023 16:24:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2251,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93fd4ec6-453f-45cf-8ecb-fd6e2b207e78
+      - 57eab985-08f6-4598-8ee2-6b6621644750
     status: 200 OK
     code: 200
     duration: ""
@@ -2262,19 +2262,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/nodes?order_by=created_at_asc&page=1&pool_id=1fe1c124-6977-4948-8f6c-f2b823fcb286&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T16:22:05.112095Z","error_message":null,"id":"59d458d7-02a0-4bf8-9a0f-81f28c5fe2ec","name":"scw-tf-cluster-default-59d458d702a04bf89a0f81f","pool_id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","provider_id":"scaleway://instance/fr-par-1/95a640e5-d685-44db-8a30-1dc37002649b","public_ip_v4":"51.158.79.120","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:24:18.723499Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "617"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:20 GMT
+      - Tue, 07 Nov 2023 16:24:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2284,7 +2284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e75b7097-5c0c-4107-a9f4-d4d85d167f5c
+      - 8ca45a1a-061f-4dac-8f0b-ad6e72378e3a
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,19 +2295,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "617"
+      - "1448"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:25 GMT
+      - Tue, 07 Nov 2023 16:24:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2317,7 +2317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90e50c2b-fb34-4786-a203-67686c5d4277
+      - b187d8a1-9d5f-4ce4-b4bf-2bcbda8da763
     status: 200 OK
     code: 200
     duration: ""
@@ -2328,19 +2328,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "617"
+      - "1448"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:30 GMT
+      - Tue, 07 Nov 2023 16:24:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2350,7 +2350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b55754bb-b9e5-4f8b-9744-a4acb57ed21a
+      - 5fd3dda0-3f83-4d19-9fc4-8e06ae0ff1d6
     status: 200 OK
     code: 200
     duration: ""
@@ -2361,19 +2361,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "617"
+      - "1448"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:35 GMT
+      - Tue, 07 Nov 2023 16:24:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2383,1228 +2383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9371aea-a5e3-4e93-8ca3-f6f6cb685680
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:40:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6a30f24a-3f85-4b59-ad32-a4dab07dbd7e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:40:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b7991995-dd5d-41f7-93d0-2e08652d8c16
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:40:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 25a7dde6-137f-4466-9548-c60f038449f6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:40:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8f039ad7-76cf-43ad-874f-b448ba5c5920
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 91f325b6-a65b-4041-bdff-fcf48291b34c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0d8b920c-a615-4e31-b341-7de52fac5407
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ab963469-7119-43bd-bf2b-133bec4cb4c2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5ff212e0-9794-43b6-a387-a479c5a2582f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 00fce1e9-f4d5-416b-919f-7f8a00e1c7f9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f764f334-1a7b-4469-a858-81d0432d1c17
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b5e5cf57-75f1-4ed9-b7ec-cdcc97b4509d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ecd2001e-cd4d-498d-a004-1f7d78d4ee1d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 62ef494a-65b3-466f-854c-f06b25d0e39f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b8e98e7d-5aff-4291-b375-e3b6ff46ce87
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 83a7ab2a-97ae-460f-91f3-55c8396da16b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 48adfeb6-9c31-45ae-a024-8976de2ba5e9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 02255eec-f48d-4c12-ad88-5c6dc9deb249
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cf7df371-d04a-4dfc-bbdd-6f7a919c883d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f204bb9a-d697-40d0-b32a-73218455e095
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f0d0a0f6-31e9-4782-9490-168170d7b102
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 14f8d494-f611-4ca4-b937-d723f1b6ff7c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 88e4d8e3-933e-4b8c-97bb-6f10d2c47ed2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2be0e1a6-fd3b-444c-8974-5c74f367cdd4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1ffda6cb-1b43-4427-8928-a0bad4fd4503
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 00675c6a-29a1-42f6-9d55-8159fd187ea3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8f2b7332-12c3-4df3-a634-340a6def6a06
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e7bd7c4b-4538-48ce-91df-0dbebe06260f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 153d01dc-8d06-4d3e-b2a9-7f82f90b7dfb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a59203de-0ed8-41a3-a4f9-f0d857e58096
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.396429Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "617"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ab19295e-3774-48e3-8a7b-df870185db88
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-18T16:43:07.266809Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "615"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3e56a562-236d-4a7f-97b3-c341c85b3e7b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992605Z","created_at":"2023-10-18T16:35:45.992605Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:37:15.310850Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1493"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b91e7ed8-bc94-4e01-9f32-08e367fa271a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-18T16:43:07.266809Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "615"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d9087e64-0b9f-4a1c-9383-4c820a89a22e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53/nodes?order_by=created_at_asc&page=1&pool_id=fbee03e2-145c-4402-aa22-e1d18213d198&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:38:42.808849Z","error_message":null,"id":"bad6db13-3e8f-4d66-a1d0-89d51ba81c8c","name":"scw-tf-cluster-default-bad6db133e8f4d66a1d089d","pool_id":"fbee03e2-145c-4402-aa22-e1d18213d198","provider_id":"scaleway://instance/fr-par-1/3dac039d-34a4-46eb-8b6d-10a79fab3e4e","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:43:07.251031Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "659"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6713446e-e738-4f62-8e29-d97a2576f659
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992605Z","created_at":"2023-10-18T16:35:45.992605Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:37:15.310850Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1493"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 033e7e2f-b51e-45e4-a856-1f06754181dc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992605Z","created_at":"2023-10-18T16:35:45.992605Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:37:15.310850Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1493"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1cc5c5de-ae57-4e9a-84fd-255a7c6ffd4e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992605Z","created_at":"2023-10-18T16:35:45.992605Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:37:15.310850Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1493"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a0e6b839-7381-4106-9b87-4dc716a1f9d0
+      - 0c984a56-7b8f-413d-8207-39148e4fc32a
     status: 200 OK
     code: 200
     duration: ""
@@ -3618,16 +2397,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters?name=tf-cluster&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992605Z","created_at":"2023-10-18T16:35:45.992605Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:37:15.310850Z","upgrade_available":false,"version":"1.28.2"}],"total_count":1}'
+    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1525"
+      - "1479"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:12 GMT
+      - Tue, 07 Nov 2023 16:24:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3637,7 +2416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9c37e0c-b3f2-43ae-b33a-d7d2057fb092
+      - c085b071-7635-4aa1-a222-bb77a25d909f
     status: 200 OK
     code: 200
     duration: ""
@@ -3648,19 +2427,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992605Z","created_at":"2023-10-18T16:35:45.992605Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:37:15.310850Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1493"
+      - "1448"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:12 GMT
+      - Tue, 07 Nov 2023 16:24:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3670,7 +2449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15a90d4f-29f5-4b46-a5a0-1fb4cf830efc
+      - e952bed9-6a75-45c3-959d-0ebf1729b567
     status: 200 OK
     code: 200
     duration: ""
@@ -3681,19 +2460,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUWHBWTUU0eGIxaEVWRTE2VFZSQmVFNTZSVEpOZWxVd1RqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFRodENuaG9OV2RxTldWb1JVUTNMek53VEVKTVFrdFpZamgwT0hwU2RtbHZPSFJHUkdsRlIxTktOMHQzY0RsM1JHZHlSMDh3ZW5BM1lsQmtabTlhTnpNNFRHUUtjbmRuTmtFM1preExkV2hrY0d0aVZFeHpOSHBIT1RkWVdVOUhZMjF6ZEhaeWVVOXFSa2RNVTBSSFNtMVJlR2RMSzBRNU15OUtPVkpSVmtoNmFVVnNkd3AxVVZKQlRsWlRiRUpJVDJGV1VWQlpWWGR1TVVGcFRuVnpVR05vZUZaUFJIRkhiRzloWWpCc01VbEVZMDFXTTFKMldXVTRlbGh2UmtOTVVqRkdkVTh5Q25sR05VaDBaR3R2UTA5MU1saDFNQ3RuUkZkaFRqWTRTRU14VVU1b1dXVmpVVkZLWnpkMFExaE9TRzlpVkZFclFWb3lhelF6ZVdaU1RUVjNWamxVY1RBS1pteHZWRUV3WkhkSFVuRnFNbWR4UkU5MVRHcGxVbGRpU0VSTGJXRkdTekpVWWxKQ1dHRnZiRmRFVG5keVN5dG5Ua04zTDA5ME1WZzNjakpRYUdkRVpRbzBNWGNyUm5SWU1HcEZVMmhyTjBkaVJqQnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWktNMEpaZW1NdkwwRkhaak5pV1ZnMFRFbHVhak53V2tNeGVGUk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJWRmR6TkdOdlJIcFpkbGxUZEROTk1FSmtlVE5JUTJkMmVXdGxTMjlLYkhjMFIyc3ZWa0ZrVVVGRldXSkdPR2QzTVFvdlFuUTJRa3RxUjNGUksxRXJObEZoVGxSa2FWWk9UR054ZEZrek9VOTZXWGhpT0ZRMGQzbFlZMUJzVkZSUmQwTkRjRU5PYlZoMFRteHBRM2RhY1hGdUNqRmtjRUZTYW1SWk5sSlZaSFJ1TUV0TUx6aHBUV1pDVW1Sak5IQjNka0l3VG5weWNWQlJhSEpuTUhSb1NVa3ZSRkpDUVRaRk9VZGtlRWxHY3pRMFptd0tSMnRpYTI5bFZUVTVhR2xNTUZKQlQweENXVzE2TW14dFpVTkJiMnB5UVhKaVNHZFZSREZCTkZCd2NGQmpaWGh2YUdSMFRtRTBPREJwVmsxalJEaHFiUW95TlhNdlExcFhiVTlOYUZOWksxTlhVekZRVUhaeWJ6SkdjblZTTldSWFJFaFdiV3hQUW5GbVMyVnhURlJ5UlZOME1XNVdhVkUzVEVScE1rMVFSRWd3Q2sxdFl5dHFTREZ2ZFZremRpOUlaRW81UmtWMk5reERhQzloYkV3eE0yODNibWxzYmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzgwYWM4MDUxLWQ4YzgtNDRjYi04NzA3LTNlNzE1MGM3MmY1My5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBEVm12NzZJZVJRUVJJaFJqdG1LcnJrdjk2dWZLZ253RzE5M3VDRmpzQlJVMHp2aHg0V3NMVUpNQg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAweGIxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEhKYUNrZDZSbXhNTmxNeVNERkdibmxPUTBoQk1XaFVXU3N4YnpONGNFeHVkMGhMTldGaE5VbGpabk5yZDNkWmRsZHhZalJWVFhCTU0yTTBNMkl2UjNjMWNGWUtRWHBaZEhKeGJFdGlhVFIyVDBSNU9UZzJTRTFYYVRWb01FdEJWVFpWVVdab1RGcGxXVWhyZVd0ME4xSjNlSFp4UWxrME56WXdWbXQ2WkUwNVRtRTJNUXBUV0RrMGEzRjBWVTlyTlRjNFNGRkdhREpMTkZwTk9XZzNNVXQwYzNjMFpWaGtaM2t4WjI1QlIycFNWMFF5ZUd4aU5IZDVVVUZ5WTJneWFWZG1PWFp1Q21SaGFXTndkalZoUTBwd2IzQjRjV1JsWm5sMlZEVnpZMk5xUkdveVJVZDVSV2czU1ZaMFlVaFRZM1F2UTA1dEsxRnBjSEpsWWt0NU9FSTRUM0ZNV1djS1NYbERlbFJzUkZCWVdXRlNMMGx3WjJkNlJqWnVVRFJJVmxkV1FXRnVjR05ZWkZCM2R5dEVOblF4UnpoQ1oyRjRiMGxvT0hOWlIweHNZa3RNWjBZMVpRb3JhbGN3U2pWcE9YWllOSFV2VkdRck5rY3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpOMDlEYTBsVmFFUm1MMFJLZERFNVVTOW1PV2d5UkZCS1FUbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOM2w1VEhwQk4wNVVla0Z1U0c5RlZpdENaMlpXY2xGTWQxSjFOVEJxVld4eEx6QkNPV2xSWkRJMlUzTlBWWEUzV2dwNGVtRTVNR3hYY1hSRlJGVldaRUZ3WTNwTmFrMXdOVlpEUVhkUFFraGhSWGw0Y1hsaVFVNU9TWFJuVEhOUWFUbFJhMHRJYW1rM1NURmtSVU40WkdWV0NrMUpUMGxFYWtGcmNrRmFVbFkzU2xnMllrVlZjMEoxVjJka00zSTBjbVpYYUdSM2RXaHZSQ3R0VGxkaVpYVm1aekJOWm1nMGVHSlFTbkYyTVhKeFdXY0tabVZRTHpWVEsxSjFVVXhDVUhwV2REQkNVVVphVDBOaVVTdHRWVkJ6VkN0NE4zWlphblJ5YUhGUFJFNUtTbnBFZDNNMFMxVkhXR2xOTVdGcmNGQmtVZ3BGYW1Rd1ZXeEZSMmgxZERoQ1NuSmhhMkZKV1dwTFZGWmFNa2QxYVROYVUybFFXalZPVW5oMlEzbFpkbkJ1Y1ZSR1JIQnRaMEZFYjJscWJqWnlORTlWQ21Sa04yaHVXalJEWVUxb1NUVXdURnBaYUc5R2MybGlXWGt3VlZaTlJqUlJWSGRJUVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzZkNGY2YzZkLTFiYjMtNGI1ZC04YjI2LWIwMjc1MzQ2NzkyYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoZHViazl6aFhmZEFJcXBRWlpkbXMxandGeDBDTzBKWTdRdXJWSlZQWjM4SjRTSWlNOGplTEhYeg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2574"
+      - "2572"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:12 GMT
+      - Tue, 07 Nov 2023 16:24:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3703,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d91e4ed9-9d40-48bb-8e19-745761a55ed0
+      - 0eacbc34-efcb-410a-a5e2-19186131c379
     status: 200 OK
     code: 200
     duration: ""
@@ -3714,19 +2493,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUWHBWTUU0eGIxaEVWRTE2VFZSQmVFNTZSVEpOZWxVd1RqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFRodENuaG9OV2RxTldWb1JVUTNMek53VEVKTVFrdFpZamgwT0hwU2RtbHZPSFJHUkdsRlIxTktOMHQzY0RsM1JHZHlSMDh3ZW5BM1lsQmtabTlhTnpNNFRHUUtjbmRuTmtFM1preExkV2hrY0d0aVZFeHpOSHBIT1RkWVdVOUhZMjF6ZEhaeWVVOXFSa2RNVTBSSFNtMVJlR2RMSzBRNU15OUtPVkpSVmtoNmFVVnNkd3AxVVZKQlRsWlRiRUpJVDJGV1VWQlpWWGR1TVVGcFRuVnpVR05vZUZaUFJIRkhiRzloWWpCc01VbEVZMDFXTTFKMldXVTRlbGh2UmtOTVVqRkdkVTh5Q25sR05VaDBaR3R2UTA5MU1saDFNQ3RuUkZkaFRqWTRTRU14VVU1b1dXVmpVVkZLWnpkMFExaE9TRzlpVkZFclFWb3lhelF6ZVdaU1RUVjNWamxVY1RBS1pteHZWRUV3WkhkSFVuRnFNbWR4UkU5MVRHcGxVbGRpU0VSTGJXRkdTekpVWWxKQ1dHRnZiRmRFVG5keVN5dG5Ua04zTDA5ME1WZzNjakpRYUdkRVpRbzBNWGNyUm5SWU1HcEZVMmhyTjBkaVJqQnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWktNMEpaZW1NdkwwRkhaak5pV1ZnMFRFbHVhak53V2tNeGVGUk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJWRmR6TkdOdlJIcFpkbGxUZEROTk1FSmtlVE5JUTJkMmVXdGxTMjlLYkhjMFIyc3ZWa0ZrVVVGRldXSkdPR2QzTVFvdlFuUTJRa3RxUjNGUksxRXJObEZoVGxSa2FWWk9UR054ZEZrek9VOTZXWGhpT0ZRMGQzbFlZMUJzVkZSUmQwTkRjRU5PYlZoMFRteHBRM2RhY1hGdUNqRmtjRUZTYW1SWk5sSlZaSFJ1TUV0TUx6aHBUV1pDVW1Sak5IQjNka0l3VG5weWNWQlJhSEpuTUhSb1NVa3ZSRkpDUVRaRk9VZGtlRWxHY3pRMFptd0tSMnRpYTI5bFZUVTVhR2xNTUZKQlQweENXVzE2TW14dFpVTkJiMnB5UVhKaVNHZFZSREZCTkZCd2NGQmpaWGh2YUdSMFRtRTBPREJwVmsxalJEaHFiUW95TlhNdlExcFhiVTlOYUZOWksxTlhVekZRVUhaeWJ6SkdjblZTTldSWFJFaFdiV3hQUW5GbVMyVnhURlJ5UlZOME1XNVdhVkUzVEVScE1rMVFSRWd3Q2sxdFl5dHFTREZ2ZFZremRpOUlaRW81UmtWMk5reERhQzloYkV3eE0yODNibWxzYmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzgwYWM4MDUxLWQ4YzgtNDRjYi04NzA3LTNlNzE1MGM3MmY1My5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBEVm12NzZJZVJRUVJJaFJqdG1LcnJrdjk2dWZLZ253RzE5M3VDRmpzQlJVMHp2aHg0V3NMVUpNQg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAweGIxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEhKYUNrZDZSbXhNTmxNeVNERkdibmxPUTBoQk1XaFVXU3N4YnpONGNFeHVkMGhMTldGaE5VbGpabk5yZDNkWmRsZHhZalJWVFhCTU0yTTBNMkl2UjNjMWNGWUtRWHBaZEhKeGJFdGlhVFIyVDBSNU9UZzJTRTFYYVRWb01FdEJWVFpWVVdab1RGcGxXVWhyZVd0ME4xSjNlSFp4UWxrME56WXdWbXQ2WkUwNVRtRTJNUXBUV0RrMGEzRjBWVTlyTlRjNFNGRkdhREpMTkZwTk9XZzNNVXQwYzNjMFpWaGtaM2t4WjI1QlIycFNWMFF5ZUd4aU5IZDVVVUZ5WTJneWFWZG1PWFp1Q21SaGFXTndkalZoUTBwd2IzQjRjV1JsWm5sMlZEVnpZMk5xUkdveVJVZDVSV2czU1ZaMFlVaFRZM1F2UTA1dEsxRnBjSEpsWWt0NU9FSTRUM0ZNV1djS1NYbERlbFJzUkZCWVdXRlNMMGx3WjJkNlJqWnVVRFJJVmxkV1FXRnVjR05ZWkZCM2R5dEVOblF4UnpoQ1oyRjRiMGxvT0hOWlIweHNZa3RNWjBZMVpRb3JhbGN3U2pWcE9YWllOSFV2VkdRck5rY3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpOMDlEYTBsVmFFUm1MMFJLZERFNVVTOW1PV2d5UkZCS1FUbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOM2w1VEhwQk4wNVVla0Z1U0c5RlZpdENaMlpXY2xGTWQxSjFOVEJxVld4eEx6QkNPV2xSWkRJMlUzTlBWWEUzV2dwNGVtRTVNR3hYY1hSRlJGVldaRUZ3WTNwTmFrMXdOVlpEUVhkUFFraGhSWGw0Y1hsaVFVNU9TWFJuVEhOUWFUbFJhMHRJYW1rM1NURmtSVU40WkdWV0NrMUpUMGxFYWtGcmNrRmFVbFkzU2xnMllrVlZjMEoxVjJka00zSTBjbVpYYUdSM2RXaHZSQ3R0VGxkaVpYVm1aekJOWm1nMGVHSlFTbkYyTVhKeFdXY0tabVZRTHpWVEsxSjFVVXhDVUhwV2REQkNVVVphVDBOaVVTdHRWVkJ6VkN0NE4zWlphblJ5YUhGUFJFNUtTbnBFZDNNMFMxVkhXR2xOTVdGcmNGQmtVZ3BGYW1Rd1ZXeEZSMmgxZERoQ1NuSmhhMkZKV1dwTFZGWmFNa2QxYVROYVUybFFXalZPVW5oMlEzbFpkbkJ1Y1ZSR1JIQnRaMEZFYjJscWJqWnlORTlWQ21Sa04yaHVXalJEWVUxb1NUVXdURnBaYUc5R2MybGlXWGt3VlZaTlJqUlJWSGRJUVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzZkNGY2YzZkLTFiYjMtNGI1ZC04YjI2LWIwMjc1MzQ2NzkyYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoZHViazl6aFhmZEFJcXBRWlpkbXMxandGeDBDTzBKWTdRdXJWSlZQWjM4SjRTSWlNOGplTEhYeg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2574"
+      - "2572"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:13 GMT
+      - Tue, 07 Nov 2023 16:24:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3736,7 +2515,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1893a8c6-2fcd-4c59-96df-d3096d07711b
+      - c254d005-b316-4d83-af9d-d37541ebf194
     status: 200 OK
     code: 200
     duration: ""
@@ -3747,19 +2526,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b8465b8c-e70b-481d-ac66-e37207423524
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c230f16e-9326-4410-a133-9c0ecadde48a
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:35:44.914318Z","dhcp_enabled":true,"id":"b8465b8c-e70b-481d-ac66-e37207423524","name":"test-data-source-cluster","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:35:44.914318Z","id":"aae07c51-5ed7-455e-aa00-aa194556cf64","subnet":"172.16.36.0/22","updated_at":"2023-10-18T16:35:44.914318Z"},{"created_at":"2023-10-18T16:35:44.914318Z","id":"769313be-1e2f-4a8e-9769-9a14e634d57a","subnet":"fd63:256c:45f7:d638::/64","updated_at":"2023-10-18T16:35:44.914318Z"}],"tags":[],"updated_at":"2023-10-18T16:35:44.914318Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:20:00.141117Z","dhcp_enabled":true,"id":"c230f16e-9326-4410-a133-9c0ecadde48a","name":"test-data-source-cluster","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:20:00.141117Z","id":"468fafae-207a-4d71-949e-059f147d0b6f","subnet":"172.16.0.0/22","updated_at":"2023-11-07T16:20:00.141117Z"},{"created_at":"2023-11-07T16:20:00.141117Z","id":"f583383b-baff-48fb-9b60-3a3a1e23d644","subnet":"fd63:256c:45f7:d9fb::/64","updated_at":"2023-11-07T16:20:00.141117Z"}],"tags":[],"updated_at":"2023-11-07T16:20:00.141117Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "725"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:13 GMT
+      - Tue, 07 Nov 2023 16:24:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3769,7 +2548,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2db1a87-48e9-4470-a00e-25e9df285df7
+      - 65839107-a1a8-4789-9626-b5336307aa97
     status: 200 OK
     code: 200
     duration: ""
@@ -3780,19 +2559,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992605Z","created_at":"2023-10-18T16:35:45.992605Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:37:15.310850Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1493"
+      - "1448"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:13 GMT
+      - Tue, 07 Nov 2023 16:24:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3802,7 +2581,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bce7df79-3e38-4252-9dce-f5b8cbeb96c1
+      - 9d0a70af-6a33-444e-bd6c-b04e8af75b31
     status: 200 OK
     code: 200
     duration: ""
@@ -3813,19 +2592,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUWHBWTUU0eGIxaEVWRTE2VFZSQmVFNTZSVEpOZWxVd1RqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFRodENuaG9OV2RxTldWb1JVUTNMek53VEVKTVFrdFpZamgwT0hwU2RtbHZPSFJHUkdsRlIxTktOMHQzY0RsM1JHZHlSMDh3ZW5BM1lsQmtabTlhTnpNNFRHUUtjbmRuTmtFM1preExkV2hrY0d0aVZFeHpOSHBIT1RkWVdVOUhZMjF6ZEhaeWVVOXFSa2RNVTBSSFNtMVJlR2RMSzBRNU15OUtPVkpSVmtoNmFVVnNkd3AxVVZKQlRsWlRiRUpJVDJGV1VWQlpWWGR1TVVGcFRuVnpVR05vZUZaUFJIRkhiRzloWWpCc01VbEVZMDFXTTFKMldXVTRlbGh2UmtOTVVqRkdkVTh5Q25sR05VaDBaR3R2UTA5MU1saDFNQ3RuUkZkaFRqWTRTRU14VVU1b1dXVmpVVkZLWnpkMFExaE9TRzlpVkZFclFWb3lhelF6ZVdaU1RUVjNWamxVY1RBS1pteHZWRUV3WkhkSFVuRnFNbWR4UkU5MVRHcGxVbGRpU0VSTGJXRkdTekpVWWxKQ1dHRnZiRmRFVG5keVN5dG5Ua04zTDA5ME1WZzNjakpRYUdkRVpRbzBNWGNyUm5SWU1HcEZVMmhyTjBkaVJqQnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWktNMEpaZW1NdkwwRkhaak5pV1ZnMFRFbHVhak53V2tNeGVGUk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJWRmR6TkdOdlJIcFpkbGxUZEROTk1FSmtlVE5JUTJkMmVXdGxTMjlLYkhjMFIyc3ZWa0ZrVVVGRldXSkdPR2QzTVFvdlFuUTJRa3RxUjNGUksxRXJObEZoVGxSa2FWWk9UR054ZEZrek9VOTZXWGhpT0ZRMGQzbFlZMUJzVkZSUmQwTkRjRU5PYlZoMFRteHBRM2RhY1hGdUNqRmtjRUZTYW1SWk5sSlZaSFJ1TUV0TUx6aHBUV1pDVW1Sak5IQjNka0l3VG5weWNWQlJhSEpuTUhSb1NVa3ZSRkpDUVRaRk9VZGtlRWxHY3pRMFptd0tSMnRpYTI5bFZUVTVhR2xNTUZKQlQweENXVzE2TW14dFpVTkJiMnB5UVhKaVNHZFZSREZCTkZCd2NGQmpaWGh2YUdSMFRtRTBPREJwVmsxalJEaHFiUW95TlhNdlExcFhiVTlOYUZOWksxTlhVekZRVUhaeWJ6SkdjblZTTldSWFJFaFdiV3hQUW5GbVMyVnhURlJ5UlZOME1XNVdhVkUzVEVScE1rMVFSRWd3Q2sxdFl5dHFTREZ2ZFZremRpOUlaRW81UmtWMk5reERhQzloYkV3eE0yODNibWxzYmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzgwYWM4MDUxLWQ4YzgtNDRjYi04NzA3LTNlNzE1MGM3MmY1My5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBEVm12NzZJZVJRUVJJaFJqdG1LcnJrdjk2dWZLZ253RzE5M3VDRmpzQlJVMHp2aHg0V3NMVUpNQg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAweGIxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEhKYUNrZDZSbXhNTmxNeVNERkdibmxPUTBoQk1XaFVXU3N4YnpONGNFeHVkMGhMTldGaE5VbGpabk5yZDNkWmRsZHhZalJWVFhCTU0yTTBNMkl2UjNjMWNGWUtRWHBaZEhKeGJFdGlhVFIyVDBSNU9UZzJTRTFYYVRWb01FdEJWVFpWVVdab1RGcGxXVWhyZVd0ME4xSjNlSFp4UWxrME56WXdWbXQ2WkUwNVRtRTJNUXBUV0RrMGEzRjBWVTlyTlRjNFNGRkdhREpMTkZwTk9XZzNNVXQwYzNjMFpWaGtaM2t4WjI1QlIycFNWMFF5ZUd4aU5IZDVVVUZ5WTJneWFWZG1PWFp1Q21SaGFXTndkalZoUTBwd2IzQjRjV1JsWm5sMlZEVnpZMk5xUkdveVJVZDVSV2czU1ZaMFlVaFRZM1F2UTA1dEsxRnBjSEpsWWt0NU9FSTRUM0ZNV1djS1NYbERlbFJzUkZCWVdXRlNMMGx3WjJkNlJqWnVVRFJJVmxkV1FXRnVjR05ZWkZCM2R5dEVOblF4UnpoQ1oyRjRiMGxvT0hOWlIweHNZa3RNWjBZMVpRb3JhbGN3U2pWcE9YWllOSFV2VkdRck5rY3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpOMDlEYTBsVmFFUm1MMFJLZERFNVVTOW1PV2d5UkZCS1FUbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOM2w1VEhwQk4wNVVla0Z1U0c5RlZpdENaMlpXY2xGTWQxSjFOVEJxVld4eEx6QkNPV2xSWkRJMlUzTlBWWEUzV2dwNGVtRTVNR3hYY1hSRlJGVldaRUZ3WTNwTmFrMXdOVlpEUVhkUFFraGhSWGw0Y1hsaVFVNU9TWFJuVEhOUWFUbFJhMHRJYW1rM1NURmtSVU40WkdWV0NrMUpUMGxFYWtGcmNrRmFVbFkzU2xnMllrVlZjMEoxVjJka00zSTBjbVpYYUdSM2RXaHZSQ3R0VGxkaVpYVm1aekJOWm1nMGVHSlFTbkYyTVhKeFdXY0tabVZRTHpWVEsxSjFVVXhDVUhwV2REQkNVVVphVDBOaVVTdHRWVkJ6VkN0NE4zWlphblJ5YUhGUFJFNUtTbnBFZDNNMFMxVkhXR2xOTVdGcmNGQmtVZ3BGYW1Rd1ZXeEZSMmgxZERoQ1NuSmhhMkZKV1dwTFZGWmFNa2QxYVROYVUybFFXalZPVW5oMlEzbFpkbkJ1Y1ZSR1JIQnRaMEZFYjJscWJqWnlORTlWQ21Sa04yaHVXalJEWVUxb1NUVXdURnBaYUc5R2MybGlXWGt3VlZaTlJqUlJWSGRJUVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzZkNGY2YzZkLTFiYjMtNGI1ZC04YjI2LWIwMjc1MzQ2NzkyYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoZHViazl6aFhmZEFJcXBRWlpkbXMxandGeDBDTzBKWTdRdXJWSlZQWjM4SjRTSWlNOGplTEhYeg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2574"
+      - "2572"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:13 GMT
+      - Tue, 07 Nov 2023 16:24:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3835,7 +2614,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7ad169d-18a7-4230-a121-47a20ea92597
+      - e0fb3268-a4a4-4b98-a1c0-f612ba393625
     status: 200 OK
     code: 200
     duration: ""
@@ -3846,19 +2625,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-18T16:43:07.266809Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:24:18.735830Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:13 GMT
+      - Tue, 07 Nov 2023 16:24:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3868,40 +2647,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ab75949-0886-47b6-8222-565f877a6216
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992605Z","created_at":"2023-10-18T16:35:45.992605Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:37:15.310850Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1493"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a86c3007-f62e-4b09-80bd-e3b8ab3b9249
+      - 6b383d50-3aa4-413c-a5ce-7796e09c8d1c
     status: 200 OK
     code: 200
     duration: ""
@@ -3915,16 +2661,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters?name=tf-cluster&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992605Z","created_at":"2023-10-18T16:35:45.992605Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:37:15.310850Z","upgrade_available":false,"version":"1.28.2"}],"total_count":1}'
+    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1525"
+      - "1479"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:13 GMT
+      - Tue, 07 Nov 2023 16:24:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3934,7 +2680,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5cd0ad18-f47e-4fe0-ae06-5d8f6a179bff
+      - 3cfc340d-ba47-4480-a69b-49ced9de8b46
     status: 200 OK
     code: 200
     duration: ""
@@ -3945,19 +2691,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53/nodes?order_by=created_at_asc&page=1&pool_id=fbee03e2-145c-4402-aa22-e1d18213d198&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:38:42.808849Z","error_message":null,"id":"bad6db13-3e8f-4d66-a1d0-89d51ba81c8c","name":"scw-tf-cluster-default-bad6db133e8f4d66a1d089d","pool_id":"fbee03e2-145c-4402-aa22-e1d18213d198","provider_id":"scaleway://instance/fr-par-1/3dac039d-34a4-46eb-8b6d-10a79fab3e4e","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:43:07.251031Z"}],"total_count":1}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "659"
+      - "1448"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:13 GMT
+      - Tue, 07 Nov 2023 16:24:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3967,7 +2713,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4cdf55ab-72eb-4e49-b277-7dca832d5a1a
+      - 2f6662b3-c830-431f-b50a-a9c33eca77c1
     status: 200 OK
     code: 200
     duration: ""
@@ -3978,19 +2724,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992605Z","created_at":"2023-10-18T16:35:45.992605Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:37:15.310850Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1493"
+      - "1448"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:13 GMT
+      - Tue, 07 Nov 2023 16:24:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4000,7 +2746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de09450b-777e-4d98-adb2-2881639736a7
+      - 2395bb7b-8d5a-473c-9d0f-b23767b7e710
     status: 200 OK
     code: 200
     duration: ""
@@ -4011,19 +2757,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/nodes?order_by=created_at_asc&page=1&pool_id=1fe1c124-6977-4948-8f6c-f2b823fcb286&status=unknown
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUWHBWTUU0eGIxaEVWRTE2VFZSQmVFNTZSVEpOZWxVd1RqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFRodENuaG9OV2RxTldWb1JVUTNMek53VEVKTVFrdFpZamgwT0hwU2RtbHZPSFJHUkdsRlIxTktOMHQzY0RsM1JHZHlSMDh3ZW5BM1lsQmtabTlhTnpNNFRHUUtjbmRuTmtFM1preExkV2hrY0d0aVZFeHpOSHBIT1RkWVdVOUhZMjF6ZEhaeWVVOXFSa2RNVTBSSFNtMVJlR2RMSzBRNU15OUtPVkpSVmtoNmFVVnNkd3AxVVZKQlRsWlRiRUpJVDJGV1VWQlpWWGR1TVVGcFRuVnpVR05vZUZaUFJIRkhiRzloWWpCc01VbEVZMDFXTTFKMldXVTRlbGh2UmtOTVVqRkdkVTh5Q25sR05VaDBaR3R2UTA5MU1saDFNQ3RuUkZkaFRqWTRTRU14VVU1b1dXVmpVVkZLWnpkMFExaE9TRzlpVkZFclFWb3lhelF6ZVdaU1RUVjNWamxVY1RBS1pteHZWRUV3WkhkSFVuRnFNbWR4UkU5MVRHcGxVbGRpU0VSTGJXRkdTekpVWWxKQ1dHRnZiRmRFVG5keVN5dG5Ua04zTDA5ME1WZzNjakpRYUdkRVpRbzBNWGNyUm5SWU1HcEZVMmhyTjBkaVJqQnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWktNMEpaZW1NdkwwRkhaak5pV1ZnMFRFbHVhak53V2tNeGVGUk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJWRmR6TkdOdlJIcFpkbGxUZEROTk1FSmtlVE5JUTJkMmVXdGxTMjlLYkhjMFIyc3ZWa0ZrVVVGRldXSkdPR2QzTVFvdlFuUTJRa3RxUjNGUksxRXJObEZoVGxSa2FWWk9UR054ZEZrek9VOTZXWGhpT0ZRMGQzbFlZMUJzVkZSUmQwTkRjRU5PYlZoMFRteHBRM2RhY1hGdUNqRmtjRUZTYW1SWk5sSlZaSFJ1TUV0TUx6aHBUV1pDVW1Sak5IQjNka0l3VG5weWNWQlJhSEpuTUhSb1NVa3ZSRkpDUVRaRk9VZGtlRWxHY3pRMFptd0tSMnRpYTI5bFZUVTVhR2xNTUZKQlQweENXVzE2TW14dFpVTkJiMnB5UVhKaVNHZFZSREZCTkZCd2NGQmpaWGh2YUdSMFRtRTBPREJwVmsxalJEaHFiUW95TlhNdlExcFhiVTlOYUZOWksxTlhVekZRVUhaeWJ6SkdjblZTTldSWFJFaFdiV3hQUW5GbVMyVnhURlJ5UlZOME1XNVdhVkUzVEVScE1rMVFSRWd3Q2sxdFl5dHFTREZ2ZFZremRpOUlaRW81UmtWMk5reERhQzloYkV3eE0yODNibWxzYmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzgwYWM4MDUxLWQ4YzgtNDRjYi04NzA3LTNlNzE1MGM3MmY1My5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBEVm12NzZJZVJRUVJJaFJqdG1LcnJrdjk2dWZLZ253RzE5M3VDRmpzQlJVMHp2aHg0V3NMVUpNQg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"nodes":[{"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T16:22:05.112095Z","error_message":null,"id":"59d458d7-02a0-4bf8-9a0f-81f28c5fe2ec","name":"scw-tf-cluster-default-59d458d702a04bf89a0f81f","pool_id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","provider_id":"scaleway://instance/fr-par-1/95a640e5-d685-44db-8a30-1dc37002649b","public_ip_v4":"51.158.79.120","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:24:18.723499Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "2574"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:13 GMT
+      - Tue, 07 Nov 2023 16:24:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4033,7 +2779,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36e72c12-cc76-436f-b0b2-f2abf804ac97
+      - d82b708f-28a8-4224-8adb-2efbbead04b9
     status: 200 OK
     code: 200
     duration: ""
@@ -4044,19 +2790,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUWHBWTUU0eGIxaEVWRTE2VFZSQmVFNTZSVEpOZWxVd1RqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFRodENuaG9OV2RxTldWb1JVUTNMek53VEVKTVFrdFpZamgwT0hwU2RtbHZPSFJHUkdsRlIxTktOMHQzY0RsM1JHZHlSMDh3ZW5BM1lsQmtabTlhTnpNNFRHUUtjbmRuTmtFM1preExkV2hrY0d0aVZFeHpOSHBIT1RkWVdVOUhZMjF6ZEhaeWVVOXFSa2RNVTBSSFNtMVJlR2RMSzBRNU15OUtPVkpSVmtoNmFVVnNkd3AxVVZKQlRsWlRiRUpJVDJGV1VWQlpWWGR1TVVGcFRuVnpVR05vZUZaUFJIRkhiRzloWWpCc01VbEVZMDFXTTFKMldXVTRlbGh2UmtOTVVqRkdkVTh5Q25sR05VaDBaR3R2UTA5MU1saDFNQ3RuUkZkaFRqWTRTRU14VVU1b1dXVmpVVkZLWnpkMFExaE9TRzlpVkZFclFWb3lhelF6ZVdaU1RUVjNWamxVY1RBS1pteHZWRUV3WkhkSFVuRnFNbWR4UkU5MVRHcGxVbGRpU0VSTGJXRkdTekpVWWxKQ1dHRnZiRmRFVG5keVN5dG5Ua04zTDA5ME1WZzNjakpRYUdkRVpRbzBNWGNyUm5SWU1HcEZVMmhyTjBkaVJqQnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWktNMEpaZW1NdkwwRkhaak5pV1ZnMFRFbHVhak53V2tNeGVGUk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJWRmR6TkdOdlJIcFpkbGxUZEROTk1FSmtlVE5JUTJkMmVXdGxTMjlLYkhjMFIyc3ZWa0ZrVVVGRldXSkdPR2QzTVFvdlFuUTJRa3RxUjNGUksxRXJObEZoVGxSa2FWWk9UR054ZEZrek9VOTZXWGhpT0ZRMGQzbFlZMUJzVkZSUmQwTkRjRU5PYlZoMFRteHBRM2RhY1hGdUNqRmtjRUZTYW1SWk5sSlZaSFJ1TUV0TUx6aHBUV1pDVW1Sak5IQjNka0l3VG5weWNWQlJhSEpuTUhSb1NVa3ZSRkpDUVRaRk9VZGtlRWxHY3pRMFptd0tSMnRpYTI5bFZUVTVhR2xNTUZKQlQweENXVzE2TW14dFpVTkJiMnB5UVhKaVNHZFZSREZCTkZCd2NGQmpaWGh2YUdSMFRtRTBPREJwVmsxalJEaHFiUW95TlhNdlExcFhiVTlOYUZOWksxTlhVekZRVUhaeWJ6SkdjblZTTldSWFJFaFdiV3hQUW5GbVMyVnhURlJ5UlZOME1XNVdhVkUzVEVScE1rMVFSRWd3Q2sxdFl5dHFTREZ2ZFZremRpOUlaRW81UmtWMk5reERhQzloYkV3eE0yODNibWxzYmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzgwYWM4MDUxLWQ4YzgtNDRjYi04NzA3LTNlNzE1MGM3MmY1My5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBEVm12NzZJZVJRUVJJaFJqdG1LcnJrdjk2dWZLZ253RzE5M3VDRmpzQlJVMHp2aHg0V3NMVUpNQg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAweGIxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEhKYUNrZDZSbXhNTmxNeVNERkdibmxPUTBoQk1XaFVXU3N4YnpONGNFeHVkMGhMTldGaE5VbGpabk5yZDNkWmRsZHhZalJWVFhCTU0yTTBNMkl2UjNjMWNGWUtRWHBaZEhKeGJFdGlhVFIyVDBSNU9UZzJTRTFYYVRWb01FdEJWVFpWVVdab1RGcGxXVWhyZVd0ME4xSjNlSFp4UWxrME56WXdWbXQ2WkUwNVRtRTJNUXBUV0RrMGEzRjBWVTlyTlRjNFNGRkdhREpMTkZwTk9XZzNNVXQwYzNjMFpWaGtaM2t4WjI1QlIycFNWMFF5ZUd4aU5IZDVVVUZ5WTJneWFWZG1PWFp1Q21SaGFXTndkalZoUTBwd2IzQjRjV1JsWm5sMlZEVnpZMk5xUkdveVJVZDVSV2czU1ZaMFlVaFRZM1F2UTA1dEsxRnBjSEpsWWt0NU9FSTRUM0ZNV1djS1NYbERlbFJzUkZCWVdXRlNMMGx3WjJkNlJqWnVVRFJJVmxkV1FXRnVjR05ZWkZCM2R5dEVOblF4UnpoQ1oyRjRiMGxvT0hOWlIweHNZa3RNWjBZMVpRb3JhbGN3U2pWcE9YWllOSFV2VkdRck5rY3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpOMDlEYTBsVmFFUm1MMFJLZERFNVVTOW1PV2d5UkZCS1FUbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOM2w1VEhwQk4wNVVla0Z1U0c5RlZpdENaMlpXY2xGTWQxSjFOVEJxVld4eEx6QkNPV2xSWkRJMlUzTlBWWEUzV2dwNGVtRTVNR3hYY1hSRlJGVldaRUZ3WTNwTmFrMXdOVlpEUVhkUFFraGhSWGw0Y1hsaVFVNU9TWFJuVEhOUWFUbFJhMHRJYW1rM1NURmtSVU40WkdWV0NrMUpUMGxFYWtGcmNrRmFVbFkzU2xnMllrVlZjMEoxVjJka00zSTBjbVpYYUdSM2RXaHZSQ3R0VGxkaVpYVm1aekJOWm1nMGVHSlFTbkYyTVhKeFdXY0tabVZRTHpWVEsxSjFVVXhDVUhwV2REQkNVVVphVDBOaVVTdHRWVkJ6VkN0NE4zWlphblJ5YUhGUFJFNUtTbnBFZDNNMFMxVkhXR2xOTVdGcmNGQmtVZ3BGYW1Rd1ZXeEZSMmgxZERoQ1NuSmhhMkZKV1dwTFZGWmFNa2QxYVROYVUybFFXalZPVW5oMlEzbFpkbkJ1Y1ZSR1JIQnRaMEZFYjJscWJqWnlORTlWQ21Sa04yaHVXalJEWVUxb1NUVXdURnBaYUc5R2MybGlXWGt3VlZaTlJqUlJWSGRJUVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzZkNGY2YzZkLTFiYjMtNGI1ZC04YjI2LWIwMjc1MzQ2NzkyYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoZHViazl6aFhmZEFJcXBRWlpkbXMxandGeDBDTzBKWTdRdXJWSlZQWjM4SjRTSWlNOGplTEhYeg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2574"
+      - "2572"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:13 GMT
+      - Tue, 07 Nov 2023 16:24:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4066,7 +2812,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db9a143d-3f53-45e6-bbba-2b800c2f92d3
+      - b1c164cf-99f4-4413-b7be-9ec3afa089d5
     status: 200 OK
     code: 200
     duration: ""
@@ -4077,19 +2823,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992605Z","created_at":"2023-10-18T16:35:45.992605Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:37:15.310850Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAweGIxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEhKYUNrZDZSbXhNTmxNeVNERkdibmxPUTBoQk1XaFVXU3N4YnpONGNFeHVkMGhMTldGaE5VbGpabk5yZDNkWmRsZHhZalJWVFhCTU0yTTBNMkl2UjNjMWNGWUtRWHBaZEhKeGJFdGlhVFIyVDBSNU9UZzJTRTFYYVRWb01FdEJWVFpWVVdab1RGcGxXVWhyZVd0ME4xSjNlSFp4UWxrME56WXdWbXQ2WkUwNVRtRTJNUXBUV0RrMGEzRjBWVTlyTlRjNFNGRkdhREpMTkZwTk9XZzNNVXQwYzNjMFpWaGtaM2t4WjI1QlIycFNWMFF5ZUd4aU5IZDVVVUZ5WTJneWFWZG1PWFp1Q21SaGFXTndkalZoUTBwd2IzQjRjV1JsWm5sMlZEVnpZMk5xUkdveVJVZDVSV2czU1ZaMFlVaFRZM1F2UTA1dEsxRnBjSEpsWWt0NU9FSTRUM0ZNV1djS1NYbERlbFJzUkZCWVdXRlNMMGx3WjJkNlJqWnVVRFJJVmxkV1FXRnVjR05ZWkZCM2R5dEVOblF4UnpoQ1oyRjRiMGxvT0hOWlIweHNZa3RNWjBZMVpRb3JhbGN3U2pWcE9YWllOSFV2VkdRck5rY3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpOMDlEYTBsVmFFUm1MMFJLZERFNVVTOW1PV2d5UkZCS1FUbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOM2w1VEhwQk4wNVVla0Z1U0c5RlZpdENaMlpXY2xGTWQxSjFOVEJxVld4eEx6QkNPV2xSWkRJMlUzTlBWWEUzV2dwNGVtRTVNR3hYY1hSRlJGVldaRUZ3WTNwTmFrMXdOVlpEUVhkUFFraGhSWGw0Y1hsaVFVNU9TWFJuVEhOUWFUbFJhMHRJYW1rM1NURmtSVU40WkdWV0NrMUpUMGxFYWtGcmNrRmFVbFkzU2xnMllrVlZjMEoxVjJka00zSTBjbVpYYUdSM2RXaHZSQ3R0VGxkaVpYVm1aekJOWm1nMGVHSlFTbkYyTVhKeFdXY0tabVZRTHpWVEsxSjFVVXhDVUhwV2REQkNVVVphVDBOaVVTdHRWVkJ6VkN0NE4zWlphblJ5YUhGUFJFNUtTbnBFZDNNMFMxVkhXR2xOTVdGcmNGQmtVZ3BGYW1Rd1ZXeEZSMmgxZERoQ1NuSmhhMkZKV1dwTFZGWmFNa2QxYVROYVUybFFXalZPVW5oMlEzbFpkbkJ1Y1ZSR1JIQnRaMEZFYjJscWJqWnlORTlWQ21Sa04yaHVXalJEWVUxb1NUVXdURnBaYUc5R2MybGlXWGt3VlZaTlJqUlJWSGRJUVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzZkNGY2YzZkLTFiYjMtNGI1ZC04YjI2LWIwMjc1MzQ2NzkyYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoZHViazl6aFhmZEFJcXBRWlpkbXMxandGeDBDTzBKWTdRdXJWSlZQWjM4SjRTSWlNOGplTEhYeg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1493"
+      - "2572"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:13 GMT
+      - Tue, 07 Nov 2023 16:24:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4099,7 +2845,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7da270d-1d86-44dc-a951-79d5904bc23a
+      - 553f56bd-50b7-4794-be24-833cfc4ffb4d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1448"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:24:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 565ee76a-687b-4e22-9e39-ffebb59f17eb
     status: 200 OK
     code: 200
     duration: ""
@@ -4113,16 +2892,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters?name=tf-cluster&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992605Z","created_at":"2023-10-18T16:35:45.992605Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:37:15.310850Z","upgrade_available":false,"version":"1.28.2"}],"total_count":1}'
+    body: '{"clusters":[{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1525"
+      - "1479"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:13 GMT
+      - Tue, 07 Nov 2023 16:24:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4132,7 +2911,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec70f6d2-fc0b-47b7-a5c2-b2867046f5fb
+      - 72ff8a88-5a73-4e13-9386-44c6b7d1d802
     status: 200 OK
     code: 200
     duration: ""
@@ -4143,19 +2922,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992605Z","created_at":"2023-10-18T16:35:45.992605Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:37:15.310850Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:21:33.115413Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1493"
+      - "1448"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:14 GMT
+      - Tue, 07 Nov 2023 16:24:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4165,7 +2944,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c868ecb2-d0a9-470c-af62-f6f529db53b3
+      - ed82c34d-a562-4b68-bd39-ab384d564aee
     status: 200 OK
     code: 200
     duration: ""
@@ -4176,19 +2955,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUWHBWTUU0eGIxaEVWRTE2VFZSQmVFNTZSVEpOZWxVd1RqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFRodENuaG9OV2RxTldWb1JVUTNMek53VEVKTVFrdFpZamgwT0hwU2RtbHZPSFJHUkdsRlIxTktOMHQzY0RsM1JHZHlSMDh3ZW5BM1lsQmtabTlhTnpNNFRHUUtjbmRuTmtFM1preExkV2hrY0d0aVZFeHpOSHBIT1RkWVdVOUhZMjF6ZEhaeWVVOXFSa2RNVTBSSFNtMVJlR2RMSzBRNU15OUtPVkpSVmtoNmFVVnNkd3AxVVZKQlRsWlRiRUpJVDJGV1VWQlpWWGR1TVVGcFRuVnpVR05vZUZaUFJIRkhiRzloWWpCc01VbEVZMDFXTTFKMldXVTRlbGh2UmtOTVVqRkdkVTh5Q25sR05VaDBaR3R2UTA5MU1saDFNQ3RuUkZkaFRqWTRTRU14VVU1b1dXVmpVVkZLWnpkMFExaE9TRzlpVkZFclFWb3lhelF6ZVdaU1RUVjNWamxVY1RBS1pteHZWRUV3WkhkSFVuRnFNbWR4UkU5MVRHcGxVbGRpU0VSTGJXRkdTekpVWWxKQ1dHRnZiRmRFVG5keVN5dG5Ua04zTDA5ME1WZzNjakpRYUdkRVpRbzBNWGNyUm5SWU1HcEZVMmhyTjBkaVJqQnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWktNMEpaZW1NdkwwRkhaak5pV1ZnMFRFbHVhak53V2tNeGVGUk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJWRmR6TkdOdlJIcFpkbGxUZEROTk1FSmtlVE5JUTJkMmVXdGxTMjlLYkhjMFIyc3ZWa0ZrVVVGRldXSkdPR2QzTVFvdlFuUTJRa3RxUjNGUksxRXJObEZoVGxSa2FWWk9UR054ZEZrek9VOTZXWGhpT0ZRMGQzbFlZMUJzVkZSUmQwTkRjRU5PYlZoMFRteHBRM2RhY1hGdUNqRmtjRUZTYW1SWk5sSlZaSFJ1TUV0TUx6aHBUV1pDVW1Sak5IQjNka0l3VG5weWNWQlJhSEpuTUhSb1NVa3ZSRkpDUVRaRk9VZGtlRWxHY3pRMFptd0tSMnRpYTI5bFZUVTVhR2xNTUZKQlQweENXVzE2TW14dFpVTkJiMnB5UVhKaVNHZFZSREZCTkZCd2NGQmpaWGh2YUdSMFRtRTBPREJwVmsxalJEaHFiUW95TlhNdlExcFhiVTlOYUZOWksxTlhVekZRVUhaeWJ6SkdjblZTTldSWFJFaFdiV3hQUW5GbVMyVnhURlJ5UlZOME1XNVdhVkUzVEVScE1rMVFSRWd3Q2sxdFl5dHFTREZ2ZFZremRpOUlaRW81UmtWMk5reERhQzloYkV3eE0yODNibWxzYmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzgwYWM4MDUxLWQ4YzgtNDRjYi04NzA3LTNlNzE1MGM3MmY1My5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBEVm12NzZJZVJRUVJJaFJqdG1LcnJrdjk2dWZLZ253RzE5M3VDRmpzQlJVMHp2aHg0V3NMVUpNQg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAweGIxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEhKYUNrZDZSbXhNTmxNeVNERkdibmxPUTBoQk1XaFVXU3N4YnpONGNFeHVkMGhMTldGaE5VbGpabk5yZDNkWmRsZHhZalJWVFhCTU0yTTBNMkl2UjNjMWNGWUtRWHBaZEhKeGJFdGlhVFIyVDBSNU9UZzJTRTFYYVRWb01FdEJWVFpWVVdab1RGcGxXVWhyZVd0ME4xSjNlSFp4UWxrME56WXdWbXQ2WkUwNVRtRTJNUXBUV0RrMGEzRjBWVTlyTlRjNFNGRkdhREpMTkZwTk9XZzNNVXQwYzNjMFpWaGtaM2t4WjI1QlIycFNWMFF5ZUd4aU5IZDVVVUZ5WTJneWFWZG1PWFp1Q21SaGFXTndkalZoUTBwd2IzQjRjV1JsWm5sMlZEVnpZMk5xUkdveVJVZDVSV2czU1ZaMFlVaFRZM1F2UTA1dEsxRnBjSEpsWWt0NU9FSTRUM0ZNV1djS1NYbERlbFJzUkZCWVdXRlNMMGx3WjJkNlJqWnVVRFJJVmxkV1FXRnVjR05ZWkZCM2R5dEVOblF4UnpoQ1oyRjRiMGxvT0hOWlIweHNZa3RNWjBZMVpRb3JhbGN3U2pWcE9YWllOSFV2VkdRck5rY3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpOMDlEYTBsVmFFUm1MMFJLZERFNVVTOW1PV2d5UkZCS1FUbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOM2w1VEhwQk4wNVVla0Z1U0c5RlZpdENaMlpXY2xGTWQxSjFOVEJxVld4eEx6QkNPV2xSWkRJMlUzTlBWWEUzV2dwNGVtRTVNR3hYY1hSRlJGVldaRUZ3WTNwTmFrMXdOVlpEUVhkUFFraGhSWGw0Y1hsaVFVNU9TWFJuVEhOUWFUbFJhMHRJYW1rM1NURmtSVU40WkdWV0NrMUpUMGxFYWtGcmNrRmFVbFkzU2xnMllrVlZjMEoxVjJka00zSTBjbVpYYUdSM2RXaHZSQ3R0VGxkaVpYVm1aekJOWm1nMGVHSlFTbkYyTVhKeFdXY0tabVZRTHpWVEsxSjFVVXhDVUhwV2REQkNVVVphVDBOaVVTdHRWVkJ6VkN0NE4zWlphblJ5YUhGUFJFNUtTbnBFZDNNMFMxVkhXR2xOTVdGcmNGQmtVZ3BGYW1Rd1ZXeEZSMmgxZERoQ1NuSmhhMkZKV1dwTFZGWmFNa2QxYVROYVUybFFXalZPVW5oMlEzbFpkbkJ1Y1ZSR1JIQnRaMEZFYjJscWJqWnlORTlWQ21Sa04yaHVXalJEWVUxb1NUVXdURnBaYUc5R2MybGlXWGt3VlZaTlJqUlJWSGRJUVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzZkNGY2YzZkLTFiYjMtNGI1ZC04YjI2LWIwMjc1MzQ2NzkyYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoZHViazl6aFhmZEFJcXBRWlpkbXMxandGeDBDTzBKWTdRdXJWSlZQWjM4SjRTSWlNOGplTEhYeg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2574"
+      - "2572"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:14 GMT
+      - Tue, 07 Nov 2023 16:24:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4198,7 +2977,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a412d9bb-ae59-4ba2-855b-d5b6a2893daa
+      - a15317ad-5d98-4abe-94c8-444adec45cdd
     status: 200 OK
     code: 200
     duration: ""
@@ -4209,19 +2988,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUWHBWTUU0eGIxaEVWRTE2VFZSQmVFNTZSVEpOZWxVd1RqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFRodENuaG9OV2RxTldWb1JVUTNMek53VEVKTVFrdFpZamgwT0hwU2RtbHZPSFJHUkdsRlIxTktOMHQzY0RsM1JHZHlSMDh3ZW5BM1lsQmtabTlhTnpNNFRHUUtjbmRuTmtFM1preExkV2hrY0d0aVZFeHpOSHBIT1RkWVdVOUhZMjF6ZEhaeWVVOXFSa2RNVTBSSFNtMVJlR2RMSzBRNU15OUtPVkpSVmtoNmFVVnNkd3AxVVZKQlRsWlRiRUpJVDJGV1VWQlpWWGR1TVVGcFRuVnpVR05vZUZaUFJIRkhiRzloWWpCc01VbEVZMDFXTTFKMldXVTRlbGh2UmtOTVVqRkdkVTh5Q25sR05VaDBaR3R2UTA5MU1saDFNQ3RuUkZkaFRqWTRTRU14VVU1b1dXVmpVVkZLWnpkMFExaE9TRzlpVkZFclFWb3lhelF6ZVdaU1RUVjNWamxVY1RBS1pteHZWRUV3WkhkSFVuRnFNbWR4UkU5MVRHcGxVbGRpU0VSTGJXRkdTekpVWWxKQ1dHRnZiRmRFVG5keVN5dG5Ua04zTDA5ME1WZzNjakpRYUdkRVpRbzBNWGNyUm5SWU1HcEZVMmhyTjBkaVJqQnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWktNMEpaZW1NdkwwRkhaak5pV1ZnMFRFbHVhak53V2tNeGVGUk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJWRmR6TkdOdlJIcFpkbGxUZEROTk1FSmtlVE5JUTJkMmVXdGxTMjlLYkhjMFIyc3ZWa0ZrVVVGRldXSkdPR2QzTVFvdlFuUTJRa3RxUjNGUksxRXJObEZoVGxSa2FWWk9UR054ZEZrek9VOTZXWGhpT0ZRMGQzbFlZMUJzVkZSUmQwTkRjRU5PYlZoMFRteHBRM2RhY1hGdUNqRmtjRUZTYW1SWk5sSlZaSFJ1TUV0TUx6aHBUV1pDVW1Sak5IQjNka0l3VG5weWNWQlJhSEpuTUhSb1NVa3ZSRkpDUVRaRk9VZGtlRWxHY3pRMFptd0tSMnRpYTI5bFZUVTVhR2xNTUZKQlQweENXVzE2TW14dFpVTkJiMnB5UVhKaVNHZFZSREZCTkZCd2NGQmpaWGh2YUdSMFRtRTBPREJwVmsxalJEaHFiUW95TlhNdlExcFhiVTlOYUZOWksxTlhVekZRVUhaeWJ6SkdjblZTTldSWFJFaFdiV3hQUW5GbVMyVnhURlJ5UlZOME1XNVdhVkUzVEVScE1rMVFSRWd3Q2sxdFl5dHFTREZ2ZFZremRpOUlaRW81UmtWMk5reERhQzloYkV3eE0yODNibWxzYmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzgwYWM4MDUxLWQ4YzgtNDRjYi04NzA3LTNlNzE1MGM3MmY1My5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBEVm12NzZJZVJRUVJJaFJqdG1LcnJrdjk2dWZLZ253RzE5M3VDRmpzQlJVMHp2aHg0V3NMVUpNQg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXIiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAweGIxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEhKYUNrZDZSbXhNTmxNeVNERkdibmxPUTBoQk1XaFVXU3N4YnpONGNFeHVkMGhMTldGaE5VbGpabk5yZDNkWmRsZHhZalJWVFhCTU0yTTBNMkl2UjNjMWNGWUtRWHBaZEhKeGJFdGlhVFIyVDBSNU9UZzJTRTFYYVRWb01FdEJWVFpWVVdab1RGcGxXVWhyZVd0ME4xSjNlSFp4UWxrME56WXdWbXQ2WkUwNVRtRTJNUXBUV0RrMGEzRjBWVTlyTlRjNFNGRkdhREpMTkZwTk9XZzNNVXQwYzNjMFpWaGtaM2t4WjI1QlIycFNWMFF5ZUd4aU5IZDVVVUZ5WTJneWFWZG1PWFp1Q21SaGFXTndkalZoUTBwd2IzQjRjV1JsWm5sMlZEVnpZMk5xUkdveVJVZDVSV2czU1ZaMFlVaFRZM1F2UTA1dEsxRnBjSEpsWWt0NU9FSTRUM0ZNV1djS1NYbERlbFJzUkZCWVdXRlNMMGx3WjJkNlJqWnVVRFJJVmxkV1FXRnVjR05ZWkZCM2R5dEVOblF4UnpoQ1oyRjRiMGxvT0hOWlIweHNZa3RNWjBZMVpRb3JhbGN3U2pWcE9YWllOSFV2VkdRck5rY3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpOMDlEYTBsVmFFUm1MMFJLZERFNVVTOW1PV2d5UkZCS1FUbE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNOM2w1VEhwQk4wNVVla0Z1U0c5RlZpdENaMlpXY2xGTWQxSjFOVEJxVld4eEx6QkNPV2xSWkRJMlUzTlBWWEUzV2dwNGVtRTVNR3hYY1hSRlJGVldaRUZ3WTNwTmFrMXdOVlpEUVhkUFFraGhSWGw0Y1hsaVFVNU9TWFJuVEhOUWFUbFJhMHRJYW1rM1NURmtSVU40WkdWV0NrMUpUMGxFYWtGcmNrRmFVbFkzU2xnMllrVlZjMEoxVjJka00zSTBjbVpYYUdSM2RXaHZSQ3R0VGxkaVpYVm1aekJOWm1nMGVHSlFTbkYyTVhKeFdXY0tabVZRTHpWVEsxSjFVVXhDVUhwV2REQkNVVVphVDBOaVVTdHRWVkJ6VkN0NE4zWlphblJ5YUhGUFJFNUtTbnBFZDNNMFMxVkhXR2xOTVdGcmNGQmtVZ3BGYW1Rd1ZXeEZSMmgxZERoQ1NuSmhhMkZKV1dwTFZGWmFNa2QxYVROYVUybFFXalZPVW5oMlEzbFpkbkJ1Y1ZSR1JIQnRaMEZFYjJscWJqWnlORTlWQ21Sa04yaHVXalJEWVUxb1NUVXdURnBaYUc5R2MybGlXWGt3VlZaTlJqUlJWSGRJUVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzZkNGY2YzZkLTFiYjMtNGI1ZC04YjI2LWIwMjc1MzQ2NzkyYi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0Zi1jbHVzdGVyCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0Zi1jbHVzdGVyIgogICAgdXNlcjogdGYtY2x1c3Rlci1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRmLWNsdXN0ZXIKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0Zi1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBoZHViazl6aFhmZEFJcXBRWlpkbXMxandGeDBDTzBKWTdRdXJWSlZQWjM4SjRTSWlNOGplTEhYeg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2574"
+      - "2572"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:14 GMT
+      - Tue, 07 Nov 2023 16:24:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4231,7 +3010,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c57e8374-ccd8-40aa-ad30-26c3cb2f22d8
+      - 810d6ab1-cb34-4967-a11e-9f0e3ffc5fcc
     status: 200 OK
     code: 200
     duration: ""
@@ -4242,19 +3021,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fbee03e2-145c-4402-aa22-e1d18213d198
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.379633Z","id":"fbee03e2-145c-4402-aa22-e1d18213d198","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-10-18T16:43:14.671542684Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:24:22.356407608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "621"
+      - "598"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:14 GMT
+      - Tue, 07 Nov 2023 16:24:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4264,7 +3043,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2857d15-e9ba-40e6-ac01-732292cbde93
+      - 106afea7-0b1c-4721-8df1-b6a0f285c474
     status: 200 OK
     code: 200
     duration: ""
@@ -4275,52 +3054,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53?with_additional_resources=true
-    method: DELETE
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992605Z","created_at":"2023-10-18T16:35:45.992605Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:43:14.736067809Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1499"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7f99c940-451d-4a41-bba8-1ccf51e90d3c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992605Z","created_at":"2023-10-18T16:35:45.992605Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:43:14.736068Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:24:22.356408Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1496"
+      - "595"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:14 GMT
+      - Tue, 07 Nov 2023 16:24:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4330,7 +3076,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f78f59b8-5a27-41a7-9af3-cd121b0a3b1e
+      - 22be75df-3ebe-4767-bed7-ed6cf72076dc
     status: 200 OK
     code: 200
     duration: ""
@@ -4341,19 +3087,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992605Z","created_at":"2023-10-18T16:35:45.992605Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:43:14.736068Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:24:22.356408Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1496"
+      - "595"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:19 GMT
+      - Tue, 07 Nov 2023 16:24:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4363,7 +3109,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 285215df-ecd8-4457-95cb-9202f854105f
+      - cfed8573-6ed9-483f-9fcd-80f584df6311
     status: 200 OK
     code: 200
     duration: ""
@@ -4374,19 +3120,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992605Z","created_at":"2023-10-18T16:35:45.992605Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:43:14.736068Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:24:22.356408Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1496"
+      - "595"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:24 GMT
+      - Tue, 07 Nov 2023 16:24:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4396,7 +3142,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5a72542-6575-4e6a-8f06-9d686c6c430a
+      - 77b3b7e6-2811-4851-b7e0-3766534d45f4
     status: 200 OK
     code: 200
     duration: ""
@@ -4407,19 +3153,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://80ac8051-d8c8-44cb-8707-3e7150c72f53.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.992605Z","created_at":"2023-10-18T16:35:45.992605Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.80ac8051-d8c8-44cb-8707-3e7150c72f53.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b8465b8c-e70b-481d-ac66-e37207423524","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-10-18T16:43:14.736068Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","container_runtime":"containerd","created_at":"2023-11-07T16:20:06.924555Z","id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","kubelet_args":{},"max_size":1,"min_size":1,"name":"default","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:24:22.356408Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1496"
+      - "595"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:29 GMT
+      - Tue, 07 Nov 2023 16:24:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4429,7 +3175,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa1213f1-5f25-407b-853f-eee3e1d3b9df
+      - 1f49fe20-7b88-4806-996b-db35328c4e03
     status: 200 OK
     code: 200
     duration: ""
@@ -4440,19 +3186,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1fe1c124-6977-4948-8f6c-f2b823fcb286
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"1fe1c124-6977-4948-8f6c-f2b823fcb286","type":"not_found"}'
     headers:
       Content-Length:
-      - "128"
+      - "125"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:35 GMT
+      - Tue, 07 Nov 2023 16:24:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4462,7 +3208,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e366fc6c-fdf5-46a7-a4f9-34958063ff2f
+      - 7ee345bc-4dd5-4707-aaaa-d35704081c06
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4473,10 +3219,142 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b8465b8c-e70b-481d-ac66-e37207423524
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"b8465b8c-e70b-481d-ac66-e37207423524","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:24:42.721863802Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1454"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:24:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 93f62be5-244b-40ab-b647-8d0f2489de89
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:24:42.721864Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1451"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:24:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f2c60b72-5cd9-4ff4-94ca-7de1cee154da
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.429757Z","created_at":"2023-11-07T16:20:01.429757Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6d4f6c6d-1bb3-4b5d-8b26-b0275346792b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","ingress":"none","name":"tf-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c230f16e-9326-4410-a133-9c0ecadde48a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-07T16:24:42.721864Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1451"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:24:48 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ad76cef8-caad-4cec-9f8b-6fe49fed20ef
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:24:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5562762a-15c9-4d87-ba1a-f24616387e18
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c230f16e-9326-4410-a133-9c0ecadde48a
+    method: DELETE
+  response:
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"c230f16e-9326-4410-a133-9c0ecadde48a","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -4485,7 +3363,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:35 GMT
+      - Tue, 07 Nov 2023 16:24:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4495,7 +3373,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85f76ad8-943f-4e83-af7c-f1d82cb33449
+      - f8103f77-33a6-42a5-b7c8-dbadaae7aece
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4506,10 +3384,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -4518,7 +3396,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:35 GMT
+      - Tue, 07 Nov 2023 16:24:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4528,7 +3406,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f81ce10c-5cc3-47a8-a968-cb86c1b9b61d
+      - b9d709d1-80db-4994-bf88-a2f2fb8eecba
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4539,10 +3417,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -4551,7 +3429,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:35 GMT
+      - Tue, 07 Nov 2023 16:24:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4561,7 +3439,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88eb4f34-6b36-4a65-99db-fc63356882c7
+      - bab3bb3d-d15b-414b-a65f-c0a194384bc0
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4572,10 +3450,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/80ac8051-d8c8-44cb-8707-3e7150c72f53
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/6d4f6c6d-1bb3-4b5d-8b26-b0275346792b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"80ac8051-d8c8-44cb-8707-3e7150c72f53","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"6d4f6c6d-1bb3-4b5d-8b26-b0275346792b","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -4584,7 +3462,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:35 GMT
+      - Tue, 07 Nov 2023 16:24:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4594,7 +3472,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7867e73-bf45-4b84-b983-dc316faa3534
+      - f4eff59e-390e-4e3a-9d8c-79553de5a8c2
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-k8s-pool-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-k8s-pool-basic.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:33:52 GMT
+      - Wed, 08 Nov 2023 09:10:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,12 +34,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a17aeb2-2602-420d-a706-d3262990d97e
+      - 1b1ab61b-33ba-4884-9b38-2c2adbbd4b02
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-data-source-pool","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
+    body: '{"name":"test-data-source-pool","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-02T15:33:53.182844Z","dhcp_enabled":true,"id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","name":"test-data-source-pool","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-02T15:33:53.182844Z","id":"8b259f89-423a-4607-9979-13dd7515cc29","subnet":"172.16.4.0/22","updated_at":"2023-11-02T15:33:53.182844Z"},{"created_at":"2023-11-02T15:33:53.182844Z","id":"05ee4fd6-0b54-497d-9684-b3673ddeb02c","subnet":"fd5f:519c:6d46:cb39::/64","updated_at":"2023-11-02T15:33:53.182844Z"}],"tags":[],"updated_at":"2023-11-02T15:33:53.182844Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-08T09:10:14.141608Z","dhcp_enabled":true,"id":"9204ea7b-13d2-4b0d-938d-30250328f16f","name":"test-data-source-pool","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-08T09:10:14.141608Z","id":"0ece81a7-0a26-41cd-b79c-3e9f201ac24f","subnet":"172.16.12.0/22","updated_at":"2023-11-08T09:10:14.141608Z"},{"created_at":"2023-11-08T09:10:14.141608Z","id":"e3f389f9-023e-44be-8d1d-b7eb49001405","subnet":"fd63:256c:45f7:998e::/64","updated_at":"2023-11-08T09:10:14.141608Z"}],"tags":[],"updated_at":"2023-11-08T09:10:14.141608Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "704"
+      - "705"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:33:53 GMT
+      - Wed, 08 Nov 2023 09:10:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7866d486-65bc-4879-a65b-d9eee72f9c68
+      - 7de1a0fc-19d7-417b-9455-12d70fd47bb9
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7c0f88fe-47b2-44c5-be75-7e0d3766bc55
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9204ea7b-13d2-4b0d-938d-30250328f16f
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T15:33:53.182844Z","dhcp_enabled":true,"id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","name":"test-data-source-pool","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-02T15:33:53.182844Z","id":"8b259f89-423a-4607-9979-13dd7515cc29","subnet":"172.16.4.0/22","updated_at":"2023-11-02T15:33:53.182844Z"},{"created_at":"2023-11-02T15:33:53.182844Z","id":"05ee4fd6-0b54-497d-9684-b3673ddeb02c","subnet":"fd5f:519c:6d46:cb39::/64","updated_at":"2023-11-02T15:33:53.182844Z"}],"tags":[],"updated_at":"2023-11-02T15:33:53.182844Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-08T09:10:14.141608Z","dhcp_enabled":true,"id":"9204ea7b-13d2-4b0d-938d-30250328f16f","name":"test-data-source-pool","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-08T09:10:14.141608Z","id":"0ece81a7-0a26-41cd-b79c-3e9f201ac24f","subnet":"172.16.12.0/22","updated_at":"2023-11-08T09:10:14.141608Z"},{"created_at":"2023-11-08T09:10:14.141608Z","id":"e3f389f9-023e-44be-8d1d-b7eb49001405","subnet":"fd63:256c:45f7:998e::/64","updated_at":"2023-11-08T09:10:14.141608Z"}],"tags":[],"updated_at":"2023-11-08T09:10:14.141608Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "704"
+      - "705"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:33:53 GMT
+      - Wed, 08 Nov 2023 09:10:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7e852c1-20ca-4bf3-ae62-31a278453f2b
+      - c36760dc-4f55-4b28-a0bf-cb5867c53190
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","type":"","name":"tf-cluster-pool","description":"","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"tf-cluster-pool","description":"","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f"}'
     form: {}
     headers:
       Content-Type:
@@ -118,7 +118,7 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614473Z","created_at":"2023-11-02T15:33:54.422614473Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-02T15:33:54.439759890Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312569940Z","created_at":"2023-11-08T09:10:15.312569940Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-08T09:10:15.332112061Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1462"
@@ -127,7 +127,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:33:54 GMT
+      - Wed, 08 Nov 2023 09:10:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0613fb4-02bd-4aeb-b18b-eddb861027c4
+      - 5b991cf0-902b-4745-a6a3-77897abff593
     status: 200 OK
     code: 200
     duration: ""
@@ -148,10 +148,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-02T15:33:54.439760Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-08T09:10:15.332112Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1453"
@@ -160,7 +160,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:33:54 GMT
+      - Wed, 08 Nov 2023 09:10:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 13da070d-d6ae-4bbc-bc5e-38989f72d750
+      - 4756c8db-605d-4aaf-83d9-137e5942bafc
     status: 200 OK
     code: 200
     duration: ""
@@ -181,10 +181,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-02T15:33:56.176242Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-08T09:10:18.117105Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1458"
@@ -193,7 +193,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:33:59 GMT
+      - Wed, 08 Nov 2023 09:10:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6d086f9-47d5-4a6a-958b-49571ad7933b
+      - 1d13686f-dca5-4cd0-bddd-e39f73bed267
     status: 200 OK
     code: 200
     duration: ""
@@ -214,10 +214,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-02T15:33:56.176242Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-08T09:10:18.117105Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1458"
@@ -226,7 +226,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:33:59 GMT
+      - Wed, 08 Nov 2023 09:10:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4201e14b-4b4f-40a9-87b2-ebdc228b9cc9
+      - 35e6325f-18ff-4e44-8cbe-b87317443099
     status: 200 OK
     code: 200
     duration: ""
@@ -247,10 +247,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGROVkVVeFRYcE5NVTVXYjFoRVZFMTZUVlJGZDAxVVJURk5lazB4VGxadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVXRUQ2xRclIzTTBkbmhYU1RWdVpVbFNia3AyWWtORGEybDVNbVJhTDNSbWNESkRORWRKYmxaNFIyUmFSa1U1YUUxa2JVYzNNMDFJUmtkaVJHaG1TM1ZKVDIwS1pUTmhaSEZDU1ZSRlYyaHZVa3BIYldsd2RFeENkRFl5ZG1kQ1FtdERSa1JCVURWNmNISkZiVkF3TTFJd1RUTjFUMlZwVm5NeFFXSnVZM2RyYzBSblJ3bzJOVFJ5S3padFpGWlVRazAxYURGMVVuTTFNWHBOY0VoV1NGQlNlWFIwUzIxd1dqWjBhRVZuTjI4MFJtbEJWVWdyTmt3cmFHOVdha1owYTBabkx6QTBDak5aWkc4NFNISmlUQzlyVjA5eVNXMXhTbmN3UkRaSWFIWllTRmh5TTNSc09FMTJkM1J1V21adWR6bHVSR3B5UW14WU1rcE9aMDlCVFhsUVEzcFNjbmdLTkVwdU1FTk9VM2R6VERGRVJsWlJOQ3RNYVVNeE9YUlRZVEF5VjBkbU5sSXJORmhJUmtsSWFXOHlTMXBXUzJVeFlYbG1aRXRVTUdaRGVqVnhVbXhYU0FvM1dtdDVUVXAwYm1JMlFrZGFZMHR3YjFkRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS2NUZGFMMGsxZUZWbFZuRnRSa2hKVFVFNE5uRXZhVXc1ZFRSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ09FTnlSVmd6Y0V0NmVrUnJWa3BuYURWR2RrWTJaRkF2TUZkTFpsaEtWRUZQYUVsYVozQlRRakJqV0M4MGFuRjFlZ3B4VUhaeVR6TnhTMDVYU25KTVpVUkljU3Q0ZEZkaldWaHdWa0ZqVkdselZGTnNRMUpyVkN0akswRlBUMlJXWld0UmRFZGliMlV2Y1hsR1ozaHdlVU5PQ21kS2FrdFJTMEZtYkRKcVVWTjBTbEZuUmpSV1EwWjZaV0YyWmpFM1JDODVjWE5tZFVoQmIxcGtaMU4wV1ZkSVNrNDVhRVJ0VVRCak4wbE1lbTg1WVdnS1RIZFFOMEl5Ym5KMk1XMXFPVWQ1VWpaUE4xbEtTalJSYVV0RGFGQkNNamQxWlRKM015dFhTbWhHTTI1clpXcDVPVkpUWjNGWFFuSXZXV1pNY1dGbWFRcHhTbkJSVkZsa1duTlVZemRUZFRaT05qTnJPR1V3WVNzMlJqTkNVekUwYWs1T1p6RkZhMGRLVnpGUVJVZDNWbGxSWVV0RkszUk5ha294ZFZwSmJtVmhDbm96WVVwQ1MxTTFiMmh6YUhWeWNIa3JiVEpyVHpaRlNsWXlieXN6ZFVZMlMySlhad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vY2MwMzRiYzAtOTY4OS00NGY1LTlhNzItNGQ5OWFjZGJiY2FmLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBOczhnZ1FJYW01VUVWMUlvS0hKT2pxS2dOeUx2TDVHWVRPQXFRYnZwUkN6VzMzdWJvVGRXbHozNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPZWtFMVRWUkJlRTVzYjFoRVZFMTZUVlJGZDA1NlFUVk5WRUY0VG14dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMEp2Q25oa0wwaFBRMGwwU2poRFdYcDBhRTV3VUZCSFoxWjJTa1F6TDI5M09XRXlhR2xDV1Zwa1ZIUkxkSFpCWjJRd1prMTZMMGM0V0hoa05rODRka3MxVkRRS2RWWnFjV3RaVTJwRmNEZ3hSRWxpUzA1bFkzVkhTWFpXTkhabVprWmhRek1yVDNnNWVuQm1iVGhSYm01UmNXSjZiSFkwWnpGdVlqZFNhbWQ2ZVRJMFJ3cHJNVzVYVGtWNlNEWkpRVzVRWTFBcmFrcE9TbkJOYURGYWVuUjJMMmM1Vkd4bFUyMUlaMmxSWTBSNGVtRm9ZVzR2WkRWcWNYZGxWRTFUU0dONGFrZHZDbkpaYTNJeFZpOU1NVEJOYVZkemQyNUxjelJWWW1kb2NWaHdMMG95ZUVaTFVrRnNaVU5CZDFONlpHMU9WamRRWWs1UVFXSk1PV3R3UkhsQ04wNXBhRWtLTjBsSlVYcDNaelZIWkZaUE5sUTVORWRPVWtKUGVVWTBWamsxTTBWck5IZGxla1k0YVdaSlRVZEdVbGhWVGpOS2J6WjVkbmRXVWpsYWJEQnBlV1Z5V1FwMVUyRk1NbU5pVmxkbFNEbHNLMnRvYUZsRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTlFqSTJkRWhLYTNvNFUxcDNZVFk0VlhGME9XTTRlVlp1T1V4TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFRFWnRTelZHUWs4eU5tWldhRUUxZEdWbVVtRnljWHAzUlhwSmFHRnNjSFZWTjNRMVMzRnpVRXBSVTFKV01tWldkUXBPY2k4NVpWWjBZVU1yUkRsRFRqTnBTbEZzYmxadlJpOXJZWG8xYmxwMlRVRXJiMmQxZWxwc1NtNUZVRFZCTWtSUmRIQmhNMEkzYWpKa04wZHFWbWhOQ2k5NVpXNXRWRVJaYjJKSVVuRlVOWFpaVjA0eFJqSjRjbWxHZFd0RllTOXRkVXRSZUZNM2FGVnhlR0ZSWnpoR1IwZG9OMjk2UlhSTGVXazVNMWRUVlZrS2Iwb3hVakl3YUcxUVFtbHVRVzEzTlU4eVZWSkpZWHBRVTFkaFEzaHhhbFZvUldObUwyUXlOM2N6WjFVdmNYWk1iVGx3V1VabmQwMHZOM1ZFZW00NFJncFdOak5RYkdOc05FVlJTbGxLU2tWR1JHZG5ZVnBSWlZKSmIzcGtUM1l4WjFGVU1uTmhjekpETlZkcE1ETk5ValpCTmxSU01EWnlXRmQzY1VKb00yNUdDblV6YjFwSGVGVTJXVFl2Y2pSc1MwaHJWbnBIUzBscFNVc3ZlakJsWTNZNVoyTmFad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTM4ZTQ4M2QtNjFkOC00OGY5LWFkMTctNTFkMTU4ZTBiOWZjLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBLdzVDRG13UUlHdGVkaGsySTRzeDdyN0tEU2FwT1pQZHRHa3hOMHN4UUxFSG95bTI2cUVFT0V4OA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2612"
@@ -259,7 +259,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:33:59 GMT
+      - Wed, 08 Nov 2023 09:10:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f560a7a-d90b-40d8-9eb9-b021d35f9b11
+      - 50835ab1-4585-4a61-a853-b7f64da00860
     status: 200 OK
     code: 200
     duration: ""
@@ -280,10 +280,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-02T15:33:56.176242Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-08T09:10:18.117105Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1458"
@@ -292,7 +292,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:33:59 GMT
+      - Wed, 08 Nov 2023 09:10:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18a842fe-7795-4f6a-a0ee-c4177934656c
+      - f061157a-52b2-4a34-9c38-3390f8536e4b
     status: 200 OK
     code: 200
     duration: ""
@@ -315,10 +315,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/pools
     method: POST
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889946643Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819065Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "647"
@@ -327,7 +327,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:34:00 GMT
+      - Wed, 08 Nov 2023 09:10:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -337,7 +337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36192e96-defa-45eb-aada-1be399bb28a9
+      - f6f89475-a657-4b8f-a42c-c43a08533e2a
     status: 200 OK
     code: 200
     duration: ""
@@ -348,10 +348,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -360,7 +360,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:34:00 GMT
+      - Wed, 08 Nov 2023 09:10:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -370,7 +370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53458060-caa7-4ef8-b516-89f64887e0e4
+      - 57901a7d-00cc-44f6-97dc-0d09684fa1b7
     status: 200 OK
     code: 200
     duration: ""
@@ -381,10 +381,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -393,7 +393,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:34:05 GMT
+      - Wed, 08 Nov 2023 09:10:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -403,7 +403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57c42cbd-ca87-42f5-ada8-7bc01f90a69f
+      - e3820876-dc4b-4f93-bc7f-c44d709f26c1
     status: 200 OK
     code: 200
     duration: ""
@@ -414,10 +414,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -426,7 +426,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:34:10 GMT
+      - Wed, 08 Nov 2023 09:10:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -436,7 +436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a42bfd2-387e-45a7-9f63-afa93fb87190
+      - 8d24b1e5-3baf-4a0c-80a1-9b94a2a9fe97
     status: 200 OK
     code: 200
     duration: ""
@@ -447,10 +447,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -459,7 +459,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:34:15 GMT
+      - Wed, 08 Nov 2023 09:10:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -469,7 +469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ac5fbf2-f857-43cf-a148-8802550aa94c
+      - 2ad9bd8e-e958-4dc6-8039-8aeb8359c742
     status: 200 OK
     code: 200
     duration: ""
@@ -480,10 +480,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -492,7 +492,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:34:20 GMT
+      - Wed, 08 Nov 2023 09:10:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8844334f-5c4c-4190-bbc3-b36c1f726383
+      - cee0d70d-572c-4fc8-b520-74aa244ee07e
     status: 200 OK
     code: 200
     duration: ""
@@ -513,10 +513,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -525,7 +525,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:34:25 GMT
+      - Wed, 08 Nov 2023 09:10:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2bdbcdc2-7e0f-49b0-8388-76c6227b40d5
+      - cb92b12c-1cfc-4011-a455-b769bc8ececc
     status: 200 OK
     code: 200
     duration: ""
@@ -546,10 +546,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -558,7 +558,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:34:30 GMT
+      - Wed, 08 Nov 2023 09:10:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 835aad0f-e1a1-45c9-9032-de75a5c9ec78
+      - d22050f3-fd58-45cc-a88a-c6e0825024bf
     status: 200 OK
     code: 200
     duration: ""
@@ -579,10 +579,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -591,7 +591,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:34:35 GMT
+      - Wed, 08 Nov 2023 09:10:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e725001-539b-448d-a22a-7515af8532e4
+      - 7b84d9c5-e364-44fb-8b30-5625e65bf56e
     status: 200 OK
     code: 200
     duration: ""
@@ -612,10 +612,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -624,7 +624,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:34:40 GMT
+      - Wed, 08 Nov 2023 09:11:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d547aab2-63a0-4d6d-a3af-ff5b51acf60b
+      - eee7bd25-eeec-4e84-9126-157976dad202
     status: 200 OK
     code: 200
     duration: ""
@@ -645,10 +645,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -657,7 +657,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:34:45 GMT
+      - Wed, 08 Nov 2023 09:11:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad4ad128-f680-4b4a-b03c-9143e748d284
+      - bff2d326-aa5e-43b3-b20d-1b77ad4ba7fe
     status: 200 OK
     code: 200
     duration: ""
@@ -678,10 +678,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -690,7 +690,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:34:50 GMT
+      - Wed, 08 Nov 2023 09:11:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 452d61bf-2157-4f6b-b921-fa782f1455f6
+      - 17f82b79-183f-4413-99c7-e063b2b6f4dd
     status: 200 OK
     code: 200
     duration: ""
@@ -711,10 +711,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -723,7 +723,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:34:55 GMT
+      - Wed, 08 Nov 2023 09:11:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aedb4863-93d5-4b9e-bcc0-00c2ca6de6ac
+      - 245527ef-c30c-45fe-b84b-aa89dec72858
     status: 200 OK
     code: 200
     duration: ""
@@ -744,10 +744,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -756,7 +756,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:35:00 GMT
+      - Wed, 08 Nov 2023 09:11:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d117b4da-5bc0-4b1f-95e9-3e480b2b3856
+      - f5a04c68-2f74-449d-a703-88ec6a2399fd
     status: 200 OK
     code: 200
     duration: ""
@@ -777,10 +777,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -789,7 +789,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:35:05 GMT
+      - Wed, 08 Nov 2023 09:11:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e57ad65-ed08-491a-8a7a-9fb2d9931c3e
+      - ec8e5370-dc19-42ab-b69c-641e3f69c7bb
     status: 200 OK
     code: 200
     duration: ""
@@ -810,10 +810,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -822,7 +822,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:35:10 GMT
+      - Wed, 08 Nov 2023 09:11:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e17e11da-2577-4ec5-89f8-8e2061811343
+      - c52ec2a6-76b3-4e28-8b3b-76faed305eb5
     status: 200 OK
     code: 200
     duration: ""
@@ -843,10 +843,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -855,7 +855,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:35:16 GMT
+      - Wed, 08 Nov 2023 09:11:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa0c9f42-61bb-4d86-8e5f-c9f499e89987
+      - 9a24d1e4-d96f-40e7-a84d-56ee7cede418
     status: 200 OK
     code: 200
     duration: ""
@@ -876,10 +876,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -888,7 +888,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:35:21 GMT
+      - Wed, 08 Nov 2023 09:11:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32075981-ab6a-430e-aa0c-8faa67b968c0
+      - 95bbba9d-35d3-458b-8fab-226190e6f864
     status: 200 OK
     code: 200
     duration: ""
@@ -909,10 +909,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -921,7 +921,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:35:26 GMT
+      - Wed, 08 Nov 2023 09:11:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c99ab4f-c076-4e8a-80f3-5752190e32a2
+      - 01ba471b-eecb-452f-ad42-cb5d5ba8d46f
     status: 200 OK
     code: 200
     duration: ""
@@ -942,10 +942,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -954,7 +954,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:35:31 GMT
+      - Wed, 08 Nov 2023 09:11:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a828040-5a1c-4f8d-b46e-0a84f67f8edf
+      - e4786950-f49a-4c3e-b1f5-3d188ddf1ff9
     status: 200 OK
     code: 200
     duration: ""
@@ -975,10 +975,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -987,7 +987,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:35:36 GMT
+      - Wed, 08 Nov 2023 09:11:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3a0e70b-603c-4b49-afd5-8c2dc02e4c67
+      - 30eb7132-c3cc-482d-9428-031d3c68f5d2
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,10 +1008,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1020,7 +1020,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:35:41 GMT
+      - Wed, 08 Nov 2023 09:12:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98ad4fd6-89e3-457f-b56d-1f69b8e70349
+      - 1df23190-ba70-4ea5-9621-2f20f60038cd
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,10 +1041,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1053,7 +1053,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:35:46 GMT
+      - Wed, 08 Nov 2023 09:12:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9916378-9849-46bf-a99a-d11e118e145e
+      - f643ed1e-0e5b-4207-aa00-886086af41dc
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,10 +1074,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1086,7 +1086,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:35:51 GMT
+      - Wed, 08 Nov 2023 09:12:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b593c6b0-54c8-4652-9c76-a779aa87554e
+      - ccb8f406-f9df-4d0b-a9c2-4222d5b67cf8
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,10 +1107,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1119,7 +1119,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:35:56 GMT
+      - Wed, 08 Nov 2023 09:12:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1129,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73327f58-0fbd-4523-a4b0-1bdd3e8866be
+      - 3a973318-b7f5-4288-8980-b4cd916193f9
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,10 +1140,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1152,7 +1152,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:36:01 GMT
+      - Wed, 08 Nov 2023 09:12:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b37e6ef3-8e0b-42b6-91ca-1dcc5056dd2f
+      - 330a7d19-2769-45e0-b33b-0a25e333e0b2
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,10 +1173,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1185,7 +1185,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:36:06 GMT
+      - Wed, 08 Nov 2023 09:12:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d771ab36-27a3-4357-b156-e13183442ec0
+      - 58c78a8c-3baa-452e-a195-878db32106d4
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,10 +1206,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1218,7 +1218,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:36:11 GMT
+      - Wed, 08 Nov 2023 09:12:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6b95289-e50a-46be-a348-6d15453c0882
+      - e456d77e-030b-4621-b444-07d33c40f103
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,10 +1239,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1251,7 +1251,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:36:16 GMT
+      - Wed, 08 Nov 2023 09:12:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3507185b-8e1c-4dff-8fe1-bf806435f805
+      - 16576fbf-a7a9-442e-8f1a-d1e2fdea22f9
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,10 +1272,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1284,7 +1284,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:36:22 GMT
+      - Wed, 08 Nov 2023 09:12:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46f76552-03fe-4807-99be-75b756c5ae84
+      - 10815711-ace1-49af-a3df-36d2dd87dba8
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,10 +1305,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1317,7 +1317,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:36:27 GMT
+      - Wed, 08 Nov 2023 09:12:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ba1dff5-70f8-469b-84fd-4a9dd8851b5e
+      - 1bb26a79-4b58-4a52-ba81-e2f9b356241b
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,10 +1338,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1350,7 +1350,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:36:32 GMT
+      - Wed, 08 Nov 2023 09:12:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1360,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15558e99-5f6d-414e-acdb-ca129b2b2e47
+      - 50a9ebea-5cb4-4dc1-9bde-924503b6ff66
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,10 +1371,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1383,7 +1383,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:36:37 GMT
+      - Wed, 08 Nov 2023 09:12:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1393,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51ca80eb-fa5a-4e13-ba9e-8e30d563d4eb
+      - 2a1ce0c6-ef01-4f51-b098-c9fc4fb3ed47
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,10 +1404,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1416,7 +1416,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:36:42 GMT
+      - Wed, 08 Nov 2023 09:13:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1426,7 +1426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8db36358-382a-40bd-9ecc-58054cbc9c7f
+      - d7f1dfb6-9931-4d57-bb45-71b82b25ee42
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,10 +1437,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1449,7 +1449,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:36:47 GMT
+      - Wed, 08 Nov 2023 09:13:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1459,7 +1459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed324f4e-b3dc-4edc-9c5d-6c3c213c11f2
+      - b84dba3d-4e37-4cf8-bef5-2f6fba967b38
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,10 +1470,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1482,7 +1482,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:36:52 GMT
+      - Wed, 08 Nov 2023 09:13:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1492,7 +1492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83ddfd31-cb65-40b5-ac6a-c9527e5f1ff8
+      - 157e9b7a-49bf-45e7-b138-7ecd8fe50091
     status: 200 OK
     code: 200
     duration: ""
@@ -1503,10 +1503,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1515,7 +1515,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:36:57 GMT
+      - Wed, 08 Nov 2023 09:13:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6fdc48fa-18de-498b-b2a4-8ae7c7921b50
+      - 217ed998-3d45-479b-868d-19c09a0afe28
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,10 +1536,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1548,7 +1548,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:37:02 GMT
+      - Wed, 08 Nov 2023 09:13:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1558,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d35217e1-cba6-46ae-9359-88a8bda291aa
+      - d0e54807-5e1d-47eb-bfd0-cfe4e9af7a50
     status: 200 OK
     code: 200
     duration: ""
@@ -1569,10 +1569,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1581,7 +1581,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:37:07 GMT
+      - Wed, 08 Nov 2023 09:13:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1591,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85f9843f-b219-425e-96c0-f4a17ed123dc
+      - 7cf7ba11-e0b9-4314-867a-35ebbf55a86a
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,10 +1602,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1614,7 +1614,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:37:12 GMT
+      - Wed, 08 Nov 2023 09:13:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7d74b1b-1724-4e9b-9f6a-d46379364e2e
+      - 703032eb-e4ca-4af5-baab-bd8b1e89f605
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,10 +1635,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1647,7 +1647,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:37:17 GMT
+      - Wed, 08 Nov 2023 09:13:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1657,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5feb1e00-4741-4382-a398-2e1e93ad70ba
+      - da80a045-1e99-46ee-ad66-53862705eb40
     status: 200 OK
     code: 200
     duration: ""
@@ -1668,10 +1668,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1680,7 +1680,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:37:22 GMT
+      - Wed, 08 Nov 2023 09:13:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1690,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - abe32590-46af-44f2-852f-d71612c7911b
+      - f8c891f1-6486-476e-8862-d77a2e2484c4
     status: 200 OK
     code: 200
     duration: ""
@@ -1701,10 +1701,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1713,7 +1713,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:37:27 GMT
+      - Wed, 08 Nov 2023 09:13:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1723,7 +1723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 054c6919-f196-456c-a5a0-67e942618f63
+      - c0fe9a83-28dc-4d4c-864c-b83105b8c435
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,10 +1734,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1746,7 +1746,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:37:32 GMT
+      - Wed, 08 Nov 2023 09:13:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1756,7 +1756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6dce56d9-e18a-4102-8325-ccdedf2348a3
+      - e459fa2f-01c7-44cc-99d7-cbc87968db85
     status: 200 OK
     code: 200
     duration: ""
@@ -1767,10 +1767,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1779,7 +1779,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:37:37 GMT
+      - Wed, 08 Nov 2023 09:13:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1789,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2972b19-c073-4870-b3b1-e05a56fe24f8
+      - 2925e6df-79fb-492b-aa7e-f82f55bcdda0
     status: 200 OK
     code: 200
     duration: ""
@@ -1800,10 +1800,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1812,7 +1812,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:37:42 GMT
+      - Wed, 08 Nov 2023 09:14:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1822,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 919f0200-6828-4aba-b817-ea6e699b5191
+      - 787c2521-e4a9-4768-94b4-a5fe07adf067
     status: 200 OK
     code: 200
     duration: ""
@@ -1833,10 +1833,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1845,7 +1845,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:37:48 GMT
+      - Wed, 08 Nov 2023 09:14:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1855,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e69d7c8-9b76-4ae4-8636-873b066142aa
+      - 89e173e7-8797-4f52-8c07-39b8e1e8f70c
     status: 200 OK
     code: 200
     duration: ""
@@ -1866,10 +1866,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1878,7 +1878,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:37:53 GMT
+      - Wed, 08 Nov 2023 09:14:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1888,7 +1888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6b719d5-79c1-489e-99b8-3b1ad9fccc5f
+      - dfc01860-a58c-4864-ab70-9273097a409c
     status: 200 OK
     code: 200
     duration: ""
@@ -1899,10 +1899,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1911,7 +1911,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:37:58 GMT
+      - Wed, 08 Nov 2023 09:14:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1921,7 +1921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4eff105f-2ab0-462c-bdbf-4eea03bad540
+      - 2816127b-2175-4eac-ad76-24d6df4c5116
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,10 +1932,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1944,7 +1944,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:38:03 GMT
+      - Wed, 08 Nov 2023 09:14:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1954,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3cfcd0ed-eef1-481b-9800-ab0c0b653658
+      - dde80b90-eb18-40a0-ac22-601644198cf0
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,10 +1965,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -1977,7 +1977,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:38:08 GMT
+      - Wed, 08 Nov 2023 09:14:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1987,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 903cf6b2-bc75-48a6-a004-eebcf3bedd10
+      - 15e30ec9-0694-4c79-a864-a0140c094b2c
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,10 +1998,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -2010,7 +2010,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:38:14 GMT
+      - Wed, 08 Nov 2023 09:14:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2020,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6adf2821-558b-4f5f-8721-f42597c77bf1
+      - 1ed986ad-b999-4a8d-90df-a16486148043
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,10 +2031,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -2043,7 +2043,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:38:19 GMT
+      - Wed, 08 Nov 2023 09:14:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2053,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e18998a-0840-413e-a3c9-a2bee23c3c31
+      - c839f702-0872-40a2-8c8f-1b1869eac378
     status: 200 OK
     code: 200
     duration: ""
@@ -2064,10 +2064,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -2076,7 +2076,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:38:24 GMT
+      - Wed, 08 Nov 2023 09:14:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2086,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6fa58cc3-f6ff-4d75-8a5d-ce28ed35fe65
+      - 0858f0dc-c379-4b87-bf75-938bc53e3e51
     status: 200 OK
     code: 200
     duration: ""
@@ -2097,10 +2097,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -2109,7 +2109,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:38:29 GMT
+      - Wed, 08 Nov 2023 09:14:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2119,7 +2119,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9539fd16-ba84-42da-82fc-1fc1e7905e0e
+      - 4d905143-38f0-448b-a6a2-a116b90bfb3d
     status: 200 OK
     code: 200
     duration: ""
@@ -2130,10 +2130,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -2142,7 +2142,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:38:34 GMT
+      - Wed, 08 Nov 2023 09:14:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2152,7 +2152,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79f16505-1c07-4c59-82f7-34a6d1d2d7cf
+      - 229854d7-5273-4e84-990d-c88a1b85316a
     status: 200 OK
     code: 200
     duration: ""
@@ -2163,10 +2163,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -2175,7 +2175,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:38:39 GMT
+      - Wed, 08 Nov 2023 09:14:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2185,7 +2185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6433dcbf-2613-4dbf-87f2-2f3a1c513a30
+      - c68e9b7b-aed4-4749-85f7-e31cee19fa2f
     status: 200 OK
     code: 200
     duration: ""
@@ -2196,10 +2196,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -2208,7 +2208,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:38:44 GMT
+      - Wed, 08 Nov 2023 09:15:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2218,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 47b88033-77f0-41a1-a367-89c0fde95914
+      - a1503a75-3c1c-45f8-9a5a-5c18a17e65f6
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,10 +2229,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -2241,7 +2241,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:38:49 GMT
+      - Wed, 08 Nov 2023 09:15:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2251,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4faf7bd-4f45-4a7a-be77-804a717aeb0d
+      - 6e4a58b9-fb3e-4000-ac1a-ac1e3e067292
     status: 200 OK
     code: 200
     duration: ""
@@ -2262,10 +2262,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -2274,7 +2274,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:38:54 GMT
+      - Wed, 08 Nov 2023 09:15:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2284,7 +2284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3c0d897-7d1f-4a85-8369-1f869efd6618
+      - cb9280b5-5f3b-4dfc-b79f-d8bc4b4dbb85
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,10 +2295,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:10:20.805819Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "644"
@@ -2307,7 +2307,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:38:59 GMT
+      - Wed, 08 Nov 2023 09:15:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2317,7 +2317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c8c6d89-d817-40a5-b8f8-dedf0ec1d2cd
+      - cf62e5dd-dbbc-490e-8c7b-125a6e9da00e
     status: 200 OK
     code: 200
     duration: ""
@@ -2328,208 +2328,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "644"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 15:39:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8673b34b-d89f-41f3-9579-527cc8f691ca
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "644"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 15:39:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 48977626-193b-4261-b035-ce0b7f3e8520
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "644"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 15:39:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 60e345d1-475b-45a9-be99-5ecb58f917d0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "644"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 15:39:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f6d6a113-8a43-47dd-ac36-45b448700001
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "644"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 15:39:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - dd067141-9c18-4448-bf5f-bed4d7a2f281
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:33:59.889947Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "644"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 15:39:30 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d3722522-0a7c-4462-81f4-e60f1d725449
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "642"
@@ -2538,7 +2340,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:39:35 GMT
+      - Wed, 08 Nov 2023 09:15:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2548,7 +2350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d27a8b95-a509-4aed-8c5e-7e6450986883
+      - e86e3a06-2a7a-4056-a3fe-56936f825f2d
     status: 200 OK
     code: 200
     duration: ""
@@ -2559,10 +2361,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-02T15:35:08.308277Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-08T09:11:31.319610Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1450"
@@ -2571,7 +2373,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:39:35 GMT
+      - Wed, 08 Nov 2023 09:15:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2581,7 +2383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 92b9b129-93fe-4b1e-8f3d-805ccc08c3d9
+      - a2d55be8-46e0-4713-a1d4-7aed0342ebb2
     status: 200 OK
     code: 200
     duration: ""
@@ -2592,10 +2394,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "642"
@@ -2604,7 +2406,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:39:35 GMT
+      - Wed, 08 Nov 2023 09:15:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2614,7 +2416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a7d8a69-d650-4e11-9b48-92b46ec920cc
+      - bbf1aa24-577e-43ab-a54e-1bda10e29590
     status: 200 OK
     code: 200
     duration: ""
@@ -2625,19 +2427,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:30.122950Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:23.517375Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "641"
+      - "643"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:39:35 GMT
+      - Wed, 08 Nov 2023 09:15:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2647,7 +2449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97e49bb9-1246-4e8d-bf81-9a99c0a0ccc4
+      - 5a65636f-a7ff-4c88-861e-8ae4478731f6
     status: 200 OK
     code: 200
     duration: ""
@@ -2658,19 +2460,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7c0f88fe-47b2-44c5-be75-7e0d3766bc55
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9204ea7b-13d2-4b0d-938d-30250328f16f
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T15:33:53.182844Z","dhcp_enabled":true,"id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","name":"test-data-source-pool","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-02T15:33:53.182844Z","id":"8b259f89-423a-4607-9979-13dd7515cc29","subnet":"172.16.4.0/22","updated_at":"2023-11-02T15:33:53.182844Z"},{"created_at":"2023-11-02T15:33:53.182844Z","id":"05ee4fd6-0b54-497d-9684-b3673ddeb02c","subnet":"fd5f:519c:6d46:cb39::/64","updated_at":"2023-11-02T15:33:53.182844Z"}],"tags":[],"updated_at":"2023-11-02T15:33:53.182844Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-08T09:10:14.141608Z","dhcp_enabled":true,"id":"9204ea7b-13d2-4b0d-938d-30250328f16f","name":"test-data-source-pool","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-08T09:10:14.141608Z","id":"0ece81a7-0a26-41cd-b79c-3e9f201ac24f","subnet":"172.16.12.0/22","updated_at":"2023-11-08T09:10:14.141608Z"},{"created_at":"2023-11-08T09:10:14.141608Z","id":"e3f389f9-023e-44be-8d1d-b7eb49001405","subnet":"fd63:256c:45f7:998e::/64","updated_at":"2023-11-08T09:10:14.141608Z"}],"tags":[],"updated_at":"2023-11-08T09:10:14.141608Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "704"
+      - "705"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:39:36 GMT
+      - Wed, 08 Nov 2023 09:15:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2680,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c7df3ba-bb16-49a4-bafc-6c54009a4dbf
+      - 56836ecb-1a56-4336-80f0-eaaff2338f82
     status: 200 OK
     code: 200
     duration: ""
@@ -2691,10 +2493,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-02T15:35:08.308277Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-08T09:11:31.319610Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1450"
@@ -2703,7 +2505,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:39:36 GMT
+      - Wed, 08 Nov 2023 09:15:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2713,7 +2515,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05a50443-b22d-48cc-8dfc-a1c75d25cafa
+      - 153f0d52-6062-435f-b0f6-f9cefa0934cb
     status: 200 OK
     code: 200
     duration: ""
@@ -2724,10 +2526,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGROVkVVeFRYcE5NVTVXYjFoRVZFMTZUVlJGZDAxVVJURk5lazB4VGxadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVXRUQ2xRclIzTTBkbmhYU1RWdVpVbFNia3AyWWtORGEybDVNbVJhTDNSbWNESkRORWRKYmxaNFIyUmFSa1U1YUUxa2JVYzNNMDFJUmtkaVJHaG1TM1ZKVDIwS1pUTmhaSEZDU1ZSRlYyaHZVa3BIYldsd2RFeENkRFl5ZG1kQ1FtdERSa1JCVURWNmNISkZiVkF3TTFJd1RUTjFUMlZwVm5NeFFXSnVZM2RyYzBSblJ3bzJOVFJ5S3padFpGWlVRazAxYURGMVVuTTFNWHBOY0VoV1NGQlNlWFIwUzIxd1dqWjBhRVZuTjI4MFJtbEJWVWdyTmt3cmFHOVdha1owYTBabkx6QTBDak5aWkc4NFNISmlUQzlyVjA5eVNXMXhTbmN3UkRaSWFIWllTRmh5TTNSc09FMTJkM1J1V21adWR6bHVSR3B5UW14WU1rcE9aMDlCVFhsUVEzcFNjbmdLTkVwdU1FTk9VM2R6VERGRVJsWlJOQ3RNYVVNeE9YUlRZVEF5VjBkbU5sSXJORmhJUmtsSWFXOHlTMXBXUzJVeFlYbG1aRXRVTUdaRGVqVnhVbXhYU0FvM1dtdDVUVXAwYm1JMlFrZGFZMHR3YjFkRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS2NUZGFMMGsxZUZWbFZuRnRSa2hKVFVFNE5uRXZhVXc1ZFRSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ09FTnlSVmd6Y0V0NmVrUnJWa3BuYURWR2RrWTJaRkF2TUZkTFpsaEtWRUZQYUVsYVozQlRRakJqV0M4MGFuRjFlZ3B4VUhaeVR6TnhTMDVYU25KTVpVUkljU3Q0ZEZkaldWaHdWa0ZqVkdselZGTnNRMUpyVkN0akswRlBUMlJXWld0UmRFZGliMlV2Y1hsR1ozaHdlVU5PQ21kS2FrdFJTMEZtYkRKcVVWTjBTbEZuUmpSV1EwWjZaV0YyWmpFM1JDODVjWE5tZFVoQmIxcGtaMU4wV1ZkSVNrNDVhRVJ0VVRCak4wbE1lbTg1WVdnS1RIZFFOMEl5Ym5KMk1XMXFPVWQ1VWpaUE4xbEtTalJSYVV0RGFGQkNNamQxWlRKM015dFhTbWhHTTI1clpXcDVPVkpUWjNGWFFuSXZXV1pNY1dGbWFRcHhTbkJSVkZsa1duTlVZemRUZFRaT05qTnJPR1V3WVNzMlJqTkNVekUwYWs1T1p6RkZhMGRLVnpGUVJVZDNWbGxSWVV0RkszUk5ha294ZFZwSmJtVmhDbm96WVVwQ1MxTTFiMmh6YUhWeWNIa3JiVEpyVHpaRlNsWXlieXN6ZFVZMlMySlhad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vY2MwMzRiYzAtOTY4OS00NGY1LTlhNzItNGQ5OWFjZGJiY2FmLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBOczhnZ1FJYW01VUVWMUlvS0hKT2pxS2dOeUx2TDVHWVRPQXFRYnZwUkN6VzMzdWJvVGRXbHozNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPZWtFMVRWUkJlRTVzYjFoRVZFMTZUVlJGZDA1NlFUVk5WRUY0VG14dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMEp2Q25oa0wwaFBRMGwwU2poRFdYcDBhRTV3VUZCSFoxWjJTa1F6TDI5M09XRXlhR2xDV1Zwa1ZIUkxkSFpCWjJRd1prMTZMMGM0V0hoa05rODRka3MxVkRRS2RWWnFjV3RaVTJwRmNEZ3hSRWxpUzA1bFkzVkhTWFpXTkhabVprWmhRek1yVDNnNWVuQm1iVGhSYm01UmNXSjZiSFkwWnpGdVlqZFNhbWQ2ZVRJMFJ3cHJNVzVYVGtWNlNEWkpRVzVRWTFBcmFrcE9TbkJOYURGYWVuUjJMMmM1Vkd4bFUyMUlaMmxSWTBSNGVtRm9ZVzR2WkRWcWNYZGxWRTFUU0dONGFrZHZDbkpaYTNJeFZpOU1NVEJOYVZkemQyNUxjelJWWW1kb2NWaHdMMG95ZUVaTFVrRnNaVU5CZDFONlpHMU9WamRRWWs1UVFXSk1PV3R3UkhsQ04wNXBhRWtLTjBsSlVYcDNaelZIWkZaUE5sUTVORWRPVWtKUGVVWTBWamsxTTBWck5IZGxla1k0YVdaSlRVZEdVbGhWVGpOS2J6WjVkbmRXVWpsYWJEQnBlV1Z5V1FwMVUyRk1NbU5pVmxkbFNEbHNLMnRvYUZsRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTlFqSTJkRWhLYTNvNFUxcDNZVFk0VlhGME9XTTRlVlp1T1V4TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFRFWnRTelZHUWs4eU5tWldhRUUxZEdWbVVtRnljWHAzUlhwSmFHRnNjSFZWTjNRMVMzRnpVRXBSVTFKV01tWldkUXBPY2k4NVpWWjBZVU1yUkRsRFRqTnBTbEZzYmxadlJpOXJZWG8xYmxwMlRVRXJiMmQxZWxwc1NtNUZVRFZCTWtSUmRIQmhNMEkzYWpKa04wZHFWbWhOQ2k5NVpXNXRWRVJaYjJKSVVuRlVOWFpaVjA0eFJqSjRjbWxHZFd0RllTOXRkVXRSZUZNM2FGVnhlR0ZSWnpoR1IwZG9OMjk2UlhSTGVXazVNMWRUVlZrS2Iwb3hVakl3YUcxUVFtbHVRVzEzTlU4eVZWSkpZWHBRVTFkaFEzaHhhbFZvUldObUwyUXlOM2N6WjFVdmNYWk1iVGx3V1VabmQwMHZOM1ZFZW00NFJncFdOak5RYkdOc05FVlJTbGxLU2tWR1JHZG5ZVnBSWlZKSmIzcGtUM1l4WjFGVU1uTmhjekpETlZkcE1ETk5ValpCTmxSU01EWnlXRmQzY1VKb00yNUdDblV6YjFwSGVGVTJXVFl2Y2pSc1MwaHJWbnBIUzBscFNVc3ZlakJsWTNZNVoyTmFad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTM4ZTQ4M2QtNjFkOC00OGY5LWFkMTctNTFkMTU4ZTBiOWZjLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBLdzVDRG13UUlHdGVkaGsySTRzeDdyN0tEU2FwT1pQZHRHa3hOMHN4UUxFSG95bTI2cUVFT0V4OA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2612"
@@ -2736,7 +2538,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:39:36 GMT
+      - Wed, 08 Nov 2023 09:15:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2746,7 +2548,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e39fbf8-7e32-4871-9aa5-fe2136d001f5
+      - c0e0e1cb-9082-431d-a7e0-6170781f4624
     status: 200 OK
     code: 200
     duration: ""
@@ -2757,10 +2559,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "642"
@@ -2769,7 +2571,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:39:36 GMT
+      - Wed, 08 Nov 2023 09:15:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2779,7 +2581,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec18d2b6-8913-4be2-9c5d-a73f64e7da45
+      - 68686897-8c65-449d-bb99-e3ade7acd0b6
     status: 200 OK
     code: 200
     duration: ""
@@ -2790,19 +2592,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:36.446836Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:23.517375Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "641"
+      - "643"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:39:36 GMT
+      - Wed, 08 Nov 2023 09:15:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2812,7 +2614,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8aa745fa-08c9-490e-8446-40bc51fc29c8
+      - 74451d76-feef-4cc0-b683-48fee5e08dbe
     status: 200 OK
     code: 200
     duration: ""
@@ -2823,19 +2625,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7c0f88fe-47b2-44c5-be75-7e0d3766bc55
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9204ea7b-13d2-4b0d-938d-30250328f16f
     method: GET
   response:
-    body: '{"created_at":"2023-11-02T15:33:53.182844Z","dhcp_enabled":true,"id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","name":"test-data-source-pool","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-02T15:33:53.182844Z","id":"8b259f89-423a-4607-9979-13dd7515cc29","subnet":"172.16.4.0/22","updated_at":"2023-11-02T15:33:53.182844Z"},{"created_at":"2023-11-02T15:33:53.182844Z","id":"05ee4fd6-0b54-497d-9684-b3673ddeb02c","subnet":"fd5f:519c:6d46:cb39::/64","updated_at":"2023-11-02T15:33:53.182844Z"}],"tags":[],"updated_at":"2023-11-02T15:33:53.182844Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-11-08T09:10:14.141608Z","dhcp_enabled":true,"id":"9204ea7b-13d2-4b0d-938d-30250328f16f","name":"test-data-source-pool","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-08T09:10:14.141608Z","id":"0ece81a7-0a26-41cd-b79c-3e9f201ac24f","subnet":"172.16.12.0/22","updated_at":"2023-11-08T09:10:14.141608Z"},{"created_at":"2023-11-08T09:10:14.141608Z","id":"e3f389f9-023e-44be-8d1d-b7eb49001405","subnet":"fd63:256c:45f7:998e::/64","updated_at":"2023-11-08T09:10:14.141608Z"}],"tags":[],"updated_at":"2023-11-08T09:10:14.141608Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "704"
+      - "705"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:39:37 GMT
+      - Wed, 08 Nov 2023 09:15:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2845,7 +2647,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24064be6-bd4c-4448-a63e-9bb6254b28af
+      - f0e5bef1-cc99-4fba-a859-eb2e8dfad921
     status: 200 OK
     code: 200
     duration: ""
@@ -2856,10 +2658,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-02T15:35:08.308277Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"type":"kapsule","updated_at":"2023-11-08T09:11:31.319610Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1450"
@@ -2868,7 +2670,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:39:37 GMT
+      - Wed, 08 Nov 2023 09:15:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2878,7 +2680,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9dd56730-0709-4ab3-8935-9f924414c043
+      - 9c1c13bb-5e10-4bd0-a7c3-2b046411b66d
     status: 200 OK
     code: 200
     duration: ""
@@ -2889,10 +2691,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGROVkVVeFRYcE5NVTVXYjFoRVZFMTZUVlJGZDAxVVJURk5lazB4VGxadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVXRUQ2xRclIzTTBkbmhYU1RWdVpVbFNia3AyWWtORGEybDVNbVJhTDNSbWNESkRORWRKYmxaNFIyUmFSa1U1YUUxa2JVYzNNMDFJUmtkaVJHaG1TM1ZKVDIwS1pUTmhaSEZDU1ZSRlYyaHZVa3BIYldsd2RFeENkRFl5ZG1kQ1FtdERSa1JCVURWNmNISkZiVkF3TTFJd1RUTjFUMlZwVm5NeFFXSnVZM2RyYzBSblJ3bzJOVFJ5S3padFpGWlVRazAxYURGMVVuTTFNWHBOY0VoV1NGQlNlWFIwUzIxd1dqWjBhRVZuTjI4MFJtbEJWVWdyTmt3cmFHOVdha1owYTBabkx6QTBDak5aWkc4NFNISmlUQzlyVjA5eVNXMXhTbmN3UkRaSWFIWllTRmh5TTNSc09FMTJkM1J1V21adWR6bHVSR3B5UW14WU1rcE9aMDlCVFhsUVEzcFNjbmdLTkVwdU1FTk9VM2R6VERGRVJsWlJOQ3RNYVVNeE9YUlRZVEF5VjBkbU5sSXJORmhJUmtsSWFXOHlTMXBXUzJVeFlYbG1aRXRVTUdaRGVqVnhVbXhYU0FvM1dtdDVUVXAwYm1JMlFrZGFZMHR3YjFkRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS2NUZGFMMGsxZUZWbFZuRnRSa2hKVFVFNE5uRXZhVXc1ZFRSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ09FTnlSVmd6Y0V0NmVrUnJWa3BuYURWR2RrWTJaRkF2TUZkTFpsaEtWRUZQYUVsYVozQlRRakJqV0M4MGFuRjFlZ3B4VUhaeVR6TnhTMDVYU25KTVpVUkljU3Q0ZEZkaldWaHdWa0ZqVkdselZGTnNRMUpyVkN0akswRlBUMlJXWld0UmRFZGliMlV2Y1hsR1ozaHdlVU5PQ21kS2FrdFJTMEZtYkRKcVVWTjBTbEZuUmpSV1EwWjZaV0YyWmpFM1JDODVjWE5tZFVoQmIxcGtaMU4wV1ZkSVNrNDVhRVJ0VVRCak4wbE1lbTg1WVdnS1RIZFFOMEl5Ym5KMk1XMXFPVWQ1VWpaUE4xbEtTalJSYVV0RGFGQkNNamQxWlRKM015dFhTbWhHTTI1clpXcDVPVkpUWjNGWFFuSXZXV1pNY1dGbWFRcHhTbkJSVkZsa1duTlVZemRUZFRaT05qTnJPR1V3WVNzMlJqTkNVekUwYWs1T1p6RkZhMGRLVnpGUVJVZDNWbGxSWVV0RkszUk5ha294ZFZwSmJtVmhDbm96WVVwQ1MxTTFiMmh6YUhWeWNIa3JiVEpyVHpaRlNsWXlieXN6ZFVZMlMySlhad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vY2MwMzRiYzAtOTY4OS00NGY1LTlhNzItNGQ5OWFjZGJiY2FmLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBOczhnZ1FJYW01VUVWMUlvS0hKT2pxS2dOeUx2TDVHWVRPQXFRYnZwUkN6VzMzdWJvVGRXbHozNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPZWtFMVRWUkJlRTVzYjFoRVZFMTZUVlJGZDA1NlFUVk5WRUY0VG14dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMEp2Q25oa0wwaFBRMGwwU2poRFdYcDBhRTV3VUZCSFoxWjJTa1F6TDI5M09XRXlhR2xDV1Zwa1ZIUkxkSFpCWjJRd1prMTZMMGM0V0hoa05rODRka3MxVkRRS2RWWnFjV3RaVTJwRmNEZ3hSRWxpUzA1bFkzVkhTWFpXTkhabVprWmhRek1yVDNnNWVuQm1iVGhSYm01UmNXSjZiSFkwWnpGdVlqZFNhbWQ2ZVRJMFJ3cHJNVzVYVGtWNlNEWkpRVzVRWTFBcmFrcE9TbkJOYURGYWVuUjJMMmM1Vkd4bFUyMUlaMmxSWTBSNGVtRm9ZVzR2WkRWcWNYZGxWRTFUU0dONGFrZHZDbkpaYTNJeFZpOU1NVEJOYVZkemQyNUxjelJWWW1kb2NWaHdMMG95ZUVaTFVrRnNaVU5CZDFONlpHMU9WamRRWWs1UVFXSk1PV3R3UkhsQ04wNXBhRWtLTjBsSlVYcDNaelZIWkZaUE5sUTVORWRPVWtKUGVVWTBWamsxTTBWck5IZGxla1k0YVdaSlRVZEdVbGhWVGpOS2J6WjVkbmRXVWpsYWJEQnBlV1Z5V1FwMVUyRk1NbU5pVmxkbFNEbHNLMnRvYUZsRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTlFqSTJkRWhLYTNvNFUxcDNZVFk0VlhGME9XTTRlVlp1T1V4TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFRFWnRTelZHUWs4eU5tWldhRUUxZEdWbVVtRnljWHAzUlhwSmFHRnNjSFZWTjNRMVMzRnpVRXBSVTFKV01tWldkUXBPY2k4NVpWWjBZVU1yUkRsRFRqTnBTbEZzYmxadlJpOXJZWG8xYmxwMlRVRXJiMmQxZWxwc1NtNUZVRFZCTWtSUmRIQmhNMEkzYWpKa04wZHFWbWhOQ2k5NVpXNXRWRVJaYjJKSVVuRlVOWFpaVjA0eFJqSjRjbWxHZFd0RllTOXRkVXRSZUZNM2FGVnhlR0ZSWnpoR1IwZG9OMjk2UlhSTGVXazVNMWRUVlZrS2Iwb3hVakl3YUcxUVFtbHVRVzEzTlU4eVZWSkpZWHBRVTFkaFEzaHhhbFZvUldObUwyUXlOM2N6WjFVdmNYWk1iVGx3V1VabmQwMHZOM1ZFZW00NFJncFdOak5RYkdOc05FVlJTbGxLU2tWR1JHZG5ZVnBSWlZKSmIzcGtUM1l4WjFGVU1uTmhjekpETlZkcE1ETk5ValpCTmxSU01EWnlXRmQzY1VKb00yNUdDblV6YjFwSGVGVTJXVFl2Y2pSc1MwaHJWbnBIUzBscFNVc3ZlakJsWTNZNVoyTmFad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTM4ZTQ4M2QtNjFkOC00OGY5LWFkMTctNTFkMTU4ZTBiOWZjLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBLdzVDRG13UUlHdGVkaGsySTRzeDdyN0tEU2FwT1pQZHRHa3hOMHN4UUxFSG95bTI2cUVFT0V4OA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2612"
@@ -2901,7 +2703,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:39:37 GMT
+      - Wed, 08 Nov 2023 09:15:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2911,7 +2713,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 204796a1-e1ba-4a8f-b742-eec44892ad87
+      - 62ac2376-73fb-406f-b03f-d12d94b11692
     status: 200 OK
     code: 200
     duration: ""
@@ -2922,10 +2724,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "642"
@@ -2934,7 +2736,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:39:37 GMT
+      - Wed, 08 Nov 2023 09:15:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2944,7 +2746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a657566e-3511-41fb-bf4b-7d36d84f13a5
+      - 19a61435-0d74-42a3-bfc2-d7de4cc87721
     status: 200 OK
     code: 200
     duration: ""
@@ -2955,19 +2757,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:36.446836Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:23.517375Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "641"
+      - "643"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:39:37 GMT
+      - Wed, 08 Nov 2023 09:15:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2977,7 +2779,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd52daf9-a6a5-4244-8206-89d62de7cbf2
+      - ce1fb3d7-583b-4cc9-a9f4-8142c9f2fe6e
     status: 200 OK
     code: 200
     duration: ""
@@ -2988,76 +2790,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "642"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 15:39:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2c4d7a6f-a7d5-4fbe-ab53-61c96e6cab1c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:36.446836Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "641"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 15:39:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ed2ab647-5627-496a-8387-9116968ed3d1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "642"
@@ -3066,7 +2802,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:39:38 GMT
+      - Wed, 08 Nov 2023 09:15:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3076,7 +2812,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da02d5d1-bca5-4d2a-8bbe-bcbc1de97e9f
+      - cfdc14d8-b850-4ce9-83e2-ec39e4c878a9
     status: 200 OK
     code: 200
     duration: ""
@@ -3087,19 +2823,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:36.446836Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:23.517375Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "641"
+      - "643"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:39:38 GMT
+      - Wed, 08 Nov 2023 09:15:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3109,7 +2845,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da934e8e-69fc-4701-9a90-a5c6f4092e19
+      - 55948613-1cc6-4a04-ba30-6d1910a9300b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "642"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 09:15:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3d7ab1e6-500f-4963-95e8-1e70a105b575
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:23.517375Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "643"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 09:15:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - be874201-605f-41fe-ba96-eeeacc0c5f30
     status: 200 OK
     code: 200
     duration: ""
@@ -3122,10 +2924,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:39:38.966555637Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:15:27.282289052Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1459"
@@ -3134,7 +2936,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:39:38 GMT
+      - Wed, 08 Nov 2023 09:15:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3144,7 +2946,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a003f7ca-d067-4054-b966-1fefef560461
+      - 9fe9739b-4467-4ef7-a674-58262a807986
     status: 200 OK
     code: 200
     duration: ""
@@ -3155,10 +2957,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:39:38.966556Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:15:27.282289Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1456"
@@ -3167,7 +2969,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:39:39 GMT
+      - Wed, 08 Nov 2023 09:15:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3177,7 +2979,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d2a8725-1493-4079-ab4c-95ddaf5e699e
+      - 439d6162-d1d5-412c-8c48-40967cafcbe6
     status: 200 OK
     code: 200
     duration: ""
@@ -3188,10 +2990,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:39:38.966556Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:15:27.282289Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1456"
@@ -3200,7 +3002,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:39:44 GMT
+      - Wed, 08 Nov 2023 09:15:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3210,7 +3012,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00220f19-1b7f-4f48-a3db-75d0625ebb6f
+      - dbca22f8-a4df-4b61-a36a-7c4bf95e9d91
     status: 200 OK
     code: 200
     duration: ""
@@ -3221,10 +3023,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:39:38.966556Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:15:27.282289Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1456"
@@ -3233,7 +3035,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:39:49 GMT
+      - Wed, 08 Nov 2023 09:15:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3243,7 +3045,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73f53940-7685-443a-9cf4-b1bf40b92ad2
+      - 13294aa8-5fb4-4cf5-86a4-3ffff036b52d
     status: 200 OK
     code: 200
     duration: ""
@@ -3254,10 +3056,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:39:38.966556Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:15:27.282289Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1456"
@@ -3266,7 +3068,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:39:54 GMT
+      - Wed, 08 Nov 2023 09:15:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3276,7 +3078,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07802968-065f-470e-900c-c7a6c848d933
+      - cfd0b9b1-3dbb-4158-881a-1e8f4f23ce69
     status: 200 OK
     code: 200
     duration: ""
@@ -3287,10 +3089,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:39:38.966556Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:15:27.282289Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1456"
@@ -3299,7 +3101,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:39:59 GMT
+      - Wed, 08 Nov 2023 09:15:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3309,7 +3111,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 133bc006-30c2-49ef-8486-4dab7a7d0c86
+      - 9d44c0b4-4bc8-402d-9ffc-7322e7d448d8
     status: 200 OK
     code: 200
     duration: ""
@@ -3320,10 +3122,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:39:38.966556Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:15:27.282289Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1456"
@@ -3332,7 +3134,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:04 GMT
+      - Wed, 08 Nov 2023 09:15:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3342,7 +3144,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 209f48b6-8ad8-45e4-bf3d-affb82c66c27
+      - d893046d-0500-46bf-8eeb-498c5456e87c
     status: 200 OK
     code: 200
     duration: ""
@@ -3353,10 +3155,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:39:38.966556Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:15:27.282289Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1456"
@@ -3365,7 +3167,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:09 GMT
+      - Wed, 08 Nov 2023 09:15:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3375,7 +3177,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54218df8-16b0-4a49-98a8-50573ff2d71d
+      - 0f996c68-81f4-4970-9bfb-d695d8631051
     status: 200 OK
     code: 200
     duration: ""
@@ -3386,10 +3188,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:39:38.966556Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:15:27.282289Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1456"
@@ -3398,7 +3200,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:14 GMT
+      - Wed, 08 Nov 2023 09:16:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3408,7 +3210,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c869895-a26d-4203-acbc-9e94ffb62736
+      - 4085152e-eec9-4502-b124-8644ec0d07b2
     status: 200 OK
     code: 200
     duration: ""
@@ -3419,10 +3221,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:40:15.523704Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:16:06.278174Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1453"
@@ -3431,7 +3233,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:19 GMT
+      - Wed, 08 Nov 2023 09:16:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3441,7 +3243,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7876a774-c408-4c45-8c45-0b7a24a24588
+      - ea61e228-1096-49c7-8017-496ae8e76637
     status: 200 OK
     code: 200
     duration: ""
@@ -3452,10 +3254,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:40:15.523704Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:16:06.278174Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1453"
@@ -3464,7 +3266,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:19 GMT
+      - Wed, 08 Nov 2023 09:16:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3474,7 +3276,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cff6eafc-86fa-4a5f-bf19-fb1ec655b967
+      - 89f3bb34-7c6d-4886-8684-54f00cca7bdf
     status: 200 OK
     code: 200
     duration: ""
@@ -3485,10 +3287,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGROVkVVeFRYcE5NVTVXYjFoRVZFMTZUVlJGZDAxVVJURk5lazB4VGxadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVXRUQ2xRclIzTTBkbmhYU1RWdVpVbFNia3AyWWtORGEybDVNbVJhTDNSbWNESkRORWRKYmxaNFIyUmFSa1U1YUUxa2JVYzNNMDFJUmtkaVJHaG1TM1ZKVDIwS1pUTmhaSEZDU1ZSRlYyaHZVa3BIYldsd2RFeENkRFl5ZG1kQ1FtdERSa1JCVURWNmNISkZiVkF3TTFJd1RUTjFUMlZwVm5NeFFXSnVZM2RyYzBSblJ3bzJOVFJ5S3padFpGWlVRazAxYURGMVVuTTFNWHBOY0VoV1NGQlNlWFIwUzIxd1dqWjBhRVZuTjI4MFJtbEJWVWdyTmt3cmFHOVdha1owYTBabkx6QTBDak5aWkc4NFNISmlUQzlyVjA5eVNXMXhTbmN3UkRaSWFIWllTRmh5TTNSc09FMTJkM1J1V21adWR6bHVSR3B5UW14WU1rcE9aMDlCVFhsUVEzcFNjbmdLTkVwdU1FTk9VM2R6VERGRVJsWlJOQ3RNYVVNeE9YUlRZVEF5VjBkbU5sSXJORmhJUmtsSWFXOHlTMXBXUzJVeFlYbG1aRXRVTUdaRGVqVnhVbXhYU0FvM1dtdDVUVXAwYm1JMlFrZGFZMHR3YjFkRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS2NUZGFMMGsxZUZWbFZuRnRSa2hKVFVFNE5uRXZhVXc1ZFRSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ09FTnlSVmd6Y0V0NmVrUnJWa3BuYURWR2RrWTJaRkF2TUZkTFpsaEtWRUZQYUVsYVozQlRRakJqV0M4MGFuRjFlZ3B4VUhaeVR6TnhTMDVYU25KTVpVUkljU3Q0ZEZkaldWaHdWa0ZqVkdselZGTnNRMUpyVkN0akswRlBUMlJXWld0UmRFZGliMlV2Y1hsR1ozaHdlVU5PQ21kS2FrdFJTMEZtYkRKcVVWTjBTbEZuUmpSV1EwWjZaV0YyWmpFM1JDODVjWE5tZFVoQmIxcGtaMU4wV1ZkSVNrNDVhRVJ0VVRCak4wbE1lbTg1WVdnS1RIZFFOMEl5Ym5KMk1XMXFPVWQ1VWpaUE4xbEtTalJSYVV0RGFGQkNNamQxWlRKM015dFhTbWhHTTI1clpXcDVPVkpUWjNGWFFuSXZXV1pNY1dGbWFRcHhTbkJSVkZsa1duTlVZemRUZFRaT05qTnJPR1V3WVNzMlJqTkNVekUwYWs1T1p6RkZhMGRLVnpGUVJVZDNWbGxSWVV0RkszUk5ha294ZFZwSmJtVmhDbm96WVVwQ1MxTTFiMmh6YUhWeWNIa3JiVEpyVHpaRlNsWXlieXN6ZFVZMlMySlhad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vY2MwMzRiYzAtOTY4OS00NGY1LTlhNzItNGQ5OWFjZGJiY2FmLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBOczhnZ1FJYW01VUVWMUlvS0hKT2pxS2dOeUx2TDVHWVRPQXFRYnZwUkN6VzMzdWJvVGRXbHozNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPZWtFMVRWUkJlRTVzYjFoRVZFMTZUVlJGZDA1NlFUVk5WRUY0VG14dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMEp2Q25oa0wwaFBRMGwwU2poRFdYcDBhRTV3VUZCSFoxWjJTa1F6TDI5M09XRXlhR2xDV1Zwa1ZIUkxkSFpCWjJRd1prMTZMMGM0V0hoa05rODRka3MxVkRRS2RWWnFjV3RaVTJwRmNEZ3hSRWxpUzA1bFkzVkhTWFpXTkhabVprWmhRek1yVDNnNWVuQm1iVGhSYm01UmNXSjZiSFkwWnpGdVlqZFNhbWQ2ZVRJMFJ3cHJNVzVYVGtWNlNEWkpRVzVRWTFBcmFrcE9TbkJOYURGYWVuUjJMMmM1Vkd4bFUyMUlaMmxSWTBSNGVtRm9ZVzR2WkRWcWNYZGxWRTFUU0dONGFrZHZDbkpaYTNJeFZpOU1NVEJOYVZkemQyNUxjelJWWW1kb2NWaHdMMG95ZUVaTFVrRnNaVU5CZDFONlpHMU9WamRRWWs1UVFXSk1PV3R3UkhsQ04wNXBhRWtLTjBsSlVYcDNaelZIWkZaUE5sUTVORWRPVWtKUGVVWTBWamsxTTBWck5IZGxla1k0YVdaSlRVZEdVbGhWVGpOS2J6WjVkbmRXVWpsYWJEQnBlV1Z5V1FwMVUyRk1NbU5pVmxkbFNEbHNLMnRvYUZsRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTlFqSTJkRWhLYTNvNFUxcDNZVFk0VlhGME9XTTRlVlp1T1V4TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFRFWnRTelZHUWs4eU5tWldhRUUxZEdWbVVtRnljWHAzUlhwSmFHRnNjSFZWTjNRMVMzRnpVRXBSVTFKV01tWldkUXBPY2k4NVpWWjBZVU1yUkRsRFRqTnBTbEZzYmxadlJpOXJZWG8xYmxwMlRVRXJiMmQxZWxwc1NtNUZVRFZCTWtSUmRIQmhNMEkzYWpKa04wZHFWbWhOQ2k5NVpXNXRWRVJaYjJKSVVuRlVOWFpaVjA0eFJqSjRjbWxHZFd0RllTOXRkVXRSZUZNM2FGVnhlR0ZSWnpoR1IwZG9OMjk2UlhSTGVXazVNMWRUVlZrS2Iwb3hVakl3YUcxUVFtbHVRVzEzTlU4eVZWSkpZWHBRVTFkaFEzaHhhbFZvUldObUwyUXlOM2N6WjFVdmNYWk1iVGx3V1VabmQwMHZOM1ZFZW00NFJncFdOak5RYkdOc05FVlJTbGxLU2tWR1JHZG5ZVnBSWlZKSmIzcGtUM1l4WjFGVU1uTmhjekpETlZkcE1ETk5ValpCTmxSU01EWnlXRmQzY1VKb00yNUdDblV6YjFwSGVGVTJXVFl2Y2pSc1MwaHJWbnBIUzBscFNVc3ZlakJsWTNZNVoyTmFad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTM4ZTQ4M2QtNjFkOC00OGY5LWFkMTctNTFkMTU4ZTBiOWZjLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBLdzVDRG13UUlHdGVkaGsySTRzeDdyN0tEU2FwT1pQZHRHa3hOMHN4UUxFSG95bTI2cUVFT0V4OA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2612"
@@ -3497,7 +3299,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:19 GMT
+      - Wed, 08 Nov 2023 09:16:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3507,7 +3309,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c4ac7e7-008c-4ea8-ae2b-677dc4e45c6c
+      - 0de8b989-414f-4cf1-9043-e277e7b223f5
     status: 200 OK
     code: 200
     duration: ""
@@ -3518,10 +3320,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/pools?name=tf-pool&order_by=created_at_asc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/pools?name=tf-pool&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
+    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
       - "670"
@@ -3530,7 +3332,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:19 GMT
+      - Wed, 08 Nov 2023 09:16:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3540,7 +3342,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8df62ffd-8fa0-495a-9c4a-b40d55b7e557
+      - b1c52c7b-8e3e-4f2e-9d97-ef0eefa4a198
     status: 200 OK
     code: 200
     duration: ""
@@ -3551,10 +3353,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "642"
@@ -3563,7 +3365,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:19 GMT
+      - Wed, 08 Nov 2023 09:16:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3573,7 +3375,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e45ece1-6973-4cc0-9ff4-893c9c10f813
+      - f16bd196-c801-42cc-b08b-fec5d2509260
     status: 200 OK
     code: 200
     duration: ""
@@ -3584,10 +3386,142 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:51.686841Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:38.990540Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "672"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 09:16:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6b4eec5f-9b18-427d-a3f3-73ba5191b0e6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "642"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 09:16:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3f585e8f-723d-46f7-bd29-e232ac6d48e9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "642"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 09:16:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ad34fae9-6173-43d6-a2a5-36d79dd8efa5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "642"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 09:16:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0c4cb021-8ca3-4d3a-aa8e-3e3357bd60e7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/pools?name=tf-pool&order_by=created_at_asc&status=unknown
+    method: GET
+  response:
+    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
       - "670"
@@ -3596,7 +3530,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:19 GMT
+      - Wed, 08 Nov 2023 09:16:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3606,7 +3540,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37785bd5-bf91-4dc9-98ff-98f364be0e68
+      - 547ba5b2-4626-484e-b6d3-95a92c7f1c7f
     status: 200 OK
     code: 200
     duration: ""
@@ -3617,10 +3551,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:38.990540Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "672"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 09:16:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ae3f7d0b-8e22-490b-b3d5-b5eb40414423
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "642"
@@ -3629,7 +3596,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:20 GMT
+      - Wed, 08 Nov 2023 09:16:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3639,7 +3606,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a558dad2-02b8-47ef-bd92-4167f7cb0816
+      - e9c820f1-724a-473b-96e9-423e2ed895ef
     status: 200 OK
     code: 200
     duration: ""
@@ -3650,19 +3617,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:38.990540Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "642"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:20 GMT
+      - Wed, 08 Nov 2023 09:16:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3672,7 +3639,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a64b2af3-3288-4e54-ac00-359001684db5
+      - fd02c5fb-2b83-4f92-adc1-051ab02ffc4a
     status: 200 OK
     code: 200
     duration: ""
@@ -3683,19 +3650,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9204ea7b-13d2-4b0d-938d-30250328f16f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-08T09:10:14.141608Z","dhcp_enabled":true,"id":"9204ea7b-13d2-4b0d-938d-30250328f16f","name":"test-data-source-pool","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-08T09:10:14.141608Z","id":"0ece81a7-0a26-41cd-b79c-3e9f201ac24f","subnet":"172.16.12.0/22","updated_at":"2023-11-08T09:10:14.141608Z"},{"created_at":"2023-11-08T09:10:14.141608Z","id":"e3f389f9-023e-44be-8d1d-b7eb49001405","subnet":"fd63:256c:45f7:998e::/64","updated_at":"2023-11-08T09:10:14.141608Z"}],"tags":[],"updated_at":"2023-11-08T09:10:14.141608Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "642"
+      - "705"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:20 GMT
+      - Wed, 08 Nov 2023 09:16:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3705,7 +3672,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3bb033e8-88ab-48bd-840a-347dcf6358c4
+      - 66c442dd-063a-4392-bfb3-baedd6179376
     status: 200 OK
     code: 200
     duration: ""
@@ -3716,175 +3683,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/pools?name=tf-pool&order_by=created_at_asc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
     method: GET
   response:
-    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "670"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 15:40:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - acd6a2ec-e57c-4d71-8485-7e919fadc753
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:51.686841Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "670"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 15:40:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 11b2b07f-0228-4d1d-854c-7c7372dfb31c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "642"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 15:40:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5601c003-94a9-430b-b627-0f3d34b39a50
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:51.686841Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "670"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 15:40:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d42fc1b0-dd6d-4b53-83f6-39ba7b8632e3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7c0f88fe-47b2-44c5-be75-7e0d3766bc55
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-02T15:33:53.182844Z","dhcp_enabled":true,"id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","name":"test-data-source-pool","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-02T15:33:53.182844Z","id":"8b259f89-423a-4607-9979-13dd7515cc29","subnet":"172.16.4.0/22","updated_at":"2023-11-02T15:33:53.182844Z"},{"created_at":"2023-11-02T15:33:53.182844Z","id":"05ee4fd6-0b54-497d-9684-b3673ddeb02c","subnet":"fd5f:519c:6d46:cb39::/64","updated_at":"2023-11-02T15:33:53.182844Z"}],"tags":[],"updated_at":"2023-11-02T15:33:53.182844Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 15:40:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 35200d5b-8ed6-42f7-991a-d40a5e7ff7a3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:40:15.523704Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:16:06.278174Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1453"
@@ -3893,7 +3695,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:21 GMT
+      - Wed, 08 Nov 2023 09:16:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3903,7 +3705,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 842d4c2d-dadf-4c54-bf54-2ca8aaef612c
+      - 6242dc7b-2dba-41e5-85ff-87ab65434630
     status: 200 OK
     code: 200
     duration: ""
@@ -3914,10 +3716,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGROVkVVeFRYcE5NVTVXYjFoRVZFMTZUVlJGZDAxVVJURk5lazB4VGxadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVXRUQ2xRclIzTTBkbmhYU1RWdVpVbFNia3AyWWtORGEybDVNbVJhTDNSbWNESkRORWRKYmxaNFIyUmFSa1U1YUUxa2JVYzNNMDFJUmtkaVJHaG1TM1ZKVDIwS1pUTmhaSEZDU1ZSRlYyaHZVa3BIYldsd2RFeENkRFl5ZG1kQ1FtdERSa1JCVURWNmNISkZiVkF3TTFJd1RUTjFUMlZwVm5NeFFXSnVZM2RyYzBSblJ3bzJOVFJ5S3padFpGWlVRazAxYURGMVVuTTFNWHBOY0VoV1NGQlNlWFIwUzIxd1dqWjBhRVZuTjI4MFJtbEJWVWdyTmt3cmFHOVdha1owYTBabkx6QTBDak5aWkc4NFNISmlUQzlyVjA5eVNXMXhTbmN3UkRaSWFIWllTRmh5TTNSc09FMTJkM1J1V21adWR6bHVSR3B5UW14WU1rcE9aMDlCVFhsUVEzcFNjbmdLTkVwdU1FTk9VM2R6VERGRVJsWlJOQ3RNYVVNeE9YUlRZVEF5VjBkbU5sSXJORmhJUmtsSWFXOHlTMXBXUzJVeFlYbG1aRXRVTUdaRGVqVnhVbXhYU0FvM1dtdDVUVXAwYm1JMlFrZGFZMHR3YjFkRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaS2NUZGFMMGsxZUZWbFZuRnRSa2hKVFVFNE5uRXZhVXc1ZFRSTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ09FTnlSVmd6Y0V0NmVrUnJWa3BuYURWR2RrWTJaRkF2TUZkTFpsaEtWRUZQYUVsYVozQlRRakJqV0M4MGFuRjFlZ3B4VUhaeVR6TnhTMDVYU25KTVpVUkljU3Q0ZEZkaldWaHdWa0ZqVkdselZGTnNRMUpyVkN0akswRlBUMlJXWld0UmRFZGliMlV2Y1hsR1ozaHdlVU5PQ21kS2FrdFJTMEZtYkRKcVVWTjBTbEZuUmpSV1EwWjZaV0YyWmpFM1JDODVjWE5tZFVoQmIxcGtaMU4wV1ZkSVNrNDVhRVJ0VVRCak4wbE1lbTg1WVdnS1RIZFFOMEl5Ym5KMk1XMXFPVWQ1VWpaUE4xbEtTalJSYVV0RGFGQkNNamQxWlRKM015dFhTbWhHTTI1clpXcDVPVkpUWjNGWFFuSXZXV1pNY1dGbWFRcHhTbkJSVkZsa1duTlVZemRUZFRaT05qTnJPR1V3WVNzMlJqTkNVekUwYWs1T1p6RkZhMGRLVnpGUVJVZDNWbGxSWVV0RkszUk5ha294ZFZwSmJtVmhDbm96WVVwQ1MxTTFiMmh6YUhWeWNIa3JiVEpyVHpaRlNsWXlieXN6ZFVZMlMySlhad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vY2MwMzRiYzAtOTY4OS00NGY1LTlhNzItNGQ5OWFjZGJiY2FmLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBOczhnZ1FJYW01VUVWMUlvS0hKT2pxS2dOeUx2TDVHWVRPQXFRYnZwUkN6VzMzdWJvVGRXbHozNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRmLWNsdXN0ZXItcG9vbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPZWtFMVRWUkJlRTVzYjFoRVZFMTZUVlJGZDA1NlFUVk5WRUY0VG14dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMEp2Q25oa0wwaFBRMGwwU2poRFdYcDBhRTV3VUZCSFoxWjJTa1F6TDI5M09XRXlhR2xDV1Zwa1ZIUkxkSFpCWjJRd1prMTZMMGM0V0hoa05rODRka3MxVkRRS2RWWnFjV3RaVTJwRmNEZ3hSRWxpUzA1bFkzVkhTWFpXTkhabVprWmhRek1yVDNnNWVuQm1iVGhSYm01UmNXSjZiSFkwWnpGdVlqZFNhbWQ2ZVRJMFJ3cHJNVzVYVGtWNlNEWkpRVzVRWTFBcmFrcE9TbkJOYURGYWVuUjJMMmM1Vkd4bFUyMUlaMmxSWTBSNGVtRm9ZVzR2WkRWcWNYZGxWRTFUU0dONGFrZHZDbkpaYTNJeFZpOU1NVEJOYVZkemQyNUxjelJWWW1kb2NWaHdMMG95ZUVaTFVrRnNaVU5CZDFONlpHMU9WamRRWWs1UVFXSk1PV3R3UkhsQ04wNXBhRWtLTjBsSlVYcDNaelZIWkZaUE5sUTVORWRPVWtKUGVVWTBWamsxTTBWck5IZGxla1k0YVdaSlRVZEdVbGhWVGpOS2J6WjVkbmRXVWpsYWJEQnBlV1Z5V1FwMVUyRk1NbU5pVmxkbFNEbHNLMnRvYUZsRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTlFqSTJkRWhLYTNvNFUxcDNZVFk0VlhGME9XTTRlVlp1T1V4TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFRFWnRTelZHUWs4eU5tWldhRUUxZEdWbVVtRnljWHAzUlhwSmFHRnNjSFZWTjNRMVMzRnpVRXBSVTFKV01tWldkUXBPY2k4NVpWWjBZVU1yUkRsRFRqTnBTbEZzYmxadlJpOXJZWG8xYmxwMlRVRXJiMmQxZWxwc1NtNUZVRFZCTWtSUmRIQmhNMEkzYWpKa04wZHFWbWhOQ2k5NVpXNXRWRVJaYjJKSVVuRlVOWFpaVjA0eFJqSjRjbWxHZFd0RllTOXRkVXRSZUZNM2FGVnhlR0ZSWnpoR1IwZG9OMjk2UlhSTGVXazVNMWRUVlZrS2Iwb3hVakl3YUcxUVFtbHVRVzEzTlU4eVZWSkpZWHBRVTFkaFEzaHhhbFZvUldObUwyUXlOM2N6WjFVdmNYWk1iVGx3V1VabmQwMHZOM1ZFZW00NFJncFdOak5RYkdOc05FVlJTbGxLU2tWR1JHZG5ZVnBSWlZKSmIzcGtUM1l4WjFGVU1uTmhjekpETlZkcE1ETk5ValpCTmxSU01EWnlXRmQzY1VKb00yNUdDblV6YjFwSGVGVTJXVFl2Y2pSc1MwaHJWbnBIUzBscFNVc3ZlakJsWTNZNVoyTmFad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYTM4ZTQ4M2QtNjFkOC00OGY5LWFkMTctNTFkMTU4ZTBiOWZjLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRmLWNsdXN0ZXItcG9vbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGYtY2x1c3Rlci1wb29sIgogICAgdXNlcjogdGYtY2x1c3Rlci1wb29sLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGYtY2x1c3Rlci1wb29sCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGYtY2x1c3Rlci1wb29sLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBLdzVDRG13UUlHdGVkaGsySTRzeDdyN0tEU2FwT1pQZHRHa3hOMHN4UUxFSG95bTI2cUVFT0V4OA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
       - "2612"
@@ -3926,7 +3728,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:21 GMT
+      - Wed, 08 Nov 2023 09:16:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3936,7 +3738,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a393840-1ab3-4de5-af96-7661c8269e8d
+      - 03963ea5-2223-49e1-a4e9-866894200e2f
     status: 200 OK
     code: 200
     duration: ""
@@ -3947,10 +3749,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "642"
@@ -3959,7 +3761,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:21 GMT
+      - Wed, 08 Nov 2023 09:16:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3969,7 +3771,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88e27911-a3e9-4125-960c-eeaba07d5ca8
+      - 4503187e-d10d-4dff-9007-264cd9d49984
     status: 200 OK
     code: 200
     duration: ""
@@ -3980,19 +3782,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:51.686841Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:38.990540Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "670"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:21 GMT
+      - Wed, 08 Nov 2023 09:16:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4002,7 +3804,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8460d43-7df5-4b6f-bf60-fd0b5db116a9
+      - 924d5d75-ff6d-4717-8cc8-baa619507ae1
     status: 200 OK
     code: 200
     duration: ""
@@ -4013,109 +3815,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "642"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 15:40:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 947affd8-7618-457b-b5a7-f586fd27dae7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/pools?name=tf-pool&order_by=created_at_asc&status=unknown
-    method: GET
-  response:
-    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "670"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 15:40:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1cd7a3f4-4222-4cef-b454-105d553406af
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:51.686841Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "670"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 15:40:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cb0230dc-ed77-4607-b02f-ddbac0ad3886
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "642"
@@ -4124,7 +3827,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:21 GMT
+      - Wed, 08 Nov 2023 09:16:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4134,7 +3837,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c5ad6f3-14a3-4678-977e-82cc5e4deff4
+      - 3ff13cbc-0610-460b-af9d-7da60dc04c60
     status: 200 OK
     code: 200
     duration: ""
@@ -4145,10 +3848,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/pools?name=tf-pool&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:51.686841Z"}],"total_count":1}'
+    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
       - "670"
@@ -4157,7 +3860,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:21 GMT
+      - Wed, 08 Nov 2023 09:16:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4167,7 +3870,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ccff9e0d-9be4-4ac3-99ae-716b71b34e43
+      - 9638393d-4cba-48c3-8b34-567f86b260af
     status: 200 OK
     code: 200
     duration: ""
@@ -4178,10 +3881,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:38.990540Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "672"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 09:16:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - df626982-ec51-498d-8c70-bf261c7e20ea
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "642"
@@ -4190,7 +3926,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:21 GMT
+      - Wed, 08 Nov 2023 09:16:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4200,7 +3936,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9ae5d7a-48c5-4bca-932b-5b7ef3eaeda0
+      - 3f111ac8-fca9-4b79-b0fd-7be3bc2e5bf0
     status: 200 OK
     code: 200
     duration: ""
@@ -4211,19 +3947,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/pools?name=tf-pool&order_by=created_at_asc&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
     method: GET
   response:
-    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:38.990540Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "670"
+      - "672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:21 GMT
+      - Wed, 08 Nov 2023 09:16:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4233,7 +3969,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8412d4f-017a-466f-b4d3-6b66b6fb9ea3
+      - a1d638eb-6d88-4df1-9a3c-7f07b5a42430
     status: 200 OK
     code: 200
     duration: ""
@@ -4244,43 +3980,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:51.686841Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "670"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 15:40:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 17734774-b9b1-4454-8a02-927706b4cf64
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:39:30.137292Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "642"
@@ -4289,7 +3992,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:21 GMT
+      - Wed, 08 Nov 2023 09:16:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4299,7 +4002,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4bf436e0-a181-4bd4-8f8f-4d160a9c4c79
+      - d93b058b-75ec-44cc-bd8c-2693b2c6cee6
     status: 200 OK
     code: 200
     duration: ""
@@ -4310,10 +4013,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf/nodes?order_by=created_at_asc&page=1&pool_id=0934ac88-551f-44ec-9f77-77813d9e9a3f&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/pools?name=tf-pool&order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-02T15:36:44.273028Z","error_message":null,"id":"0dc86902-e12a-42fd-a4b0-703c51c65e16","name":"scw-tf-cluster-pool-tf-pool-0dc86902e12a42fda4","pool_id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","provider_id":"scaleway://instance/fr-par-1/1bb0b6b0-3096-49ae-aa49-7a4ea27bbd17","public_ip_v4":"51.15.239.152","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-02T15:39:51.686841Z"}],"total_count":1}'
+    body: '{"pools":[{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
       - "670"
@@ -4322,7 +4025,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:22 GMT
+      - Wed, 08 Nov 2023 09:16:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4332,7 +4035,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7122a9d-8d28-4c7a-9612-c2bf1ca34a98
+      - a0429335-7d79-4e3e-a489-791eb0e9cce7
     status: 200 OK
     code: 200
     duration: ""
@@ -4343,10 +4046,109 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0934ac88-551f-44ec-9f77-77813d9e9a3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:38.990540Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "672"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 09:16:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7218f0f7-81da-4b12-b89b-448c79c1da2f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:15:23.533846Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "642"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 09:16:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5380dee7-ceb3-4770-b4e6-c7e48d2482a9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc/nodes?order_by=created_at_asc&page=1&pool_id=d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-08T09:11:57.448360Z","error_message":null,"id":"996b48d3-af74-47e7-8df0-714de8ac0374","name":"scw-tf-cluster-pool-tf-pool-996b48d3af7447e78d","pool_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","provider_id":"scaleway://instance/fr-par-1/d9c9fc65-54c9-4e0b-82f6-2b503aa08190","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-08T09:15:38.990540Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "672"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 09:16:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cfb9e0dd-198e-4824-9783-ffa078756698
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
     method: DELETE
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","container_runtime":"containerd","created_at":"2023-11-02T15:33:59.882202Z","id":"0934ac88-551f-44ec-9f77-77813d9e9a3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-02T15:40:22.611178892Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:16:10.632564921Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "648"
@@ -4355,7 +4157,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:22 GMT
+      - Wed, 08 Nov 2023 09:16:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4365,7 +4167,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4459d860-742e-44d4-8566-27fde546dbc7
+      - 9b0bd110-fb9b-4661-9f22-a4482865d3f9
     status: 200 OK
     code: 200
     duration: ""
@@ -4376,10 +4178,274 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:16:10.632565Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "645"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 09:16:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d123e3ea-1590-47a3-a4a7-5ee9276f60d3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:16:10.632565Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "645"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 09:16:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 600cfece-78fe-4e35-8d1f-04190bb5fc05
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:16:10.632565Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "645"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 09:16:20 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 91f56182-c712-41f0-bcad-92cb212807c6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:16:10.632565Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "645"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 09:16:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f30ed984-fa32-4302-9a2b-f86a54a2b94b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:16:10.632565Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "645"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 09:16:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e26fed0e-ffe6-48a9-bacf-bf5d2a42ccb1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:16:10.632565Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "645"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 09:16:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 84c3eb7e-d940-497a-976b-06bdfcba0446
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","container_runtime":"containerd","created_at":"2023-11-08T09:10:20.797259Z","id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","kubelet_args":{},"max_size":1,"min_size":1,"name":"tf-pool","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","data_scaleway_k8s_pool","basic"],"updated_at":"2023-11-08T09:16:10.632565Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "645"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 09:16:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 760ff767-3a60-447c-b699-0bfcbb08d27c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"d630a7e8-4927-4dc2-8a9f-2bb6634b5aa4","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "125"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Nov 2023 09:16:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 57c0563a-bcf2-473b-8223-a7588b69379a
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:40:22.693681518Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:16:46.134371905Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1459"
@@ -4388,7 +4454,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:22 GMT
+      - Wed, 08 Nov 2023 09:16:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4398,7 +4464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0aa20a3c-c66a-47cb-935f-5e78d6b7a009
+      - c7aafd05-bf85-4f12-a962-d620768e4419
     status: 200 OK
     code: 200
     duration: ""
@@ -4409,10 +4475,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:40:22.693682Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:16:46.134372Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1456"
@@ -4421,7 +4487,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:22 GMT
+      - Wed, 08 Nov 2023 09:16:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4431,7 +4497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44961d33-815d-4bd8-94eb-dea38d2f97bb
+      - 06522336-fd0b-41e9-9d25-bbda57a5aaad
     status: 200 OK
     code: 200
     duration: ""
@@ -4442,10 +4508,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:40:22.693682Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a38e483d-61d8-48f9-ad17-51d158e0b9fc.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-08T09:10:15.312570Z","created_at":"2023-11-08T09:10:15.312570Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a38e483d-61d8-48f9-ad17-51d158e0b9fc.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-08T09:16:46.134372Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
       - "1456"
@@ -4454,7 +4520,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:27 GMT
+      - Wed, 08 Nov 2023 09:16:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4464,7 +4530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63b6c9c5-3b6d-43f5-ae89-c7fda448355c
+      - dd90af82-cd05-45fb-a4e8-cd298f47925c
     status: 200 OK
     code: 200
     duration: ""
@@ -4475,142 +4541,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:40:22.693682Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1456"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 15:40:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1ff96878-3508-41cd-ad7c-b177db3fabe9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:40:22.693682Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1456"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 15:40:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 44eb12e5-a7c8-44e0-8eda-71a4242ce82e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:40:22.693682Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1456"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 15:40:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3d24faa0-4fb1-434f-b11a-4079f7672b22
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://cc034bc0-9689-44f5-9a72-4d99acdbbcaf.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-02T15:33:54.422614Z","created_at":"2023-11-02T15:33:54.422614Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cc034bc0-9689-44f5-9a72-4d99acdbbcaf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","ingress":"none","name":"tf-cluster-pool","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","data_scaleway_k8s_cluster","basic"],"type":"kapsule","updated_at":"2023-11-02T15:40:22.693682Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1456"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Nov 2023 15:40:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a724d997-ffbd-4859-ab29-39c2187c69db
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -4619,7 +4553,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:53 GMT
+      - Wed, 08 Nov 2023 09:16:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4629,7 +4563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 224f167a-a532-4054-b746-5d3f520e4131
+      - 9b337557-4cea-4dce-bca8-83056ab95c1b
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4640,10 +4574,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7c0f88fe-47b2-44c5-be75-7e0d3766bc55
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9204ea7b-13d2-4b0d-938d-30250328f16f
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"7c0f88fe-47b2-44c5-be75-7e0d3766bc55","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"9204ea7b-13d2-4b0d-938d-30250328f16f","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -4652,7 +4586,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:53 GMT
+      - Wed, 08 Nov 2023 09:16:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4662,7 +4596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d59da220-6249-4795-a1d8-898a59b08fea
+      - a835a41a-0304-46f6-bce1-d487241d4841
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4673,10 +4607,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/cc034bc0-9689-44f5-9a72-4d99acdbbcaf
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a38e483d-61d8-48f9-ad17-51d158e0b9fc
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"cc034bc0-9689-44f5-9a72-4d99acdbbcaf","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"a38e483d-61d8-48f9-ad17-51d158e0b9fc","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -4685,7 +4619,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Nov 2023 15:40:53 GMT
+      - Wed, 08 Nov 2023 09:16:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4695,7 +4629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 475bbfc9-f4c4-4ce0-94c7-5e02379c5607
+      - a59ccaa6-bae0-437a-995b-a6b186a742e4
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-auto-upgrade.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-auto-upgrade.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:41 GMT
+      - Tue, 07 Nov 2023 16:19:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17202fb0-9c3d-43e4-a182-fecb8e1d0c2e
+      - 262c984d-dcfd-4bb8-8dea-c1a56e8748fc
     status: 200 OK
     code: 200
     duration: ""
@@ -61,7 +61,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:41 GMT
+      - Tue, 07 Nov 2023 16:19:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -71,7 +71,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2381b7e7-7e5c-4f70-b3e9-88eb25f2ebba
+      - 48dc0c9f-226a-4d63-8e84-40830ee37133
     status: 200 OK
     code: 200
     duration: ""
@@ -98,7 +98,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:41 GMT
+      - Tue, 07 Nov 2023 16:19:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -108,7 +108,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db488340-aa00-46c5-9a3f-07fcdc1090eb
+      - 75e2a1f0-2626-4854-bbc5-fdb2072e20bc
     status: 200 OK
     code: 200
     duration: ""
@@ -135,7 +135,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:41 GMT
+      - Tue, 07 Nov 2023 16:19:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -145,12 +145,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b0a81d6-9151-421b-b96c-93c8a48dbe60
+      - 73ba9f7f-a647-419b-8a96-dbbf15ad4b05
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-auto-upgrade","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"test-auto-upgrade","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -161,16 +161,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-18T16:43:44.258914Z","dhcp_enabled":true,"id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:44.258914Z","id":"4f19792d-685a-4cf1-bd52-1cb3823f144b","subnet":"172.16.8.0/22","updated_at":"2023-10-18T16:43:44.258914Z"},{"created_at":"2023-10-18T16:43:44.258914Z","id":"51e3553d-0372-4af8-a40c-83dc7752e070","subnet":"fd63:256c:45f7:aefc::/64","updated_at":"2023-10-18T16:43:44.258914Z"}],"tags":[],"updated_at":"2023-10-18T16:43:44.258914Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "717"
+      - "699"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:44 GMT
+      - Tue, 07 Nov 2023 16:20:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -180,7 +180,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9ae143d-0e41-4918-84c4-a8813490447b
+      - 84efed90-690c-4304-9847-5379714e50fe
     status: 200 OK
     code: 200
     duration: ""
@@ -191,19 +191,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9695b5c8-f87e-4172-805f-afbb4cb27d8b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:43:44.258914Z","dhcp_enabled":true,"id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:44.258914Z","id":"4f19792d-685a-4cf1-bd52-1cb3823f144b","subnet":"172.16.8.0/22","updated_at":"2023-10-18T16:43:44.258914Z"},{"created_at":"2023-10-18T16:43:44.258914Z","id":"51e3553d-0372-4af8-a40c-83dc7752e070","subnet":"fd63:256c:45f7:aefc::/64","updated_at":"2023-10-18T16:43:44.258914Z"}],"tags":[],"updated_at":"2023-10-18T16:43:44.258914Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "717"
+      - "699"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:44 GMT
+      - Tue, 07 Nov 2023 16:20:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -213,12 +213,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2fa4afea-ed5f-455b-bd68-650c394a7530
+      - 2c44850d-1335-4a57-823f-a5e070988197
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-auto-upgrade","description":"","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"version":"1.27.6","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":{"enable":false,"maintenance_window":{"start_hour":0,"day":"any"}},"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-auto-upgrade","description":"","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"version":"1.27.6","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":{"enable":false,"maintenance_window":{"start_hour":0,"day":"any"}},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07"}'
     form: {}
     headers:
       Content-Type:
@@ -229,16 +229,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195709950Z","created_at":"2023-10-18T16:43:45.195709950Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:43:45.207921783Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081695626Z","created_at":"2023-11-07T16:20:01.081695626Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:01.092822070Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1513"
+      - "1468"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:45 GMT
+      - Tue, 07 Nov 2023 16:20:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -248,7 +248,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2b1694e-ab9c-4f0d-bdfe-9ec126fea87e
+      - 599ccced-c5bf-4043-972a-ba653a6a12b2
     status: 200 OK
     code: 200
     duration: ""
@@ -259,19 +259,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:43:45.207922Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:01.092822Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1504"
+      - "1459"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:45 GMT
+      - Tue, 07 Nov 2023 16:20:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -281,7 +281,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dfca8aa7-ddb5-4836-b2e0-566ec3d08c63
+      - da559be3-3e01-4b1f-b4dc-9754777c911f
     status: 200 OK
     code: 200
     duration: ""
@@ -292,19 +292,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:43:46.705628Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.802278Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1509"
+      - "1464"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:50 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -314,7 +314,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fdc0cc0e-05c9-4719-ae18-837445846366
+      - e0a7d31f-e51b-43bc-99dd-8fb5c29a43dc
     status: 200 OK
     code: 200
     duration: ""
@@ -325,19 +325,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:43:46.705628Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.802278Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1509"
+      - "1464"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:50 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -347,7 +347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 58f01897-a209-4aa4-96fc-0d3f4acf1faa
+      - 73b1d9a5-30e4-467f-b49e-11ed40867b2d
     status: 200 OK
     code: 200
     duration: ""
@@ -358,19 +358,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VGtSTk1FNXNiMWhFVkUxNlRWUkJlRTU2UlRKT1JFMHdUbXh2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRqRnJDa2RRWW01NVdrRnhUa0p6VUhwU2MwVkZSV012VDNsblRITnFTRGhQVmpWQlVFTTVlV2hOZVZnck5GZzVPVVE0VUVrNU5rRkRiVTF2UWpkWWQzSlpjMUlLWkZCVVNVbDZhM1pqY1hFd2VrTnVXSEp0UjFWelVYUmxaRFlyZURob1owVk1hRlo2VDA1eFUzWktlRXgwYXpRdmNUTXpNMUV6TmxaWlVWWXZjaTkyUlFvdlpub3dURGxSSzJ4a1JISjNMM1kzYlROMk5qVjBNMWRvWW5KNk1tRnBkRmR0TVM5RWF6VllWWGxyTDNOblVGUkVTREF6V0hSUlNUUlZZbWxOYlZoakNpdDRlRlZWU2xKUFJuRnpXRTE2VUd0clducFFVMngyZUU5R1ZEWklLMlF5ZW5sTE5WcEdZblJyVWxKS1VuTkdkWEpWWTBNek5qWklkRFpXZEhOU1VVVUtSRWhsTkhNMU1YVkhSRmxaUzJGcVpVbFJSa3ByVTJGU1dIQkxiMHhFZUc5WlNWb3plRFZyYUROcloxQmFiRnBUY0ZodVVHdG9Za3hCZEZRcmVHdElOd296YjI0dmEwOUdkM1ZUUm1KNFdUUTFiRkpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpCTkc1V1NsUmFVa3hIYjNWNVVpOVVWVkpwU25kUFRUZE5NMk5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCT0d4cWJXa3dTMlpUYlRWWldtbHJablJQVG1kNlEwOTRTMVpGT0VSUWVEUllUMEkyT1hFelowODVVek52VWsxVGNncGhVVzlLWTJSMlFXMHJOVzlrVmtwRU4xWnFXamhCVVUxV2FESndOMFVyY1VwNFRYZFJNVkpUVEZWek0xRmtibWRMZDBka1QzQmxhM2cwYVVoMlptdElDbk5qUkhRcmR5dFdjMjk1T1hoMk9DOVpWMFoyTTJwT2FHbzBibU16U0RSMFpVVnVka1ExTmtzemMydG1TRTR2ZEVaQlduUllXRTFrVjNoelJqaFZMemtLTDJaRU5GSmpZV2RRV0VKeWVsSkxjRmxaUW00clJqUmhTMGR4UjNSRWMyOTFWa0VyYzJ0VE1tNUlSV2R2UjJjelQweGpRVm8wYlc0elFqUlFOVWxuYUFwWFlrOWFRMHN6ZVZwaWMxbGFjMUJpWkd3NVpXbHhSRUpvUzBZNFpVcHJXRm96VWxWVFRWVlpkakJHVDBaMmEyOUJjamx3Ynk5dFMwUm9VRU15WVdWeUNrcHFMek5wY1Rrek1HbFhaMEZ0TTJRNVpteFpZMkk0WjI1T2JURnBaMU5UZEhOMGVnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGI4MTdlZC1lZTI2LTRmZDYtYmI2Zi0yOTI1ZjUwOTgxMjUuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1VloxemV4elFPaG1TRjRmOURZU01pbUZsWjZQdDlBM3hrSkFiQlNXVlNwcElZTTR2S2tUY0NzMQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2630"
+      - "2628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:50 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -380,7 +380,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0fb835a-4db7-4ba7-8c28-157b5a2759a7
+      - f1adcac9-cdee-450a-8300-abed9ab82b14
     status: 200 OK
     code: 200
     duration: ""
@@ -391,19 +391,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:43:46.705628Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.802278Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1509"
+      - "1464"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:50 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -413,7 +413,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0b574c99-468d-4da1-b995-fa6fb75f669b
+      - 017cbd31-6fa8-4ba3-978b-ad496fd40119
     status: 200 OK
     code: 200
     duration: ""
@@ -424,19 +424,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9695b5c8-f87e-4172-805f-afbb4cb27d8b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:43:44.258914Z","dhcp_enabled":true,"id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:44.258914Z","id":"4f19792d-685a-4cf1-bd52-1cb3823f144b","subnet":"172.16.8.0/22","updated_at":"2023-10-18T16:43:44.258914Z"},{"created_at":"2023-10-18T16:43:44.258914Z","id":"51e3553d-0372-4af8-a40c-83dc7752e070","subnet":"fd63:256c:45f7:aefc::/64","updated_at":"2023-10-18T16:43:44.258914Z"}],"tags":[],"updated_at":"2023-10-18T16:43:44.258914Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "717"
+      - "699"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:51 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -446,7 +446,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11ed420f-1947-4fb2-addb-1c1ef677370b
+      - 03bb531a-1f09-416a-b18c-8659857182ee
     status: 200 OK
     code: 200
     duration: ""
@@ -457,19 +457,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:43:46.705628Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.802278Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1509"
+      - "1464"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:51 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -479,7 +479,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b138f0f8-5c84-4b30-bb58-d5d3fa7eea00
+      - 0f46107b-272e-4097-9891-0a8f53f1bca2
     status: 200 OK
     code: 200
     duration: ""
@@ -490,19 +490,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VGtSTk1FNXNiMWhFVkUxNlRWUkJlRTU2UlRKT1JFMHdUbXh2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRqRnJDa2RRWW01NVdrRnhUa0p6VUhwU2MwVkZSV012VDNsblRITnFTRGhQVmpWQlVFTTVlV2hOZVZnck5GZzVPVVE0VUVrNU5rRkRiVTF2UWpkWWQzSlpjMUlLWkZCVVNVbDZhM1pqY1hFd2VrTnVXSEp0UjFWelVYUmxaRFlyZURob1owVk1hRlo2VDA1eFUzWktlRXgwYXpRdmNUTXpNMUV6TmxaWlVWWXZjaTkyUlFvdlpub3dURGxSSzJ4a1JISjNMM1kzYlROMk5qVjBNMWRvWW5KNk1tRnBkRmR0TVM5RWF6VllWWGxyTDNOblVGUkVTREF6V0hSUlNUUlZZbWxOYlZoakNpdDRlRlZWU2xKUFJuRnpXRTE2VUd0clducFFVMngyZUU5R1ZEWklLMlF5ZW5sTE5WcEdZblJyVWxKS1VuTkdkWEpWWTBNek5qWklkRFpXZEhOU1VVVUtSRWhsTkhNMU1YVkhSRmxaUzJGcVpVbFJSa3ByVTJGU1dIQkxiMHhFZUc5WlNWb3plRFZyYUROcloxQmFiRnBUY0ZodVVHdG9Za3hCZEZRcmVHdElOd296YjI0dmEwOUdkM1ZUUm1KNFdUUTFiRkpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpCTkc1V1NsUmFVa3hIYjNWNVVpOVVWVkpwU25kUFRUZE5NMk5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCT0d4cWJXa3dTMlpUYlRWWldtbHJablJQVG1kNlEwOTRTMVpGT0VSUWVEUllUMEkyT1hFelowODVVek52VWsxVGNncGhVVzlLWTJSMlFXMHJOVzlrVmtwRU4xWnFXamhCVVUxV2FESndOMFVyY1VwNFRYZFJNVkpUVEZWek0xRmtibWRMZDBka1QzQmxhM2cwYVVoMlptdElDbk5qUkhRcmR5dFdjMjk1T1hoMk9DOVpWMFoyTTJwT2FHbzBibU16U0RSMFpVVnVka1ExTmtzemMydG1TRTR2ZEVaQlduUllXRTFrVjNoelJqaFZMemtLTDJaRU5GSmpZV2RRV0VKeWVsSkxjRmxaUW00clJqUmhTMGR4UjNSRWMyOTFWa0VyYzJ0VE1tNUlSV2R2UjJjelQweGpRVm8wYlc0elFqUlFOVWxuYUFwWFlrOWFRMHN6ZVZwaWMxbGFjMUJpWkd3NVpXbHhSRUpvUzBZNFpVcHJXRm96VWxWVFRWVlpkakJHVDBaMmEyOUJjamx3Ynk5dFMwUm9VRU15WVdWeUNrcHFMek5wY1Rrek1HbFhaMEZ0TTJRNVpteFpZMkk0WjI1T2JURnBaMU5UZEhOMGVnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGI4MTdlZC1lZTI2LTRmZDYtYmI2Zi0yOTI1ZjUwOTgxMjUuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1VloxemV4elFPaG1TRjRmOURZU01pbUZsWjZQdDlBM3hrSkFiQlNXVlNwcElZTTR2S2tUY0NzMQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2630"
+      - "2628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:51 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -512,7 +512,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d4586a0-488c-40ef-9ada-00bfc0974cdc
+      - 1d137a0b-c5d1-4c61-8066-72100741805c
     status: 200 OK
     code: 200
     duration: ""
@@ -523,19 +523,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9695b5c8-f87e-4172-805f-afbb4cb27d8b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:43:44.258914Z","dhcp_enabled":true,"id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:44.258914Z","id":"4f19792d-685a-4cf1-bd52-1cb3823f144b","subnet":"172.16.8.0/22","updated_at":"2023-10-18T16:43:44.258914Z"},{"created_at":"2023-10-18T16:43:44.258914Z","id":"51e3553d-0372-4af8-a40c-83dc7752e070","subnet":"fd63:256c:45f7:aefc::/64","updated_at":"2023-10-18T16:43:44.258914Z"}],"tags":[],"updated_at":"2023-10-18T16:43:44.258914Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "717"
+      - "699"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:51 GMT
+      - Tue, 07 Nov 2023 16:20:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -545,7 +545,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d799c3ee-86af-4a35-94be-785bc878b3df
+      - 8c1e0299-4c98-48cd-9ff9-b3cf511a7cb3
     status: 200 OK
     code: 200
     duration: ""
@@ -556,19 +556,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:43:46.705628Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.802278Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1509"
+      - "1464"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:51 GMT
+      - Tue, 07 Nov 2023 16:20:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -578,7 +578,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a14bbee7-c1d3-41c8-943c-503d024f32f9
+      - 71c96ec6-56c8-4dac-bf9b-37bf05c60656
     status: 200 OK
     code: 200
     duration: ""
@@ -589,19 +589,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VGtSTk1FNXNiMWhFVkUxNlRWUkJlRTU2UlRKT1JFMHdUbXh2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRqRnJDa2RRWW01NVdrRnhUa0p6VUhwU2MwVkZSV012VDNsblRITnFTRGhQVmpWQlVFTTVlV2hOZVZnck5GZzVPVVE0VUVrNU5rRkRiVTF2UWpkWWQzSlpjMUlLWkZCVVNVbDZhM1pqY1hFd2VrTnVXSEp0UjFWelVYUmxaRFlyZURob1owVk1hRlo2VDA1eFUzWktlRXgwYXpRdmNUTXpNMUV6TmxaWlVWWXZjaTkyUlFvdlpub3dURGxSSzJ4a1JISjNMM1kzYlROMk5qVjBNMWRvWW5KNk1tRnBkRmR0TVM5RWF6VllWWGxyTDNOblVGUkVTREF6V0hSUlNUUlZZbWxOYlZoakNpdDRlRlZWU2xKUFJuRnpXRTE2VUd0clducFFVMngyZUU5R1ZEWklLMlF5ZW5sTE5WcEdZblJyVWxKS1VuTkdkWEpWWTBNek5qWklkRFpXZEhOU1VVVUtSRWhsTkhNMU1YVkhSRmxaUzJGcVpVbFJSa3ByVTJGU1dIQkxiMHhFZUc5WlNWb3plRFZyYUROcloxQmFiRnBUY0ZodVVHdG9Za3hCZEZRcmVHdElOd296YjI0dmEwOUdkM1ZUUm1KNFdUUTFiRkpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpCTkc1V1NsUmFVa3hIYjNWNVVpOVVWVkpwU25kUFRUZE5NMk5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCT0d4cWJXa3dTMlpUYlRWWldtbHJablJQVG1kNlEwOTRTMVpGT0VSUWVEUllUMEkyT1hFelowODVVek52VWsxVGNncGhVVzlLWTJSMlFXMHJOVzlrVmtwRU4xWnFXamhCVVUxV2FESndOMFVyY1VwNFRYZFJNVkpUVEZWek0xRmtibWRMZDBka1QzQmxhM2cwYVVoMlptdElDbk5qUkhRcmR5dFdjMjk1T1hoMk9DOVpWMFoyTTJwT2FHbzBibU16U0RSMFpVVnVka1ExTmtzemMydG1TRTR2ZEVaQlduUllXRTFrVjNoelJqaFZMemtLTDJaRU5GSmpZV2RRV0VKeWVsSkxjRmxaUW00clJqUmhTMGR4UjNSRWMyOTFWa0VyYzJ0VE1tNUlSV2R2UjJjelQweGpRVm8wYlc0elFqUlFOVWxuYUFwWFlrOWFRMHN6ZVZwaWMxbGFjMUJpWkd3NVpXbHhSRUpvUzBZNFpVcHJXRm96VWxWVFRWVlpkakJHVDBaMmEyOUJjamx3Ynk5dFMwUm9VRU15WVdWeUNrcHFMek5wY1Rrek1HbFhaMEZ0TTJRNVpteFpZMkk0WjI1T2JURnBaMU5UZEhOMGVnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGI4MTdlZC1lZTI2LTRmZDYtYmI2Zi0yOTI1ZjUwOTgxMjUuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1VloxemV4elFPaG1TRjRmOURZU01pbUZsWjZQdDlBM3hrSkFiQlNXVlNwcElZTTR2S2tUY0NzMQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2630"
+      - "2628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:51 GMT
+      - Tue, 07 Nov 2023 16:20:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -611,475 +611,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36539d1f-5cd9-442a-af26-8076ae2e9a9f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
-    method: GET
-  response:
-    body: '{"versions":[{"available_admission_plugins":["AlwaysPullImages","PodNodeSelector","PodTolerationRestriction"],"available_cnis":["cilium","calico","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","SidecarContainers","ValidatingAdmissionPolicy"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
-      1.28.2","name":"1.28.2","region":"fr-par"},{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod","ValidatingAdmissionPolicy","CSINodeExpandSecret"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
-      1.27.6","name":"1.27.6","region":"fr-par"},{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod","ValidatingAdmissionPolicy","CSINodeExpandSecret"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
-      1.26.9","name":"1.26.9","region":"fr-par"},{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod","CSINodeExpandSecret"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
-      1.25.14","name":"1.25.14","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
-      1.24.17","name":"1.24.17","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
-      1.23.17","name":"1.23.17","region":"fr-par"}]}'
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 895c6885-2f6b-4d80-96cc-7efacf332b74
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:43:46.705628Z","upgrade_available":true,"version":"1.27.6"}'
-    headers:
-      Content-Length:
-      - "1509"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1a1b2973-a84c-4191-ae82-03a9fc26f783
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":null,"description":null,"tags":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":null,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":null},"auto_upgrade":{"enable":true,"maintenance_window":null},"feature_gates":null,"admission_plugins":null,"open_id_connect_config":{"issuer_url":null,"client_id":null,"username_claim":null,"username_prefix":null,"groups_claim":null,"groups_prefix":null,"required_claim":null},"apiserver_cert_sans":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
-    method: PATCH
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:43:52.359687661Z","upgrade_available":true,"version":"1.27.6"}'
-    headers:
-      Content-Length:
-      - "1506"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 99508190-0bea-47e5-8562-a0db2d9c9b79
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:43:52.359688Z","upgrade_available":true,"version":"1.27.6"}'
-    headers:
-      Content-Length:
-      - "1503"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 57a5bc6b-8ab3-4efa-80d8-6657cbd8696f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:43:53.481015Z","upgrade_available":true,"version":"1.27.6"}'
-    headers:
-      Content-Length:
-      - "1508"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - db5d1bc3-debb-4101-a156-b981e786878a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:43:53.481015Z","upgrade_available":true,"version":"1.27.6"}'
-    headers:
-      Content-Length:
-      - "1508"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 68735868-8935-4075-aca6-b9c5ed2fa687
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VGtSTk1FNXNiMWhFVkUxNlRWUkJlRTU2UlRKT1JFMHdUbXh2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRqRnJDa2RRWW01NVdrRnhUa0p6VUhwU2MwVkZSV012VDNsblRITnFTRGhQVmpWQlVFTTVlV2hOZVZnck5GZzVPVVE0VUVrNU5rRkRiVTF2UWpkWWQzSlpjMUlLWkZCVVNVbDZhM1pqY1hFd2VrTnVXSEp0UjFWelVYUmxaRFlyZURob1owVk1hRlo2VDA1eFUzWktlRXgwYXpRdmNUTXpNMUV6TmxaWlVWWXZjaTkyUlFvdlpub3dURGxSSzJ4a1JISjNMM1kzYlROMk5qVjBNMWRvWW5KNk1tRnBkRmR0TVM5RWF6VllWWGxyTDNOblVGUkVTREF6V0hSUlNUUlZZbWxOYlZoakNpdDRlRlZWU2xKUFJuRnpXRTE2VUd0clducFFVMngyZUU5R1ZEWklLMlF5ZW5sTE5WcEdZblJyVWxKS1VuTkdkWEpWWTBNek5qWklkRFpXZEhOU1VVVUtSRWhsTkhNMU1YVkhSRmxaUzJGcVpVbFJSa3ByVTJGU1dIQkxiMHhFZUc5WlNWb3plRFZyYUROcloxQmFiRnBUY0ZodVVHdG9Za3hCZEZRcmVHdElOd296YjI0dmEwOUdkM1ZUUm1KNFdUUTFiRkpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpCTkc1V1NsUmFVa3hIYjNWNVVpOVVWVkpwU25kUFRUZE5NMk5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCT0d4cWJXa3dTMlpUYlRWWldtbHJablJQVG1kNlEwOTRTMVpGT0VSUWVEUllUMEkyT1hFelowODVVek52VWsxVGNncGhVVzlLWTJSMlFXMHJOVzlrVmtwRU4xWnFXamhCVVUxV2FESndOMFVyY1VwNFRYZFJNVkpUVEZWek0xRmtibWRMZDBka1QzQmxhM2cwYVVoMlptdElDbk5qUkhRcmR5dFdjMjk1T1hoMk9DOVpWMFoyTTJwT2FHbzBibU16U0RSMFpVVnVka1ExTmtzemMydG1TRTR2ZEVaQlduUllXRTFrVjNoelJqaFZMemtLTDJaRU5GSmpZV2RRV0VKeWVsSkxjRmxaUW00clJqUmhTMGR4UjNSRWMyOTFWa0VyYzJ0VE1tNUlSV2R2UjJjelQweGpRVm8wYlc0elFqUlFOVWxuYUFwWFlrOWFRMHN6ZVZwaWMxbGFjMUJpWkd3NVpXbHhSRUpvUzBZNFpVcHJXRm96VWxWVFRWVlpkakJHVDBaMmEyOUJjamx3Ynk5dFMwUm9VRU15WVdWeUNrcHFMek5wY1Rrek1HbFhaMEZ0TTJRNVpteFpZMkk0WjI1T2JURnBaMU5UZEhOMGVnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGI4MTdlZC1lZTI2LTRmZDYtYmI2Zi0yOTI1ZjUwOTgxMjUuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1VloxemV4elFPaG1TRjRmOURZU01pbUZsWjZQdDlBM3hrSkFiQlNXVlNwcElZTTR2S2tUY0NzMQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2630"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 98374729-2066-4732-9a75-7e2ac8901898
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:43:53.481015Z","upgrade_available":true,"version":"1.27.6"}'
-    headers:
-      Content-Length:
-      - "1508"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ea3e2f80-a0ed-43ac-89c2-167db518a99c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9695b5c8-f87e-4172-805f-afbb4cb27d8b
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-18T16:43:44.258914Z","dhcp_enabled":true,"id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:44.258914Z","id":"4f19792d-685a-4cf1-bd52-1cb3823f144b","subnet":"172.16.8.0/22","updated_at":"2023-10-18T16:43:44.258914Z"},{"created_at":"2023-10-18T16:43:44.258914Z","id":"51e3553d-0372-4af8-a40c-83dc7752e070","subnet":"fd63:256c:45f7:aefc::/64","updated_at":"2023-10-18T16:43:44.258914Z"}],"tags":[],"updated_at":"2023-10-18T16:43:44.258914Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "717"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 250c63ac-8cc6-463f-a8c1-3b408a40407f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:43:53.481015Z","upgrade_available":true,"version":"1.27.6"}'
-    headers:
-      Content-Length:
-      - "1508"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b12adb30-d097-4d16-83fc-63e088691180
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VGtSTk1FNXNiMWhFVkUxNlRWUkJlRTU2UlRKT1JFMHdUbXh2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRqRnJDa2RRWW01NVdrRnhUa0p6VUhwU2MwVkZSV012VDNsblRITnFTRGhQVmpWQlVFTTVlV2hOZVZnck5GZzVPVVE0VUVrNU5rRkRiVTF2UWpkWWQzSlpjMUlLWkZCVVNVbDZhM1pqY1hFd2VrTnVXSEp0UjFWelVYUmxaRFlyZURob1owVk1hRlo2VDA1eFUzWktlRXgwYXpRdmNUTXpNMUV6TmxaWlVWWXZjaTkyUlFvdlpub3dURGxSSzJ4a1JISjNMM1kzYlROMk5qVjBNMWRvWW5KNk1tRnBkRmR0TVM5RWF6VllWWGxyTDNOblVGUkVTREF6V0hSUlNUUlZZbWxOYlZoakNpdDRlRlZWU2xKUFJuRnpXRTE2VUd0clducFFVMngyZUU5R1ZEWklLMlF5ZW5sTE5WcEdZblJyVWxKS1VuTkdkWEpWWTBNek5qWklkRFpXZEhOU1VVVUtSRWhsTkhNMU1YVkhSRmxaUzJGcVpVbFJSa3ByVTJGU1dIQkxiMHhFZUc5WlNWb3plRFZyYUROcloxQmFiRnBUY0ZodVVHdG9Za3hCZEZRcmVHdElOd296YjI0dmEwOUdkM1ZUUm1KNFdUUTFiRkpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpCTkc1V1NsUmFVa3hIYjNWNVVpOVVWVkpwU25kUFRUZE5NMk5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCT0d4cWJXa3dTMlpUYlRWWldtbHJablJQVG1kNlEwOTRTMVpGT0VSUWVEUllUMEkyT1hFelowODVVek52VWsxVGNncGhVVzlLWTJSMlFXMHJOVzlrVmtwRU4xWnFXamhCVVUxV2FESndOMFVyY1VwNFRYZFJNVkpUVEZWek0xRmtibWRMZDBka1QzQmxhM2cwYVVoMlptdElDbk5qUkhRcmR5dFdjMjk1T1hoMk9DOVpWMFoyTTJwT2FHbzBibU16U0RSMFpVVnVka1ExTmtzemMydG1TRTR2ZEVaQlduUllXRTFrVjNoelJqaFZMemtLTDJaRU5GSmpZV2RRV0VKeWVsSkxjRmxaUW00clJqUmhTMGR4UjNSRWMyOTFWa0VyYzJ0VE1tNUlSV2R2UjJjelQweGpRVm8wYlc0elFqUlFOVWxuYUFwWFlrOWFRMHN6ZVZwaWMxbGFjMUJpWkd3NVpXbHhSRUpvUzBZNFpVcHJXRm96VWxWVFRWVlpkakJHVDBaMmEyOUJjamx3Ynk5dFMwUm9VRU15WVdWeUNrcHFMek5wY1Rrek1HbFhaMEZ0TTJRNVpteFpZMkk0WjI1T2JURnBaMU5UZEhOMGVnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGI4MTdlZC1lZTI2LTRmZDYtYmI2Zi0yOTI1ZjUwOTgxMjUuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1VloxemV4elFPaG1TRjRmOURZU01pbUZsWjZQdDlBM3hrSkFiQlNXVlNwcElZTTR2S2tUY0NzMQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2630"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 82b80e94-a683-40f7-96b6-5cfec414403f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9695b5c8-f87e-4172-805f-afbb4cb27d8b
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-18T16:43:44.258914Z","dhcp_enabled":true,"id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:44.258914Z","id":"4f19792d-685a-4cf1-bd52-1cb3823f144b","subnet":"172.16.8.0/22","updated_at":"2023-10-18T16:43:44.258914Z"},{"created_at":"2023-10-18T16:43:44.258914Z","id":"51e3553d-0372-4af8-a40c-83dc7752e070","subnet":"fd63:256c:45f7:aefc::/64","updated_at":"2023-10-18T16:43:44.258914Z"}],"tags":[],"updated_at":"2023-10-18T16:43:44.258914Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "717"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f5609f4f-a0c9-479c-ae3d-7c151f06df75
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:43:53.481015Z","upgrade_available":true,"version":"1.27.6"}'
-    headers:
-      Content-Length:
-      - "1508"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d5a2e419-3c9c-4bfa-8ed0-ee403e6a5a20
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VGtSTk1FNXNiMWhFVkUxNlRWUkJlRTU2UlRKT1JFMHdUbXh2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRqRnJDa2RRWW01NVdrRnhUa0p6VUhwU2MwVkZSV012VDNsblRITnFTRGhQVmpWQlVFTTVlV2hOZVZnck5GZzVPVVE0VUVrNU5rRkRiVTF2UWpkWWQzSlpjMUlLWkZCVVNVbDZhM1pqY1hFd2VrTnVXSEp0UjFWelVYUmxaRFlyZURob1owVk1hRlo2VDA1eFUzWktlRXgwYXpRdmNUTXpNMUV6TmxaWlVWWXZjaTkyUlFvdlpub3dURGxSSzJ4a1JISjNMM1kzYlROMk5qVjBNMWRvWW5KNk1tRnBkRmR0TVM5RWF6VllWWGxyTDNOblVGUkVTREF6V0hSUlNUUlZZbWxOYlZoakNpdDRlRlZWU2xKUFJuRnpXRTE2VUd0clducFFVMngyZUU5R1ZEWklLMlF5ZW5sTE5WcEdZblJyVWxKS1VuTkdkWEpWWTBNek5qWklkRFpXZEhOU1VVVUtSRWhsTkhNMU1YVkhSRmxaUzJGcVpVbFJSa3ByVTJGU1dIQkxiMHhFZUc5WlNWb3plRFZyYUROcloxQmFiRnBUY0ZodVVHdG9Za3hCZEZRcmVHdElOd296YjI0dmEwOUdkM1ZUUm1KNFdUUTFiRkpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpCTkc1V1NsUmFVa3hIYjNWNVVpOVVWVkpwU25kUFRUZE5NMk5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCT0d4cWJXa3dTMlpUYlRWWldtbHJablJQVG1kNlEwOTRTMVpGT0VSUWVEUllUMEkyT1hFelowODVVek52VWsxVGNncGhVVzlLWTJSMlFXMHJOVzlrVmtwRU4xWnFXamhCVVUxV2FESndOMFVyY1VwNFRYZFJNVkpUVEZWek0xRmtibWRMZDBka1QzQmxhM2cwYVVoMlptdElDbk5qUkhRcmR5dFdjMjk1T1hoMk9DOVpWMFoyTTJwT2FHbzBibU16U0RSMFpVVnVka1ExTmtzemMydG1TRTR2ZEVaQlduUllXRTFrVjNoelJqaFZMemtLTDJaRU5GSmpZV2RRV0VKeWVsSkxjRmxaUW00clJqUmhTMGR4UjNSRWMyOTFWa0VyYzJ0VE1tNUlSV2R2UjJjelQweGpRVm8wYlc0elFqUlFOVWxuYUFwWFlrOWFRMHN6ZVZwaWMxbGFjMUJpWkd3NVpXbHhSRUpvUzBZNFpVcHJXRm96VWxWVFRWVlpkakJHVDBaMmEyOUJjamx3Ynk5dFMwUm9VRU15WVdWeUNrcHFMek5wY1Rrek1HbFhaMEZ0TTJRNVpteFpZMkk0WjI1T2JURnBaMU5UZEhOMGVnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGI4MTdlZC1lZTI2LTRmZDYtYmI2Zi0yOTI1ZjUwOTgxMjUuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1VloxemV4elFPaG1TRjRmOURZU01pbUZsWjZQdDlBM3hrSkFiQlNXVlNwcElZTTR2S2tUY0NzMQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2630"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 182fe764-81d8-4cce-869b-18c275c5b135
+      - e17a19a7-c93c-4dfc-a4c5-8a3abdea92c4
     status: 200 OK
     code: 200
     duration: ""
@@ -1106,7 +638,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:59 GMT
+      - Tue, 07 Nov 2023 16:20:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1116,7 +648,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30e9237f-2ccb-431c-8af7-f4c1bb7ac1a4
+      - 5a836999-5282-421c-b791-3c80a924e94e
     status: 200 OK
     code: 200
     duration: ""
@@ -1127,19 +659,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:43:53.481015Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.802278Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1508"
+      - "1464"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:59 GMT
+      - Tue, 07 Nov 2023 16:20:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1149,12 +681,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66b18a48-d931-4e5c-9e06-97abd0b78ed9
+      - 88de29ad-7328-4c08-9695-7c9ce1311dbe
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":null,"description":null,"tags":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":null,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":null},"auto_upgrade":{"enable":null,"maintenance_window":null},"feature_gates":null,"admission_plugins":null,"open_id_connect_config":{"issuer_url":null,"client_id":null,"username_claim":null,"username_prefix":null,"groups_claim":null,"groups_prefix":null,"required_claim":null},"apiserver_cert_sans":null}'
+    body: '{"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":null,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":null},"auto_upgrade":{"enable":true,"maintenance_window":null},"open_id_connect_config":{"issuer_url":null,"client_id":null,"username_claim":null,"username_prefix":null,"groups_claim":null,"groups_prefix":null,"required_claim":null}}'
     form: {}
     headers:
       Content-Type:
@@ -1162,19 +694,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:43:59.941922296Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:08.253288979Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1506"
+      - "1461"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:59 GMT
+      - Tue, 07 Nov 2023 16:20:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1184,7 +716,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8c4cf96-010e-4432-98db-87a523d17f93
+      - df971082-3bd9-4ba5-bfcf-4f10d9d291fc
     status: 200 OK
     code: 200
     duration: ""
@@ -1195,19 +727,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:43:59.941922Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:08.253289Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1503"
+      - "1458"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:00 GMT
+      - Tue, 07 Nov 2023 16:20:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1217,7 +749,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 324f0076-38c6-4b12-a492-9fcb547bfda5
+      - 7ef1e83d-7e89-4125-8e41-e44464560035
     status: 200 OK
     code: 200
     duration: ""
@@ -1228,19 +760,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:01.062120Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:09.405391Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1508"
+      - "1463"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:05 GMT
+      - Tue, 07 Nov 2023 16:20:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1250,7 +782,475 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f69f12ad-60ee-479e-a451-fc61afd99e0e
+      - 9168901f-b7fe-46ce-a5be-4c009f35325d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:09.405391Z","upgrade_available":true,"version":"1.27.6"}'
+    headers:
+      Content-Length:
+      - "1463"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:20:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d785cb5f-02d5-4772-8d35-841e23b3014d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:20:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 41b25aac-5d5b-47e2-ac4e-a291a89fdabd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:09.405391Z","upgrade_available":true,"version":"1.27.6"}'
+    headers:
+      Content-Length:
+      - "1463"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:20:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d6733f91-e1be-4002-84c7-bffcf891e680
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
+    method: GET
+  response:
+    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "699"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:20:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a1cf5514-886f-466e-a154-87317361932c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:09.405391Z","upgrade_available":true,"version":"1.27.6"}'
+    headers:
+      Content-Length:
+      - "1463"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:20:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 454f1697-43b0-40ab-9488-eecfee77dc91
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:20:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f9707fb0-fd8c-49ab-a7f7-0cfed886a96a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
+    method: GET
+  response:
+    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "699"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:20:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 92b8f13f-4424-40a3-9229-9fcfe0e8134d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:09.405391Z","upgrade_available":true,"version":"1.27.6"}'
+    headers:
+      Content-Length:
+      - "1463"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:20:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 657bf7bc-7a2c-4ae5-8787-28c9a301acf4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:20:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4a2485e8-02fb-47c8-b4dd-f1c7533fbe1e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/versions
+    method: GET
+  response:
+    body: '{"versions":[{"available_admission_plugins":["AlwaysPullImages","PodNodeSelector","PodTolerationRestriction"],"available_cnis":["cilium","calico","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","SidecarContainers","ValidatingAdmissionPolicy"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.28.2","name":"1.28.2","region":"fr-par"},{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod","ValidatingAdmissionPolicy","CSINodeExpandSecret"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.27.6","name":"1.27.6","region":"fr-par"},{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","GRPCContainerProbe","ReadWriteOncePod","ValidatingAdmissionPolicy","CSINodeExpandSecret"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.26.9","name":"1.26.9","region":"fr-par"},{"available_admission_plugins":["PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod","CSINodeExpandSecret"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.25.14","name":"1.25.14","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe","ReadWriteOncePod"],"available_ingresses":["none"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.24.17","name":"1.24.17","region":"fr-par"},{"available_admission_plugins":["PodSecurityPolicy","PodNodeSelector","AlwaysPullImages","PodTolerationRestriction"],"available_cnis":["cilium","calico","weave","flannel","kilo"],"available_container_runtimes":["containerd"],"available_feature_gates":["HPAScaleToZero","EphemeralContainers","KubeletCredentialProviders","GRPCContainerProbe"],"available_ingresses":["none","nginx","traefik2"],"available_kubelet_args":{"containerLogMaxFiles":"uint16","containerLogMaxSize":"quantity","cpuCFSQuota":"bool","cpuCFSQuotaPeriod":"duration","cpuManagerPolicy":"enum:none|static","enableDebuggingHandlers":"bool","imageGCHighThresholdPercent":"uint32","imageGCLowThresholdPercent":"uint32","maxPods":"uint16"},"label":"Kubernetes
+      1.23.17","name":"1.23.17","region":"fr-par"}]}'
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:20:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 77c144d5-643a-4979-a390-8e605aa3719f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:09.405391Z","upgrade_available":true,"version":"1.27.6"}'
+    headers:
+      Content-Length:
+      - "1463"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:20:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8ec19da2-ca13-45bc-99a3-941a0ab58cd2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":null,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":null},"auto_upgrade":{"enable":null,"maintenance_window":null},"open_id_connect_config":{"issuer_url":null,"client_id":null,"username_claim":null,"username_prefix":null,"groups_claim":null,"groups_prefix":null,"required_claim":null}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    method: PATCH
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:16.388844462Z","upgrade_available":true,"version":"1.27.6"}'
+    headers:
+      Content-Length:
+      - "1461"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:20:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6788d37e-2095-4e8b-bb37-8eccc7d7da9f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:16.388844Z","upgrade_available":true,"version":"1.27.6"}'
+    headers:
+      Content-Length:
+      - "1458"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:20:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 251c5b1f-e2e4-4324-aa93-c1cc5eaef8af
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:18.690666Z","upgrade_available":true,"version":"1.27.6"}'
+    headers:
+      Content-Length:
+      - "1463"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:20:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b7d64495-f7a5-495d-8bb7-7cbbeeaf7f9a
     status: 200 OK
     code: 200
     duration: ""
@@ -1263,19 +1263,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125/upgrade
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/upgrade
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:05.096327255Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:22.100507845Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1507"
+      - "1462"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:05 GMT
+      - Tue, 07 Nov 2023 16:20:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1285,7 +1285,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f69691a-c259-40ac-983e-bde8b12ef725
+      - 5c11d204-1c77-455e-ad07-1beab1b6d8a9
     status: 200 OK
     code: 200
     duration: ""
@@ -1296,19 +1296,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:05.096327Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:22.100508Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1504"
+      - "1459"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:05 GMT
+      - Tue, 07 Nov 2023 16:20:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1318,7 +1318,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fdc3fdf7-1dbe-4659-9bc2-d292be052192
+      - 4ac505b7-0f4c-4472-bb97-40e6630fc7b4
     status: 200 OK
     code: 200
     duration: ""
@@ -1329,19 +1329,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:06.207284Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:23.703504Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1509"
+      - "1464"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:10 GMT
+      - Tue, 07 Nov 2023 16:20:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1351,7 +1351,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10a4d3bc-9593-4a17-907d-c9e8859531b3
+      - c6749c05-7314-4d14-92b3-60ba154ea165
     status: 200 OK
     code: 200
     duration: ""
@@ -1362,19 +1362,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:06.207284Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:23.703504Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1509"
+      - "1464"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:10 GMT
+      - Tue, 07 Nov 2023 16:20:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1384,7 +1384,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17c3e664-4826-4e21-9731-8a19dd3a3c20
+      - a71615b7-27d7-458f-a687-9f79918430d8
     status: 200 OK
     code: 200
     duration: ""
@@ -1395,19 +1395,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VGtSTk1FNXNiMWhFVkUxNlRWUkJlRTU2UlRKT1JFMHdUbXh2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRqRnJDa2RRWW01NVdrRnhUa0p6VUhwU2MwVkZSV012VDNsblRITnFTRGhQVmpWQlVFTTVlV2hOZVZnck5GZzVPVVE0VUVrNU5rRkRiVTF2UWpkWWQzSlpjMUlLWkZCVVNVbDZhM1pqY1hFd2VrTnVXSEp0UjFWelVYUmxaRFlyZURob1owVk1hRlo2VDA1eFUzWktlRXgwYXpRdmNUTXpNMUV6TmxaWlVWWXZjaTkyUlFvdlpub3dURGxSSzJ4a1JISjNMM1kzYlROMk5qVjBNMWRvWW5KNk1tRnBkRmR0TVM5RWF6VllWWGxyTDNOblVGUkVTREF6V0hSUlNUUlZZbWxOYlZoakNpdDRlRlZWU2xKUFJuRnpXRTE2VUd0clducFFVMngyZUU5R1ZEWklLMlF5ZW5sTE5WcEdZblJyVWxKS1VuTkdkWEpWWTBNek5qWklkRFpXZEhOU1VVVUtSRWhsTkhNMU1YVkhSRmxaUzJGcVpVbFJSa3ByVTJGU1dIQkxiMHhFZUc5WlNWb3plRFZyYUROcloxQmFiRnBUY0ZodVVHdG9Za3hCZEZRcmVHdElOd296YjI0dmEwOUdkM1ZUUm1KNFdUUTFiRkpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpCTkc1V1NsUmFVa3hIYjNWNVVpOVVWVkpwU25kUFRUZE5NMk5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCT0d4cWJXa3dTMlpUYlRWWldtbHJablJQVG1kNlEwOTRTMVpGT0VSUWVEUllUMEkyT1hFelowODVVek52VWsxVGNncGhVVzlLWTJSMlFXMHJOVzlrVmtwRU4xWnFXamhCVVUxV2FESndOMFVyY1VwNFRYZFJNVkpUVEZWek0xRmtibWRMZDBka1QzQmxhM2cwYVVoMlptdElDbk5qUkhRcmR5dFdjMjk1T1hoMk9DOVpWMFoyTTJwT2FHbzBibU16U0RSMFpVVnVka1ExTmtzemMydG1TRTR2ZEVaQlduUllXRTFrVjNoelJqaFZMemtLTDJaRU5GSmpZV2RRV0VKeWVsSkxjRmxaUW00clJqUmhTMGR4UjNSRWMyOTFWa0VyYzJ0VE1tNUlSV2R2UjJjelQweGpRVm8wYlc0elFqUlFOVWxuYUFwWFlrOWFRMHN6ZVZwaWMxbGFjMUJpWkd3NVpXbHhSRUpvUzBZNFpVcHJXRm96VWxWVFRWVlpkakJHVDBaMmEyOUJjamx3Ynk5dFMwUm9VRU15WVdWeUNrcHFMek5wY1Rrek1HbFhaMEZ0TTJRNVpteFpZMkk0WjI1T2JURnBaMU5UZEhOMGVnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGI4MTdlZC1lZTI2LTRmZDYtYmI2Zi0yOTI1ZjUwOTgxMjUuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1VloxemV4elFPaG1TRjRmOURZU01pbUZsWjZQdDlBM3hrSkFiQlNXVlNwcElZTTR2S2tUY0NzMQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2630"
+      - "2628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:10 GMT
+      - Tue, 07 Nov 2023 16:20:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1417,7 +1417,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c338f40f-f6dc-483b-88cd-3c50d9b04d03
+      - cb07995f-09b7-4dc6-8e42-d9378f3006f0
     status: 200 OK
     code: 200
     duration: ""
@@ -1428,19 +1428,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:06.207284Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:23.703504Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1509"
+      - "1464"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:10 GMT
+      - Tue, 07 Nov 2023 16:20:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1450,7 +1450,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6ef67b0-0a2b-434d-aca1-ca08b53f371a
+      - d3c9ac74-0f05-4860-abc4-5c36f0d4f4bd
     status: 200 OK
     code: 200
     duration: ""
@@ -1461,19 +1461,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9695b5c8-f87e-4172-805f-afbb4cb27d8b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:43:44.258914Z","dhcp_enabled":true,"id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:44.258914Z","id":"4f19792d-685a-4cf1-bd52-1cb3823f144b","subnet":"172.16.8.0/22","updated_at":"2023-10-18T16:43:44.258914Z"},{"created_at":"2023-10-18T16:43:44.258914Z","id":"51e3553d-0372-4af8-a40c-83dc7752e070","subnet":"fd63:256c:45f7:aefc::/64","updated_at":"2023-10-18T16:43:44.258914Z"}],"tags":[],"updated_at":"2023-10-18T16:43:44.258914Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "717"
+      - "699"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:10 GMT
+      - Tue, 07 Nov 2023 16:20:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1483,7 +1483,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3063cba1-bf4f-4a43-821c-7949cb7e8b3f
+      - 21100362-c1a6-42ac-ac4a-f963f9bc4bf8
     status: 200 OK
     code: 200
     duration: ""
@@ -1494,19 +1494,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:06.207284Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:23.703504Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1509"
+      - "1464"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:10 GMT
+      - Tue, 07 Nov 2023 16:20:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1516,7 +1516,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ad81d50-c6c0-42d2-b4bb-c7680667ea03
+      - c1e96cf1-70e6-4e20-bb2d-2b88e27430b5
     status: 200 OK
     code: 200
     duration: ""
@@ -1527,19 +1527,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VGtSTk1FNXNiMWhFVkUxNlRWUkJlRTU2UlRKT1JFMHdUbXh2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRqRnJDa2RRWW01NVdrRnhUa0p6VUhwU2MwVkZSV012VDNsblRITnFTRGhQVmpWQlVFTTVlV2hOZVZnck5GZzVPVVE0VUVrNU5rRkRiVTF2UWpkWWQzSlpjMUlLWkZCVVNVbDZhM1pqY1hFd2VrTnVXSEp0UjFWelVYUmxaRFlyZURob1owVk1hRlo2VDA1eFUzWktlRXgwYXpRdmNUTXpNMUV6TmxaWlVWWXZjaTkyUlFvdlpub3dURGxSSzJ4a1JISjNMM1kzYlROMk5qVjBNMWRvWW5KNk1tRnBkRmR0TVM5RWF6VllWWGxyTDNOblVGUkVTREF6V0hSUlNUUlZZbWxOYlZoakNpdDRlRlZWU2xKUFJuRnpXRTE2VUd0clducFFVMngyZUU5R1ZEWklLMlF5ZW5sTE5WcEdZblJyVWxKS1VuTkdkWEpWWTBNek5qWklkRFpXZEhOU1VVVUtSRWhsTkhNMU1YVkhSRmxaUzJGcVpVbFJSa3ByVTJGU1dIQkxiMHhFZUc5WlNWb3plRFZyYUROcloxQmFiRnBUY0ZodVVHdG9Za3hCZEZRcmVHdElOd296YjI0dmEwOUdkM1ZUUm1KNFdUUTFiRkpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpCTkc1V1NsUmFVa3hIYjNWNVVpOVVWVkpwU25kUFRUZE5NMk5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCT0d4cWJXa3dTMlpUYlRWWldtbHJablJQVG1kNlEwOTRTMVpGT0VSUWVEUllUMEkyT1hFelowODVVek52VWsxVGNncGhVVzlLWTJSMlFXMHJOVzlrVmtwRU4xWnFXamhCVVUxV2FESndOMFVyY1VwNFRYZFJNVkpUVEZWek0xRmtibWRMZDBka1QzQmxhM2cwYVVoMlptdElDbk5qUkhRcmR5dFdjMjk1T1hoMk9DOVpWMFoyTTJwT2FHbzBibU16U0RSMFpVVnVka1ExTmtzemMydG1TRTR2ZEVaQlduUllXRTFrVjNoelJqaFZMemtLTDJaRU5GSmpZV2RRV0VKeWVsSkxjRmxaUW00clJqUmhTMGR4UjNSRWMyOTFWa0VyYzJ0VE1tNUlSV2R2UjJjelQweGpRVm8wYlc0elFqUlFOVWxuYUFwWFlrOWFRMHN6ZVZwaWMxbGFjMUJpWkd3NVpXbHhSRUpvUzBZNFpVcHJXRm96VWxWVFRWVlpkakJHVDBaMmEyOUJjamx3Ynk5dFMwUm9VRU15WVdWeUNrcHFMek5wY1Rrek1HbFhaMEZ0TTJRNVpteFpZMkk0WjI1T2JURnBaMU5UZEhOMGVnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGI4MTdlZC1lZTI2LTRmZDYtYmI2Zi0yOTI1ZjUwOTgxMjUuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1VloxemV4elFPaG1TRjRmOURZU01pbUZsWjZQdDlBM3hrSkFiQlNXVlNwcElZTTR2S2tUY0NzMQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2630"
+      - "2628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:10 GMT
+      - Tue, 07 Nov 2023 16:20:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1549,7 +1549,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd197cd4-3116-4d73-999e-1047751b214f
+      - 579b4d0f-20a0-4d66-848b-8fb7cf0c4557
     status: 200 OK
     code: 200
     duration: ""
@@ -1560,19 +1560,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9695b5c8-f87e-4172-805f-afbb4cb27d8b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:43:44.258914Z","dhcp_enabled":true,"id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:44.258914Z","id":"4f19792d-685a-4cf1-bd52-1cb3823f144b","subnet":"172.16.8.0/22","updated_at":"2023-10-18T16:43:44.258914Z"},{"created_at":"2023-10-18T16:43:44.258914Z","id":"51e3553d-0372-4af8-a40c-83dc7752e070","subnet":"fd63:256c:45f7:aefc::/64","updated_at":"2023-10-18T16:43:44.258914Z"}],"tags":[],"updated_at":"2023-10-18T16:43:44.258914Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "717"
+      - "699"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:11 GMT
+      - Tue, 07 Nov 2023 16:20:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1582,7 +1582,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7fe90f0-920e-4047-bbae-40b035f45d34
+      - 88cbe7e5-913e-4269-86a1-94043c892292
     status: 200 OK
     code: 200
     duration: ""
@@ -1593,19 +1593,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:06.207284Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:23.703504Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1509"
+      - "1464"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:11 GMT
+      - Tue, 07 Nov 2023 16:20:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1615,7 +1615,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60439596-2f43-4d71-af77-d6f23ba9f9c3
+      - 1f6e3ed3-8c2e-4f74-830c-87b93276ab75
     status: 200 OK
     code: 200
     duration: ""
@@ -1626,19 +1626,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VGtSTk1FNXNiMWhFVkUxNlRWUkJlRTU2UlRKT1JFMHdUbXh2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRqRnJDa2RRWW01NVdrRnhUa0p6VUhwU2MwVkZSV012VDNsblRITnFTRGhQVmpWQlVFTTVlV2hOZVZnck5GZzVPVVE0VUVrNU5rRkRiVTF2UWpkWWQzSlpjMUlLWkZCVVNVbDZhM1pqY1hFd2VrTnVXSEp0UjFWelVYUmxaRFlyZURob1owVk1hRlo2VDA1eFUzWktlRXgwYXpRdmNUTXpNMUV6TmxaWlVWWXZjaTkyUlFvdlpub3dURGxSSzJ4a1JISjNMM1kzYlROMk5qVjBNMWRvWW5KNk1tRnBkRmR0TVM5RWF6VllWWGxyTDNOblVGUkVTREF6V0hSUlNUUlZZbWxOYlZoakNpdDRlRlZWU2xKUFJuRnpXRTE2VUd0clducFFVMngyZUU5R1ZEWklLMlF5ZW5sTE5WcEdZblJyVWxKS1VuTkdkWEpWWTBNek5qWklkRFpXZEhOU1VVVUtSRWhsTkhNMU1YVkhSRmxaUzJGcVpVbFJSa3ByVTJGU1dIQkxiMHhFZUc5WlNWb3plRFZyYUROcloxQmFiRnBUY0ZodVVHdG9Za3hCZEZRcmVHdElOd296YjI0dmEwOUdkM1ZUUm1KNFdUUTFiRkpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpCTkc1V1NsUmFVa3hIYjNWNVVpOVVWVkpwU25kUFRUZE5NMk5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCT0d4cWJXa3dTMlpUYlRWWldtbHJablJQVG1kNlEwOTRTMVpGT0VSUWVEUllUMEkyT1hFelowODVVek52VWsxVGNncGhVVzlLWTJSMlFXMHJOVzlrVmtwRU4xWnFXamhCVVUxV2FESndOMFVyY1VwNFRYZFJNVkpUVEZWek0xRmtibWRMZDBka1QzQmxhM2cwYVVoMlptdElDbk5qUkhRcmR5dFdjMjk1T1hoMk9DOVpWMFoyTTJwT2FHbzBibU16U0RSMFpVVnVka1ExTmtzemMydG1TRTR2ZEVaQlduUllXRTFrVjNoelJqaFZMemtLTDJaRU5GSmpZV2RRV0VKeWVsSkxjRmxaUW00clJqUmhTMGR4UjNSRWMyOTFWa0VyYzJ0VE1tNUlSV2R2UjJjelQweGpRVm8wYlc0elFqUlFOVWxuYUFwWFlrOWFRMHN6ZVZwaWMxbGFjMUJpWkd3NVpXbHhSRUpvUzBZNFpVcHJXRm96VWxWVFRWVlpkakJHVDBaMmEyOUJjamx3Ynk5dFMwUm9VRU15WVdWeUNrcHFMek5wY1Rrek1HbFhaMEZ0TTJRNVpteFpZMkk0WjI1T2JURnBaMU5UZEhOMGVnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGI4MTdlZC1lZTI2LTRmZDYtYmI2Zi0yOTI1ZjUwOTgxMjUuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1VloxemV4elFPaG1TRjRmOURZU01pbUZsWjZQdDlBM3hrSkFiQlNXVlNwcElZTTR2S2tUY0NzMQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2630"
+      - "2628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:11 GMT
+      - Tue, 07 Nov 2023 16:20:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1648,7 +1648,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2acbd9f4-3865-4518-87b9-59dfcb60c719
+      - 61592b6a-bc71-4cd0-92fd-7ee5373c17f2
     status: 200 OK
     code: 200
     duration: ""
@@ -1659,19 +1659,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:06.207284Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:23.703504Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1509"
+      - "1464"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:11 GMT
+      - Tue, 07 Nov 2023 16:20:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1681,12 +1681,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3135278-2b4c-4f5c-adfa-da92a1f919a9
+      - 959b45cc-df6f-4f6f-8253-5fe935fa7423
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":null,"description":null,"tags":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":null,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":null},"auto_upgrade":{"enable":false,"maintenance_window":null},"feature_gates":null,"admission_plugins":null,"open_id_connect_config":{"issuer_url":null,"client_id":null,"username_claim":null,"username_prefix":null,"groups_claim":null,"groups_prefix":null,"required_claim":null},"apiserver_cert_sans":null}'
+    body: '{"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":null,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":null},"auto_upgrade":{"enable":false,"maintenance_window":null},"open_id_connect_config":{"issuer_url":null,"client_id":null,"username_claim":null,"username_prefix":null,"groups_claim":null,"groups_prefix":null,"required_claim":null}}'
     form: {}
     headers:
       Content-Type:
@@ -1694,19 +1694,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:11.984657595Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:32.345322806Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1508"
+      - "1463"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:12 GMT
+      - Tue, 07 Nov 2023 16:20:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1716,7 +1716,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1e05540-4b1e-47f0-ae61-2aea7c751c39
+      - e652cf10-9c9e-4839-9b38-625f8ffd7b01
     status: 200 OK
     code: 200
     duration: ""
@@ -1727,19 +1727,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:11.984658Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:32.345323Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1505"
+      - "1460"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:12 GMT
+      - Tue, 07 Nov 2023 16:20:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1749,7 +1749,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f41d352-f919-4b0d-8ca9-65fa3242d83f
+      - 5c457f15-36d2-466d-9752-305ac7357a5e
     status: 200 OK
     code: 200
     duration: ""
@@ -1760,19 +1760,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:13.133374Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:33.465477Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1510"
+      - "1465"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:17 GMT
+      - Tue, 07 Nov 2023 16:20:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1782,7 +1782,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aded49db-51b8-4eed-a529-8d2ec331dbf6
+      - 62a912b6-33b6-4936-a093-2626674001f7
     status: 200 OK
     code: 200
     duration: ""
@@ -1793,19 +1793,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:13.133374Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:33.465477Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1510"
+      - "1465"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:17 GMT
+      - Tue, 07 Nov 2023 16:20:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1815,7 +1815,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4295e5f2-ca7d-4114-8a7d-1ffa78fe6bf0
+      - 9dcaaa54-e41e-46c2-a8ba-917de3445f77
     status: 200 OK
     code: 200
     duration: ""
@@ -1826,19 +1826,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VGtSTk1FNXNiMWhFVkUxNlRWUkJlRTU2UlRKT1JFMHdUbXh2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRqRnJDa2RRWW01NVdrRnhUa0p6VUhwU2MwVkZSV012VDNsblRITnFTRGhQVmpWQlVFTTVlV2hOZVZnck5GZzVPVVE0VUVrNU5rRkRiVTF2UWpkWWQzSlpjMUlLWkZCVVNVbDZhM1pqY1hFd2VrTnVXSEp0UjFWelVYUmxaRFlyZURob1owVk1hRlo2VDA1eFUzWktlRXgwYXpRdmNUTXpNMUV6TmxaWlVWWXZjaTkyUlFvdlpub3dURGxSSzJ4a1JISjNMM1kzYlROMk5qVjBNMWRvWW5KNk1tRnBkRmR0TVM5RWF6VllWWGxyTDNOblVGUkVTREF6V0hSUlNUUlZZbWxOYlZoakNpdDRlRlZWU2xKUFJuRnpXRTE2VUd0clducFFVMngyZUU5R1ZEWklLMlF5ZW5sTE5WcEdZblJyVWxKS1VuTkdkWEpWWTBNek5qWklkRFpXZEhOU1VVVUtSRWhsTkhNMU1YVkhSRmxaUzJGcVpVbFJSa3ByVTJGU1dIQkxiMHhFZUc5WlNWb3plRFZyYUROcloxQmFiRnBUY0ZodVVHdG9Za3hCZEZRcmVHdElOd296YjI0dmEwOUdkM1ZUUm1KNFdUUTFiRkpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpCTkc1V1NsUmFVa3hIYjNWNVVpOVVWVkpwU25kUFRUZE5NMk5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCT0d4cWJXa3dTMlpUYlRWWldtbHJablJQVG1kNlEwOTRTMVpGT0VSUWVEUllUMEkyT1hFelowODVVek52VWsxVGNncGhVVzlLWTJSMlFXMHJOVzlrVmtwRU4xWnFXamhCVVUxV2FESndOMFVyY1VwNFRYZFJNVkpUVEZWek0xRmtibWRMZDBka1QzQmxhM2cwYVVoMlptdElDbk5qUkhRcmR5dFdjMjk1T1hoMk9DOVpWMFoyTTJwT2FHbzBibU16U0RSMFpVVnVka1ExTmtzemMydG1TRTR2ZEVaQlduUllXRTFrVjNoelJqaFZMemtLTDJaRU5GSmpZV2RRV0VKeWVsSkxjRmxaUW00clJqUmhTMGR4UjNSRWMyOTFWa0VyYzJ0VE1tNUlSV2R2UjJjelQweGpRVm8wYlc0elFqUlFOVWxuYUFwWFlrOWFRMHN6ZVZwaWMxbGFjMUJpWkd3NVpXbHhSRUpvUzBZNFpVcHJXRm96VWxWVFRWVlpkakJHVDBaMmEyOUJjamx3Ynk5dFMwUm9VRU15WVdWeUNrcHFMek5wY1Rrek1HbFhaMEZ0TTJRNVpteFpZMkk0WjI1T2JURnBaMU5UZEhOMGVnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGI4MTdlZC1lZTI2LTRmZDYtYmI2Zi0yOTI1ZjUwOTgxMjUuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1VloxemV4elFPaG1TRjRmOURZU01pbUZsWjZQdDlBM3hrSkFiQlNXVlNwcElZTTR2S2tUY0NzMQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2630"
+      - "2628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:17 GMT
+      - Tue, 07 Nov 2023 16:20:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1848,7 +1848,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50f7e129-0910-454a-88f6-0dcc925d35a8
+      - 4fbba46f-923a-4cca-adf9-b3ea9e252769
     status: 200 OK
     code: 200
     duration: ""
@@ -1859,19 +1859,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:13.133374Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:33.465477Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1510"
+      - "1465"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:17 GMT
+      - Tue, 07 Nov 2023 16:20:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1881,7 +1881,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9bdd924d-7b4f-4e83-929c-870a6415ea7b
+      - f69828d6-eda5-4f7a-8e53-088cf5dbfda4
     status: 200 OK
     code: 200
     duration: ""
@@ -1892,19 +1892,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9695b5c8-f87e-4172-805f-afbb4cb27d8b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:43:44.258914Z","dhcp_enabled":true,"id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:44.258914Z","id":"4f19792d-685a-4cf1-bd52-1cb3823f144b","subnet":"172.16.8.0/22","updated_at":"2023-10-18T16:43:44.258914Z"},{"created_at":"2023-10-18T16:43:44.258914Z","id":"51e3553d-0372-4af8-a40c-83dc7752e070","subnet":"fd63:256c:45f7:aefc::/64","updated_at":"2023-10-18T16:43:44.258914Z"}],"tags":[],"updated_at":"2023-10-18T16:43:44.258914Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "717"
+      - "699"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:17 GMT
+      - Tue, 07 Nov 2023 16:20:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1914,7 +1914,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a37ce27f-4383-4e3e-a585-4df4ea88ecbc
+      - 15ce3a3a-3bc2-430b-870c-9fb8ec9eabbc
     status: 200 OK
     code: 200
     duration: ""
@@ -1925,19 +1925,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:13.133374Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:33.465477Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1510"
+      - "1465"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:17 GMT
+      - Tue, 07 Nov 2023 16:20:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1947,7 +1947,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37e279d3-d47a-46c9-bf4d-98000c3f2287
+      - 8fc9e65a-4f36-4052-997f-3827d7e830ca
     status: 200 OK
     code: 200
     duration: ""
@@ -1958,19 +1958,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VGtSTk1FNXNiMWhFVkUxNlRWUkJlRTU2UlRKT1JFMHdUbXh2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRqRnJDa2RRWW01NVdrRnhUa0p6VUhwU2MwVkZSV012VDNsblRITnFTRGhQVmpWQlVFTTVlV2hOZVZnck5GZzVPVVE0VUVrNU5rRkRiVTF2UWpkWWQzSlpjMUlLWkZCVVNVbDZhM1pqY1hFd2VrTnVXSEp0UjFWelVYUmxaRFlyZURob1owVk1hRlo2VDA1eFUzWktlRXgwYXpRdmNUTXpNMUV6TmxaWlVWWXZjaTkyUlFvdlpub3dURGxSSzJ4a1JISjNMM1kzYlROMk5qVjBNMWRvWW5KNk1tRnBkRmR0TVM5RWF6VllWWGxyTDNOblVGUkVTREF6V0hSUlNUUlZZbWxOYlZoakNpdDRlRlZWU2xKUFJuRnpXRTE2VUd0clducFFVMngyZUU5R1ZEWklLMlF5ZW5sTE5WcEdZblJyVWxKS1VuTkdkWEpWWTBNek5qWklkRFpXZEhOU1VVVUtSRWhsTkhNMU1YVkhSRmxaUzJGcVpVbFJSa3ByVTJGU1dIQkxiMHhFZUc5WlNWb3plRFZyYUROcloxQmFiRnBUY0ZodVVHdG9Za3hCZEZRcmVHdElOd296YjI0dmEwOUdkM1ZUUm1KNFdUUTFiRkpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpCTkc1V1NsUmFVa3hIYjNWNVVpOVVWVkpwU25kUFRUZE5NMk5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCT0d4cWJXa3dTMlpUYlRWWldtbHJablJQVG1kNlEwOTRTMVpGT0VSUWVEUllUMEkyT1hFelowODVVek52VWsxVGNncGhVVzlLWTJSMlFXMHJOVzlrVmtwRU4xWnFXamhCVVUxV2FESndOMFVyY1VwNFRYZFJNVkpUVEZWek0xRmtibWRMZDBka1QzQmxhM2cwYVVoMlptdElDbk5qUkhRcmR5dFdjMjk1T1hoMk9DOVpWMFoyTTJwT2FHbzBibU16U0RSMFpVVnVka1ExTmtzemMydG1TRTR2ZEVaQlduUllXRTFrVjNoelJqaFZMemtLTDJaRU5GSmpZV2RRV0VKeWVsSkxjRmxaUW00clJqUmhTMGR4UjNSRWMyOTFWa0VyYzJ0VE1tNUlSV2R2UjJjelQweGpRVm8wYlc0elFqUlFOVWxuYUFwWFlrOWFRMHN6ZVZwaWMxbGFjMUJpWkd3NVpXbHhSRUpvUzBZNFpVcHJXRm96VWxWVFRWVlpkakJHVDBaMmEyOUJjamx3Ynk5dFMwUm9VRU15WVdWeUNrcHFMek5wY1Rrek1HbFhaMEZ0TTJRNVpteFpZMkk0WjI1T2JURnBaMU5UZEhOMGVnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGI4MTdlZC1lZTI2LTRmZDYtYmI2Zi0yOTI1ZjUwOTgxMjUuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1VloxemV4elFPaG1TRjRmOURZU01pbUZsWjZQdDlBM3hrSkFiQlNXVlNwcElZTTR2S2tUY0NzMQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2630"
+      - "2628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:17 GMT
+      - Tue, 07 Nov 2023 16:20:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1980,7 +1980,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c059375-4234-419f-a81f-f4507f668bde
+      - cd466476-e7a4-42b6-a134-8536859fc306
     status: 200 OK
     code: 200
     duration: ""
@@ -1991,19 +1991,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9695b5c8-f87e-4172-805f-afbb4cb27d8b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:43:44.258914Z","dhcp_enabled":true,"id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:44.258914Z","id":"4f19792d-685a-4cf1-bd52-1cb3823f144b","subnet":"172.16.8.0/22","updated_at":"2023-10-18T16:43:44.258914Z"},{"created_at":"2023-10-18T16:43:44.258914Z","id":"51e3553d-0372-4af8-a40c-83dc7752e070","subnet":"fd63:256c:45f7:aefc::/64","updated_at":"2023-10-18T16:43:44.258914Z"}],"tags":[],"updated_at":"2023-10-18T16:43:44.258914Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "717"
+      - "699"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:18 GMT
+      - Tue, 07 Nov 2023 16:20:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2013,7 +2013,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - edd945f8-90a2-43e4-8df0-4211090226c6
+      - b0837111-f7e5-4e38-8f0c-dced219884dc
     status: 200 OK
     code: 200
     duration: ""
@@ -2024,19 +2024,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:13.133374Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:33.465477Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1510"
+      - "1465"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:18 GMT
+      - Tue, 07 Nov 2023 16:20:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2046,7 +2046,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ccc5dfd-c262-467e-b3db-be60670e1775
+      - 52d1a55d-82d1-4644-bf7a-6a69748a7e26
     status: 200 OK
     code: 200
     duration: ""
@@ -2057,19 +2057,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VGtSTk1FNXNiMWhFVkUxNlRWUkJlRTU2UlRKT1JFMHdUbXh2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRqRnJDa2RRWW01NVdrRnhUa0p6VUhwU2MwVkZSV012VDNsblRITnFTRGhQVmpWQlVFTTVlV2hOZVZnck5GZzVPVVE0VUVrNU5rRkRiVTF2UWpkWWQzSlpjMUlLWkZCVVNVbDZhM1pqY1hFd2VrTnVXSEp0UjFWelVYUmxaRFlyZURob1owVk1hRlo2VDA1eFUzWktlRXgwYXpRdmNUTXpNMUV6TmxaWlVWWXZjaTkyUlFvdlpub3dURGxSSzJ4a1JISjNMM1kzYlROMk5qVjBNMWRvWW5KNk1tRnBkRmR0TVM5RWF6VllWWGxyTDNOblVGUkVTREF6V0hSUlNUUlZZbWxOYlZoakNpdDRlRlZWU2xKUFJuRnpXRTE2VUd0clducFFVMngyZUU5R1ZEWklLMlF5ZW5sTE5WcEdZblJyVWxKS1VuTkdkWEpWWTBNek5qWklkRFpXZEhOU1VVVUtSRWhsTkhNMU1YVkhSRmxaUzJGcVpVbFJSa3ByVTJGU1dIQkxiMHhFZUc5WlNWb3plRFZyYUROcloxQmFiRnBUY0ZodVVHdG9Za3hCZEZRcmVHdElOd296YjI0dmEwOUdkM1ZUUm1KNFdUUTFiRkpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpCTkc1V1NsUmFVa3hIYjNWNVVpOVVWVkpwU25kUFRUZE5NMk5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCT0d4cWJXa3dTMlpUYlRWWldtbHJablJQVG1kNlEwOTRTMVpGT0VSUWVEUllUMEkyT1hFelowODVVek52VWsxVGNncGhVVzlLWTJSMlFXMHJOVzlrVmtwRU4xWnFXamhCVVUxV2FESndOMFVyY1VwNFRYZFJNVkpUVEZWek0xRmtibWRMZDBka1QzQmxhM2cwYVVoMlptdElDbk5qUkhRcmR5dFdjMjk1T1hoMk9DOVpWMFoyTTJwT2FHbzBibU16U0RSMFpVVnVka1ExTmtzemMydG1TRTR2ZEVaQlduUllXRTFrVjNoelJqaFZMemtLTDJaRU5GSmpZV2RRV0VKeWVsSkxjRmxaUW00clJqUmhTMGR4UjNSRWMyOTFWa0VyYzJ0VE1tNUlSV2R2UjJjelQweGpRVm8wYlc0elFqUlFOVWxuYUFwWFlrOWFRMHN6ZVZwaWMxbGFjMUJpWkd3NVpXbHhSRUpvUzBZNFpVcHJXRm96VWxWVFRWVlpkakJHVDBaMmEyOUJjamx3Ynk5dFMwUm9VRU15WVdWeUNrcHFMek5wY1Rrek1HbFhaMEZ0TTJRNVpteFpZMkk0WjI1T2JURnBaMU5UZEhOMGVnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGI4MTdlZC1lZTI2LTRmZDYtYmI2Zi0yOTI1ZjUwOTgxMjUuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1VloxemV4elFPaG1TRjRmOURZU01pbUZsWjZQdDlBM3hrSkFiQlNXVlNwcElZTTR2S2tUY0NzMQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2630"
+      - "2628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:18 GMT
+      - Tue, 07 Nov 2023 16:20:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2079,7 +2079,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74379800-5899-4ccd-bdaf-79318b9de1e3
+      - 6a0c8271-c523-4655-9d3f-887920fc37dc
     status: 200 OK
     code: 200
     duration: ""
@@ -2106,7 +2106,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:18 GMT
+      - Tue, 07 Nov 2023 16:20:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2116,7 +2116,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a387ae9b-227d-4470-a3df-66aae2261112
+      - 5e4ef00b-4dee-42e0-a6e9-be09bba696ce
     status: 200 OK
     code: 200
     duration: ""
@@ -2127,19 +2127,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:13.133374Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:33.465477Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1510"
+      - "1465"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:18 GMT
+      - Tue, 07 Nov 2023 16:20:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2149,12 +2149,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91890872-891e-4424-8139-f15800276e37
+      - 16e9b96b-43d9-4bb1-a6ac-728a12e8f191
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":null,"description":null,"tags":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":null,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":null},"auto_upgrade":{"enable":true,"maintenance_window":{"start_hour":3,"day":"tuesday"}},"feature_gates":null,"admission_plugins":null,"open_id_connect_config":{"issuer_url":null,"client_id":null,"username_claim":null,"username_prefix":null,"groups_claim":null,"groups_prefix":null,"required_claim":null},"apiserver_cert_sans":null}'
+    body: '{"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":null,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":null},"auto_upgrade":{"enable":true,"maintenance_window":{"start_hour":3,"day":"tuesday"}},"open_id_connect_config":{"issuer_url":null,"client_id":null,"username_claim":null,"username_prefix":null,"groups_claim":null,"groups_prefix":null,"required_claim":null}}'
     form: {}
     headers:
       Content-Type:
@@ -2162,19 +2162,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:18.863202092Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:39.251402866Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1511"
+      - "1466"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:18 GMT
+      - Tue, 07 Nov 2023 16:20:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2184,7 +2184,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5b125ad-fd0e-42e0-ace1-900bfca932c5
+      - 66cdf7f7-642a-4430-9a1b-1c7f802dad78
     status: 200 OK
     code: 200
     duration: ""
@@ -2195,19 +2195,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:18.863202Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:39.251403Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1508"
+      - "1463"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:18 GMT
+      - Tue, 07 Nov 2023 16:20:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2217,7 +2217,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab7185dc-1b0c-4cf8-b181-dc73378a6fca
+      - d3a04531-756a-4a1c-a86d-adc8f6f6ab02
     status: 200 OK
     code: 200
     duration: ""
@@ -2228,19 +2228,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:20.019116Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:40.379486Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1513"
+      - "1468"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:24 GMT
+      - Tue, 07 Nov 2023 16:20:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2250,7 +2250,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96b2f1f4-2e8c-425d-a8ff-e28f0e6daac3
+      - 33d0d410-50f5-4690-84b4-1cdd890cbbaa
     status: 200 OK
     code: 200
     duration: ""
@@ -2261,19 +2261,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:20.019116Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:40.379486Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1513"
+      - "1468"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:24 GMT
+      - Tue, 07 Nov 2023 16:20:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2283,7 +2283,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a60c314-dc2a-4940-b61c-961079f55a03
+      - 2e47576f-31b5-460e-add2-1ae33f6fc478
     status: 200 OK
     code: 200
     duration: ""
@@ -2294,19 +2294,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VGtSTk1FNXNiMWhFVkUxNlRWUkJlRTU2UlRKT1JFMHdUbXh2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRqRnJDa2RRWW01NVdrRnhUa0p6VUhwU2MwVkZSV012VDNsblRITnFTRGhQVmpWQlVFTTVlV2hOZVZnck5GZzVPVVE0VUVrNU5rRkRiVTF2UWpkWWQzSlpjMUlLWkZCVVNVbDZhM1pqY1hFd2VrTnVXSEp0UjFWelVYUmxaRFlyZURob1owVk1hRlo2VDA1eFUzWktlRXgwYXpRdmNUTXpNMUV6TmxaWlVWWXZjaTkyUlFvdlpub3dURGxSSzJ4a1JISjNMM1kzYlROMk5qVjBNMWRvWW5KNk1tRnBkRmR0TVM5RWF6VllWWGxyTDNOblVGUkVTREF6V0hSUlNUUlZZbWxOYlZoakNpdDRlRlZWU2xKUFJuRnpXRTE2VUd0clducFFVMngyZUU5R1ZEWklLMlF5ZW5sTE5WcEdZblJyVWxKS1VuTkdkWEpWWTBNek5qWklkRFpXZEhOU1VVVUtSRWhsTkhNMU1YVkhSRmxaUzJGcVpVbFJSa3ByVTJGU1dIQkxiMHhFZUc5WlNWb3plRFZyYUROcloxQmFiRnBUY0ZodVVHdG9Za3hCZEZRcmVHdElOd296YjI0dmEwOUdkM1ZUUm1KNFdUUTFiRkpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpCTkc1V1NsUmFVa3hIYjNWNVVpOVVWVkpwU25kUFRUZE5NMk5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCT0d4cWJXa3dTMlpUYlRWWldtbHJablJQVG1kNlEwOTRTMVpGT0VSUWVEUllUMEkyT1hFelowODVVek52VWsxVGNncGhVVzlLWTJSMlFXMHJOVzlrVmtwRU4xWnFXamhCVVUxV2FESndOMFVyY1VwNFRYZFJNVkpUVEZWek0xRmtibWRMZDBka1QzQmxhM2cwYVVoMlptdElDbk5qUkhRcmR5dFdjMjk1T1hoMk9DOVpWMFoyTTJwT2FHbzBibU16U0RSMFpVVnVka1ExTmtzemMydG1TRTR2ZEVaQlduUllXRTFrVjNoelJqaFZMemtLTDJaRU5GSmpZV2RRV0VKeWVsSkxjRmxaUW00clJqUmhTMGR4UjNSRWMyOTFWa0VyYzJ0VE1tNUlSV2R2UjJjelQweGpRVm8wYlc0elFqUlFOVWxuYUFwWFlrOWFRMHN6ZVZwaWMxbGFjMUJpWkd3NVpXbHhSRUpvUzBZNFpVcHJXRm96VWxWVFRWVlpkakJHVDBaMmEyOUJjamx3Ynk5dFMwUm9VRU15WVdWeUNrcHFMek5wY1Rrek1HbFhaMEZ0TTJRNVpteFpZMkk0WjI1T2JURnBaMU5UZEhOMGVnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGI4MTdlZC1lZTI2LTRmZDYtYmI2Zi0yOTI1ZjUwOTgxMjUuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1VloxemV4elFPaG1TRjRmOURZU01pbUZsWjZQdDlBM3hrSkFiQlNXVlNwcElZTTR2S2tUY0NzMQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2630"
+      - "2628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:24 GMT
+      - Tue, 07 Nov 2023 16:20:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2316,7 +2316,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c00565c6-5100-4978-bec6-f7cd775fe291
+      - 196b5d15-0c10-424d-b5ed-0fd551a1725d
     status: 200 OK
     code: 200
     duration: ""
@@ -2327,19 +2327,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:20.019116Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:40.379486Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1513"
+      - "1468"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:24 GMT
+      - Tue, 07 Nov 2023 16:20:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2349,7 +2349,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 47aab527-ee6e-4409-9cd6-246aafc84ee9
+      - 6688c6e9-3dfe-4c6e-b920-9d6ae7144677
     status: 200 OK
     code: 200
     duration: ""
@@ -2360,19 +2360,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9695b5c8-f87e-4172-805f-afbb4cb27d8b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:43:44.258914Z","dhcp_enabled":true,"id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:44.258914Z","id":"4f19792d-685a-4cf1-bd52-1cb3823f144b","subnet":"172.16.8.0/22","updated_at":"2023-10-18T16:43:44.258914Z"},{"created_at":"2023-10-18T16:43:44.258914Z","id":"51e3553d-0372-4af8-a40c-83dc7752e070","subnet":"fd63:256c:45f7:aefc::/64","updated_at":"2023-10-18T16:43:44.258914Z"}],"tags":[],"updated_at":"2023-10-18T16:43:44.258914Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "717"
+      - "699"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:24 GMT
+      - Tue, 07 Nov 2023 16:20:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2382,7 +2382,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce2c0696-873d-4446-af3d-b7289c273929
+      - b3e259be-fc63-4738-959c-98adc675f6ac
     status: 200 OK
     code: 200
     duration: ""
@@ -2393,19 +2393,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:20.019116Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:40.379486Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1513"
+      - "1468"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:24 GMT
+      - Tue, 07 Nov 2023 16:20:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2415,7 +2415,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe15d93f-b112-493f-83f8-5566b8a2121c
+      - f1d19522-f885-46d4-aa9c-47f5640c60a2
     status: 200 OK
     code: 200
     duration: ""
@@ -2426,19 +2426,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VGtSTk1FNXNiMWhFVkUxNlRWUkJlRTU2UlRKT1JFMHdUbXh2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRqRnJDa2RRWW01NVdrRnhUa0p6VUhwU2MwVkZSV012VDNsblRITnFTRGhQVmpWQlVFTTVlV2hOZVZnck5GZzVPVVE0VUVrNU5rRkRiVTF2UWpkWWQzSlpjMUlLWkZCVVNVbDZhM1pqY1hFd2VrTnVXSEp0UjFWelVYUmxaRFlyZURob1owVk1hRlo2VDA1eFUzWktlRXgwYXpRdmNUTXpNMUV6TmxaWlVWWXZjaTkyUlFvdlpub3dURGxSSzJ4a1JISjNMM1kzYlROMk5qVjBNMWRvWW5KNk1tRnBkRmR0TVM5RWF6VllWWGxyTDNOblVGUkVTREF6V0hSUlNUUlZZbWxOYlZoakNpdDRlRlZWU2xKUFJuRnpXRTE2VUd0clducFFVMngyZUU5R1ZEWklLMlF5ZW5sTE5WcEdZblJyVWxKS1VuTkdkWEpWWTBNek5qWklkRFpXZEhOU1VVVUtSRWhsTkhNMU1YVkhSRmxaUzJGcVpVbFJSa3ByVTJGU1dIQkxiMHhFZUc5WlNWb3plRFZyYUROcloxQmFiRnBUY0ZodVVHdG9Za3hCZEZRcmVHdElOd296YjI0dmEwOUdkM1ZUUm1KNFdUUTFiRkpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpCTkc1V1NsUmFVa3hIYjNWNVVpOVVWVkpwU25kUFRUZE5NMk5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCT0d4cWJXa3dTMlpUYlRWWldtbHJablJQVG1kNlEwOTRTMVpGT0VSUWVEUllUMEkyT1hFelowODVVek52VWsxVGNncGhVVzlLWTJSMlFXMHJOVzlrVmtwRU4xWnFXamhCVVUxV2FESndOMFVyY1VwNFRYZFJNVkpUVEZWek0xRmtibWRMZDBka1QzQmxhM2cwYVVoMlptdElDbk5qUkhRcmR5dFdjMjk1T1hoMk9DOVpWMFoyTTJwT2FHbzBibU16U0RSMFpVVnVka1ExTmtzemMydG1TRTR2ZEVaQlduUllXRTFrVjNoelJqaFZMemtLTDJaRU5GSmpZV2RRV0VKeWVsSkxjRmxaUW00clJqUmhTMGR4UjNSRWMyOTFWa0VyYzJ0VE1tNUlSV2R2UjJjelQweGpRVm8wYlc0elFqUlFOVWxuYUFwWFlrOWFRMHN6ZVZwaWMxbGFjMUJpWkd3NVpXbHhSRUpvUzBZNFpVcHJXRm96VWxWVFRWVlpkakJHVDBaMmEyOUJjamx3Ynk5dFMwUm9VRU15WVdWeUNrcHFMek5wY1Rrek1HbFhaMEZ0TTJRNVpteFpZMkk0WjI1T2JURnBaMU5UZEhOMGVnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGI4MTdlZC1lZTI2LTRmZDYtYmI2Zi0yOTI1ZjUwOTgxMjUuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1VloxemV4elFPaG1TRjRmOURZU01pbUZsWjZQdDlBM3hrSkFiQlNXVlNwcElZTTR2S2tUY0NzMQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2630"
+      - "2628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:24 GMT
+      - Tue, 07 Nov 2023 16:20:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2448,7 +2448,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8f764b8-eba1-4943-85b8-edbfb6190879
+      - 8a6de6dd-0bb0-4bc6-ae80-d7c501429a38
     status: 200 OK
     code: 200
     duration: ""
@@ -2459,19 +2459,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9695b5c8-f87e-4172-805f-afbb4cb27d8b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:43:44.258914Z","dhcp_enabled":true,"id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:44.258914Z","id":"4f19792d-685a-4cf1-bd52-1cb3823f144b","subnet":"172.16.8.0/22","updated_at":"2023-10-18T16:43:44.258914Z"},{"created_at":"2023-10-18T16:43:44.258914Z","id":"51e3553d-0372-4af8-a40c-83dc7752e070","subnet":"fd63:256c:45f7:aefc::/64","updated_at":"2023-10-18T16:43:44.258914Z"}],"tags":[],"updated_at":"2023-10-18T16:43:44.258914Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "717"
+      - "699"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:25 GMT
+      - Tue, 07 Nov 2023 16:20:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2481,7 +2481,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6fed7a06-a80d-4191-908c-269048505b04
+      - cfa4bc92-00c7-4341-b569-59c008e46fef
     status: 200 OK
     code: 200
     duration: ""
@@ -2492,19 +2492,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:20.019116Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"tuesday","start_hour":3}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:40.379486Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1513"
+      - "1468"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:25 GMT
+      - Tue, 07 Nov 2023 16:20:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2514,7 +2514,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16f8e91c-39d4-4340-b48c-56fae1a59353
+      - adc2e104-261f-4137-82a9-f737d518de69
     status: 200 OK
     code: 200
     duration: ""
@@ -2525,19 +2525,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VGtSTk1FNXNiMWhFVkUxNlRWUkJlRTU2UlRKT1JFMHdUbXh2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRqRnJDa2RRWW01NVdrRnhUa0p6VUhwU2MwVkZSV012VDNsblRITnFTRGhQVmpWQlVFTTVlV2hOZVZnck5GZzVPVVE0VUVrNU5rRkRiVTF2UWpkWWQzSlpjMUlLWkZCVVNVbDZhM1pqY1hFd2VrTnVXSEp0UjFWelVYUmxaRFlyZURob1owVk1hRlo2VDA1eFUzWktlRXgwYXpRdmNUTXpNMUV6TmxaWlVWWXZjaTkyUlFvdlpub3dURGxSSzJ4a1JISjNMM1kzYlROMk5qVjBNMWRvWW5KNk1tRnBkRmR0TVM5RWF6VllWWGxyTDNOblVGUkVTREF6V0hSUlNUUlZZbWxOYlZoakNpdDRlRlZWU2xKUFJuRnpXRTE2VUd0clducFFVMngyZUU5R1ZEWklLMlF5ZW5sTE5WcEdZblJyVWxKS1VuTkdkWEpWWTBNek5qWklkRFpXZEhOU1VVVUtSRWhsTkhNMU1YVkhSRmxaUzJGcVpVbFJSa3ByVTJGU1dIQkxiMHhFZUc5WlNWb3plRFZyYUROcloxQmFiRnBUY0ZodVVHdG9Za3hCZEZRcmVHdElOd296YjI0dmEwOUdkM1ZUUm1KNFdUUTFiRkpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpCTkc1V1NsUmFVa3hIYjNWNVVpOVVWVkpwU25kUFRUZE5NMk5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCT0d4cWJXa3dTMlpUYlRWWldtbHJablJQVG1kNlEwOTRTMVpGT0VSUWVEUllUMEkyT1hFelowODVVek52VWsxVGNncGhVVzlLWTJSMlFXMHJOVzlrVmtwRU4xWnFXamhCVVUxV2FESndOMFVyY1VwNFRYZFJNVkpUVEZWek0xRmtibWRMZDBka1QzQmxhM2cwYVVoMlptdElDbk5qUkhRcmR5dFdjMjk1T1hoMk9DOVpWMFoyTTJwT2FHbzBibU16U0RSMFpVVnVka1ExTmtzemMydG1TRTR2ZEVaQlduUllXRTFrVjNoelJqaFZMemtLTDJaRU5GSmpZV2RRV0VKeWVsSkxjRmxaUW00clJqUmhTMGR4UjNSRWMyOTFWa0VyYzJ0VE1tNUlSV2R2UjJjelQweGpRVm8wYlc0elFqUlFOVWxuYUFwWFlrOWFRMHN6ZVZwaWMxbGFjMUJpWkd3NVpXbHhSRUpvUzBZNFpVcHJXRm96VWxWVFRWVlpkakJHVDBaMmEyOUJjamx3Ynk5dFMwUm9VRU15WVdWeUNrcHFMek5wY1Rrek1HbFhaMEZ0TTJRNVpteFpZMkk0WjI1T2JURnBaMU5UZEhOMGVnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGI4MTdlZC1lZTI2LTRmZDYtYmI2Zi0yOTI1ZjUwOTgxMjUuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1VloxemV4elFPaG1TRjRmOURZU01pbUZsWjZQdDlBM3hrSkFiQlNXVlNwcElZTTR2S2tUY0NzMQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2630"
+      - "2628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:25 GMT
+      - Tue, 07 Nov 2023 16:20:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2547,7 +2547,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41d2b1a4-7932-4904-a45c-46e0d14b2ce3
+      - 707d45a5-66c5-42e9-916d-610ced405fb7
     status: 200 OK
     code: 200
     duration: ""
@@ -2574,7 +2574,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:25 GMT
+      - Tue, 07 Nov 2023 16:20:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2584,12 +2584,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f240f47-eb90-4aea-881f-784605c915ba
+      - 685b9bea-6660-4c07-96ff-c924747a3043
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":null,"description":null,"tags":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":null,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":null},"auto_upgrade":{"enable":null,"maintenance_window":{"start_hour":0,"day":"any"}},"feature_gates":null,"admission_plugins":null,"open_id_connect_config":{"issuer_url":null,"client_id":null,"username_claim":null,"username_prefix":null,"groups_claim":null,"groups_prefix":null,"required_claim":null},"apiserver_cert_sans":null}'
+    body: '{"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":null,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":null},"auto_upgrade":{"enable":null,"maintenance_window":{"start_hour":0,"day":"any"}},"open_id_connect_config":{"issuer_url":null,"client_id":null,"username_claim":null,"username_prefix":null,"groups_claim":null,"groups_prefix":null,"required_claim":null}}'
     form: {}
     headers:
       Content-Type:
@@ -2597,19 +2597,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:25.785593802Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:46.069336829Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1507"
+      - "1462"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:25 GMT
+      - Tue, 07 Nov 2023 16:20:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2619,7 +2619,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45804521-6077-4b53-82e7-66a871bfb2f7
+      - 03e3dc84-4547-4901-99f9-77b924143038
     status: 200 OK
     code: 200
     duration: ""
@@ -2630,19 +2630,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:25.785594Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:46.069337Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1504"
+      - "1459"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:25 GMT
+      - Tue, 07 Nov 2023 16:20:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2652,7 +2652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00ba6640-0bc3-47f2-a485-e350f1f2cc9b
+      - 1e690d36-3d16-4527-80f8-b996851e6e66
     status: 200 OK
     code: 200
     duration: ""
@@ -2663,19 +2663,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:26.906989Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:47.202578Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1509"
+      - "1464"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:30 GMT
+      - Tue, 07 Nov 2023 16:20:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2685,7 +2685,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ffe44dd7-a122-49fc-b557-7d5461966434
+      - 78e45673-5f9e-47ff-839c-0d1c590f6571
     status: 200 OK
     code: 200
     duration: ""
@@ -2696,19 +2696,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:26.906989Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:47.202578Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1509"
+      - "1464"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:30 GMT
+      - Tue, 07 Nov 2023 16:20:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2718,7 +2718,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b47f0ca-2210-4c3e-93b2-6fcedfb75903
+      - bd4e3d85-91f5-46eb-9890-035f89c389bb
     status: 200 OK
     code: 200
     duration: ""
@@ -2729,19 +2729,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VGtSTk1FNXNiMWhFVkUxNlRWUkJlRTU2UlRKT1JFMHdUbXh2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRqRnJDa2RRWW01NVdrRnhUa0p6VUhwU2MwVkZSV012VDNsblRITnFTRGhQVmpWQlVFTTVlV2hOZVZnck5GZzVPVVE0VUVrNU5rRkRiVTF2UWpkWWQzSlpjMUlLWkZCVVNVbDZhM1pqY1hFd2VrTnVXSEp0UjFWelVYUmxaRFlyZURob1owVk1hRlo2VDA1eFUzWktlRXgwYXpRdmNUTXpNMUV6TmxaWlVWWXZjaTkyUlFvdlpub3dURGxSSzJ4a1JISjNMM1kzYlROMk5qVjBNMWRvWW5KNk1tRnBkRmR0TVM5RWF6VllWWGxyTDNOblVGUkVTREF6V0hSUlNUUlZZbWxOYlZoakNpdDRlRlZWU2xKUFJuRnpXRTE2VUd0clducFFVMngyZUU5R1ZEWklLMlF5ZW5sTE5WcEdZblJyVWxKS1VuTkdkWEpWWTBNek5qWklkRFpXZEhOU1VVVUtSRWhsTkhNMU1YVkhSRmxaUzJGcVpVbFJSa3ByVTJGU1dIQkxiMHhFZUc5WlNWb3plRFZyYUROcloxQmFiRnBUY0ZodVVHdG9Za3hCZEZRcmVHdElOd296YjI0dmEwOUdkM1ZUUm1KNFdUUTFiRkpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpCTkc1V1NsUmFVa3hIYjNWNVVpOVVWVkpwU25kUFRUZE5NMk5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCT0d4cWJXa3dTMlpUYlRWWldtbHJablJQVG1kNlEwOTRTMVpGT0VSUWVEUllUMEkyT1hFelowODVVek52VWsxVGNncGhVVzlLWTJSMlFXMHJOVzlrVmtwRU4xWnFXamhCVVUxV2FESndOMFVyY1VwNFRYZFJNVkpUVEZWek0xRmtibWRMZDBka1QzQmxhM2cwYVVoMlptdElDbk5qUkhRcmR5dFdjMjk1T1hoMk9DOVpWMFoyTTJwT2FHbzBibU16U0RSMFpVVnVka1ExTmtzemMydG1TRTR2ZEVaQlduUllXRTFrVjNoelJqaFZMemtLTDJaRU5GSmpZV2RRV0VKeWVsSkxjRmxaUW00clJqUmhTMGR4UjNSRWMyOTFWa0VyYzJ0VE1tNUlSV2R2UjJjelQweGpRVm8wYlc0elFqUlFOVWxuYUFwWFlrOWFRMHN6ZVZwaWMxbGFjMUJpWkd3NVpXbHhSRUpvUzBZNFpVcHJXRm96VWxWVFRWVlpkakJHVDBaMmEyOUJjamx3Ynk5dFMwUm9VRU15WVdWeUNrcHFMek5wY1Rrek1HbFhaMEZ0TTJRNVpteFpZMkk0WjI1T2JURnBaMU5UZEhOMGVnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGI4MTdlZC1lZTI2LTRmZDYtYmI2Zi0yOTI1ZjUwOTgxMjUuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1VloxemV4elFPaG1TRjRmOURZU01pbUZsWjZQdDlBM3hrSkFiQlNXVlNwcElZTTR2S2tUY0NzMQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2630"
+      - "2628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:31 GMT
+      - Tue, 07 Nov 2023 16:20:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2751,7 +2751,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ac34cbb-2fa8-49bf-b20c-5ce578c809e1
+      - f35c5d62-e8b4-4dd6-9773-4bc1b26e59aa
     status: 200 OK
     code: 200
     duration: ""
@@ -2762,19 +2762,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:26.906989Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:47.202578Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1509"
+      - "1464"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:31 GMT
+      - Tue, 07 Nov 2023 16:20:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2784,7 +2784,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e755451-3896-425d-871e-92c4fd25805b
+      - 8ff4f673-04a2-4295-b967-84b003687279
     status: 200 OK
     code: 200
     duration: ""
@@ -2795,19 +2795,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9695b5c8-f87e-4172-805f-afbb4cb27d8b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:43:44.258914Z","dhcp_enabled":true,"id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:44.258914Z","id":"4f19792d-685a-4cf1-bd52-1cb3823f144b","subnet":"172.16.8.0/22","updated_at":"2023-10-18T16:43:44.258914Z"},{"created_at":"2023-10-18T16:43:44.258914Z","id":"51e3553d-0372-4af8-a40c-83dc7752e070","subnet":"fd63:256c:45f7:aefc::/64","updated_at":"2023-10-18T16:43:44.258914Z"}],"tags":[],"updated_at":"2023-10-18T16:43:44.258914Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:19:59.728566Z","dhcp_enabled":true,"id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","name":"test-auto-upgrade","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.728566Z","id":"023e53e6-e922-4cd6-a6a3-e23ac831dc20","subnet":"172.16.8.0/22","updated_at":"2023-11-07T16:19:59.728566Z"},{"created_at":"2023-11-07T16:19:59.728566Z","id":"432972cf-8308-4579-8172-a46d9e676df9","subnet":"fd63:256c:45f7:e00::/64","updated_at":"2023-11-07T16:19:59.728566Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.728566Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "717"
+      - "699"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:31 GMT
+      - Tue, 07 Nov 2023 16:20:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2817,7 +2817,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4abd95b9-9b53-4d0f-822c-d59b802373f4
+      - fbe083d8-83ed-47a0-a3d3-6f4ce5ec1aac
     status: 200 OK
     code: 200
     duration: ""
@@ -2828,19 +2828,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:26.906989Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:47.202578Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1509"
+      - "1464"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:31 GMT
+      - Tue, 07 Nov 2023 16:20:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2850,7 +2850,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17d14ac8-41b4-45cf-b998-5c2f4851ed21
+      - 0eef9c57-7c5b-41d9-88ef-3b3048470207
     status: 200 OK
     code: 200
     duration: ""
@@ -2861,19 +2861,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VGtSTk1FNXNiMWhFVkUxNlRWUkJlRTU2UlRKT1JFMHdUbXh2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRqRnJDa2RRWW01NVdrRnhUa0p6VUhwU2MwVkZSV012VDNsblRITnFTRGhQVmpWQlVFTTVlV2hOZVZnck5GZzVPVVE0VUVrNU5rRkRiVTF2UWpkWWQzSlpjMUlLWkZCVVNVbDZhM1pqY1hFd2VrTnVXSEp0UjFWelVYUmxaRFlyZURob1owVk1hRlo2VDA1eFUzWktlRXgwYXpRdmNUTXpNMUV6TmxaWlVWWXZjaTkyUlFvdlpub3dURGxSSzJ4a1JISjNMM1kzYlROMk5qVjBNMWRvWW5KNk1tRnBkRmR0TVM5RWF6VllWWGxyTDNOblVGUkVTREF6V0hSUlNUUlZZbWxOYlZoakNpdDRlRlZWU2xKUFJuRnpXRTE2VUd0clducFFVMngyZUU5R1ZEWklLMlF5ZW5sTE5WcEdZblJyVWxKS1VuTkdkWEpWWTBNek5qWklkRFpXZEhOU1VVVUtSRWhsTkhNMU1YVkhSRmxaUzJGcVpVbFJSa3ByVTJGU1dIQkxiMHhFZUc5WlNWb3plRFZyYUROcloxQmFiRnBUY0ZodVVHdG9Za3hCZEZRcmVHdElOd296YjI0dmEwOUdkM1ZUUm1KNFdUUTFiRkpqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpCTkc1V1NsUmFVa3hIYjNWNVVpOVVWVkpwU25kUFRUZE5NMk5OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCT0d4cWJXa3dTMlpUYlRWWldtbHJablJQVG1kNlEwOTRTMVpGT0VSUWVEUllUMEkyT1hFelowODVVek52VWsxVGNncGhVVzlLWTJSMlFXMHJOVzlrVmtwRU4xWnFXamhCVVUxV2FESndOMFVyY1VwNFRYZFJNVkpUVEZWek0xRmtibWRMZDBka1QzQmxhM2cwYVVoMlptdElDbk5qUkhRcmR5dFdjMjk1T1hoMk9DOVpWMFoyTTJwT2FHbzBibU16U0RSMFpVVnVka1ExTmtzemMydG1TRTR2ZEVaQlduUllXRTFrVjNoelJqaFZMemtLTDJaRU5GSmpZV2RRV0VKeWVsSkxjRmxaUW00clJqUmhTMGR4UjNSRWMyOTFWa0VyYzJ0VE1tNUlSV2R2UjJjelQweGpRVm8wYlc0elFqUlFOVWxuYUFwWFlrOWFRMHN6ZVZwaWMxbGFjMUJpWkd3NVpXbHhSRUpvUzBZNFpVcHJXRm96VWxWVFRWVlpkakJHVDBaMmEyOUJjamx3Ynk5dFMwUm9VRU15WVdWeUNrcHFMek5wY1Rrek1HbFhaMEZ0TTJRNVpteFpZMkk0WjI1T2JURnBaMU5UZEhOMGVnb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGI4MTdlZC1lZTI2LTRmZDYtYmI2Zi0yOTI1ZjUwOTgxMjUuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB1VloxemV4elFPaG1TRjRmOURZU01pbUZsWjZQdDlBM3hrSkFiQlNXVlNwcElZTTR2S2tUY0NzMQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0by11cGdyYWRlIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwMXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRDdERDa1lyZW5seVVGRllTVk40ZFdRemIxSkdTV0pTYm04elQwSnFiQzlLWm5sV2JHUnJVVVJ4VDJrNVNGWXJXRlV3UkUxaE16Wk9iMVZaTTFsRVZ6WlZaREVLWlc5emFXOWlVVlJsUXpsVU9WQjNNMlJxV1hKa09WSjFXRWMzVFdWSVQzcHhWRkZqWkdWMU15dE9SVFZCVFdWUWRUWmhhRVpWYW5Cdk9XWnNVemR3WXdvMU5qZEllVFJvU2pWWldXZFdaRVZNUjNGMFNWWkVkR2hFZUVsS2REbFJNSEEyVTBaU1lscGpaVGRhUjBSVWJpdGFObTAyVkhRMFZGVjRhbFJMVVRKTkNteDNWWHBWSzBreGVuVjJlRkZJYlZwUk9FOU9aVUZ5UlVzemVHZFVkMXBZTTFORFFtRnpSSGxuY0dwU2FqWnBNVUZCT0c1Rk4wdzFURnBqZEROUlYzTUtNVk0wYkhkTlprOXljbUV6YlVwNVozWmlUVGxtVDBSUFNHbGljekp6WWpobWMzZzFSMEZMVDFOTlp6bGlLelpSUm04elExSjFOVmN2TjFaNUwzaG5aZ3BtT1VwV05uSk9SMWQzT0RVNVFVRnNjRkJqUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpKZUhCbmRFbG5WRkZoZG1OTE1HaFFObk5ESzB3NFVHTlBhRXhOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDZFN0SWIwMHZVVVZQWVZkNWIxWlVhVTFRVG14UlFscHVSMFprTUVGNmMyeGFiMU53ZVZWUVNURnBVRlpKTm5kemNBcGhWa2czZW01alNYSnZhMGxzY25ObU0zUmFkVEY1V0VkVVFqSlZjWGwwWnpWVFZFSlNSakpLU25Od1JIQXhNVGRqYVM5NGMyVXJObXM0TUdGdFFYSTJDbGRaWlRJd2VsWlVjREo1WVhwRU9TOU9iek13WmpSQ2VrOUtVM1F2VTNWcVlsaDVObGhRVVVGd2NGSkVZVk4xZEZGa05rZzNjMFVyVTJwc1JXZFpiVEFLY1RKU0t6YzNlVWhJYjFKTGJIVnpWMmRRVGxKNVYxZElZblpLTVdsNVNqTllUR0pYYkdOUE1UbGhNRVZqWjJaSWIzWm1SMGxNWWtsMVlsWnJWRlZIZVFwVlpFNDBTMEo0UkhJM2VtUnRMMjVVZUhoVFkxTjJMMWhTWkRoeGN5dFpNWEZUTTNZMFRYUTRjV2REVFZCWFpGaFRZMHhrUlhodWFGQlBjR2RrYkhaM0NuTnlVWFUyZEZoeWFXMXlVVUk1YlcxdFoySnJja05UYXpaSFdUQlhUMlUwUWxjeGRBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8zMmQwN2QzNi0zNDkxLTRkZmEtOTcwOS1iOTI0MzJhYjJlNzkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1hdXRvLXVwZ3JhZGUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtYXV0by11cGdyYWRlIgogICAgdXNlcjogdGVzdC1hdXRvLXVwZ3JhZGUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LWF1dG8tdXBncmFkZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtYXV0by11cGdyYWRlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBqRWNId0hmVkU1R1ZwbzBGMkpqbUZjeFE5bDU1M3hqMVZQN2V6cnZ2Vjh6cWcyNFE0RTVxQmRFTw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2630"
+      - "2628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:31 GMT
+      - Tue, 07 Nov 2023 16:20:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2883,7 +2883,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 614ee395-baf3-4d3c-b17e-34c83b3551c2
+      - 2b190735-caca-43f6-8a3e-3fe1bd2a8917
     status: 200 OK
     code: 200
     duration: ""
@@ -2894,19 +2894,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:32.155220510Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:52.400607035Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1507"
+      - "1462"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:32 GMT
+      - Tue, 07 Nov 2023 16:20:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2916,7 +2916,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c378f2d5-ef6f-45de-a2c9-430f7ecf3b7e
+      - 61c72e17-cce1-4eb2-924e-db78c7d6a0a4
     status: 200 OK
     code: 200
     duration: ""
@@ -2927,19 +2927,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:32.155221Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:52.400607Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1504"
+      - "1459"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:32 GMT
+      - Tue, 07 Nov 2023 16:20:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2949,7 +2949,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5838a46-c2cf-461b-ad35-17df8c18dc30
+      - 240f9889-d7d7-41d4-92ba-dfe347855517
     status: 200 OK
     code: 200
     duration: ""
@@ -2960,19 +2960,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4b817ed-ee26-4fd6-bb6f-2925f5098125.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:45.195710Z","created_at":"2023-10-18T16:43:45.195710Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4b817ed-ee26-4fd6-bb6f-2925f5098125.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-10-18T16:44:32.155221Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://32d07d36-3491-4dfa-9709-b92432ab2e79.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.081696Z","created_at":"2023-11-07T16:20:01.081696Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.32d07d36-3491-4dfa-9709-b92432ab2e79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"32d07d36-3491-4dfa-9709-b92432ab2e79","ingress":"none","name":"test-auto-upgrade","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","auto_upgrade"],"type":"kapsule","updated_at":"2023-11-07T16:20:52.400607Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1504"
+      - "1459"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:37 GMT
+      - Tue, 07 Nov 2023 16:20:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2982,7 +2982,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 268230e7-9d58-4502-998d-39b105c1f7a4
+      - 3df91742-5a06-40b7-8954-344dde481c16
     status: 200 OK
     code: 200
     duration: ""
@@ -2993,10 +2993,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"32d07d36-3491-4dfa-9709-b92432ab2e79","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3005,7 +3005,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:42 GMT
+      - Tue, 07 Nov 2023 16:21:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3015,7 +3015,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7a17ad1-0f57-4ff0-8979-01d204275c49
+      - 10fe92df-da0c-4552-be4f-50e828534caf
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3026,10 +3026,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9695b5c8-f87e-4172-805f-afbb4cb27d8b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8f67fd8-7797-4774-b8c7-83a826d5da07
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"9695b5c8-f87e-4172-805f-afbb4cb27d8b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"a8f67fd8-7797-4774-b8c7-83a826d5da07","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3038,7 +3038,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:42 GMT
+      - Tue, 07 Nov 2023 16:21:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3048,7 +3048,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf3975b9-5888-4170-b898-0a60bba76c2b
+      - 74d76f4b-3df3-48fe-865b-5fd9963339d9
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3059,10 +3059,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4b817ed-ee26-4fd6-bb6f-2925f5098125
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/32d07d36-3491-4dfa-9709-b92432ab2e79
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"a4b817ed-ee26-4fd6-bb6f-2925f5098125","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"32d07d36-3491-4dfa-9709-b92432ab2e79","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3071,7 +3071,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:42 GMT
+      - Tue, 07 Nov 2023 16:21:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3081,7 +3081,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16730764-9c60-461a-abe5-d387728b63f6
+      - 658cecdc-f8dc-4c9a-b81f-f0be8e6eed2e
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-autoscaling.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-autoscaling.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:41 GMT
+      - Tue, 07 Nov 2023 16:19:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,12 +34,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c797c36-7f73-4ef3-838e-f2d26d7f5f3d
+      - 5406efca-2ded-464b-88fe-65e4d247949b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-autoscaler","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"test-autoscaler","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-18T16:44:00.098797Z","dhcp_enabled":true,"id":"66609b41-6f0b-4e20-b1b1-adcebf968e47","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-18T16:44:00.098797Z","id":"9da3a37f-0bdc-47e2-bd67-e6c5dd55040c","subnet":"172.16.8.0/22","updated_at":"2023-10-18T16:44:00.098797Z"},{"created_at":"2023-10-18T16:44:00.098797Z","id":"71643564-6514-4b7d-b4f5-512d55efccdc","subnet":"fd68:d440:21c4:61e3::/64","updated_at":"2023-10-18T16:44:00.098797Z"}],"tags":[],"updated_at":"2023-10-18T16:44:00.098797Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-07T16:21:03.300586Z","dhcp_enabled":true,"id":"fc79e33c-2733-41ba-ab51-205753408640","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-07T16:21:03.300586Z","id":"001fa777-48cd-44e8-a1bf-5b36989c0eab","subnet":"172.16.16.0/22","updated_at":"2023-11-07T16:21:03.300586Z"},{"created_at":"2023-11-07T16:21:03.300586Z","id":"34932260-3937-4dd7-9bb2-6613881d2a75","subnet":"fd68:d440:21c4:9c5e::/64","updated_at":"2023-11-07T16:21:03.300586Z"}],"tags":[],"updated_at":"2023-11-07T16:21:03.300586Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "715"
+      - "699"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:01 GMT
+      - Tue, 07 Nov 2023 16:21:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b19a3db-f6b6-47f3-981d-2a31657bcee9
+      - afe9bd08-3ec7-470b-a578-8b6ff9ce1299
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/66609b41-6f0b-4e20-b1b1-adcebf968e47
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/fc79e33c-2733-41ba-ab51-205753408640
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:44:00.098797Z","dhcp_enabled":true,"id":"66609b41-6f0b-4e20-b1b1-adcebf968e47","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-18T16:44:00.098797Z","id":"9da3a37f-0bdc-47e2-bd67-e6c5dd55040c","subnet":"172.16.8.0/22","updated_at":"2023-10-18T16:44:00.098797Z"},{"created_at":"2023-10-18T16:44:00.098797Z","id":"71643564-6514-4b7d-b4f5-512d55efccdc","subnet":"fd68:d440:21c4:61e3::/64","updated_at":"2023-10-18T16:44:00.098797Z"}],"tags":[],"updated_at":"2023-10-18T16:44:00.098797Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-07T16:21:03.300586Z","dhcp_enabled":true,"id":"fc79e33c-2733-41ba-ab51-205753408640","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-07T16:21:03.300586Z","id":"001fa777-48cd-44e8-a1bf-5b36989c0eab","subnet":"172.16.16.0/22","updated_at":"2023-11-07T16:21:03.300586Z"},{"created_at":"2023-11-07T16:21:03.300586Z","id":"34932260-3937-4dd7-9bb2-6613881d2a75","subnet":"fd68:d440:21c4:9c5e::/64","updated_at":"2023-11-07T16:21:03.300586Z"}],"tags":[],"updated_at":"2023-11-07T16:21:03.300586Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "715"
+      - "699"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:01 GMT
+      - Tue, 07 Nov 2023 16:21:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93bb7d09-7983-4ad3-b1c9-a9af1195f0ae
+      - 979b12f0-11a1-4bc2-a41a-1c6b3d4a04b7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-autoscaler-01","description":"","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":true,"scale_down_delay_after_add":"20m","estimator":"binpacking","expander":"most_pods","ignore_daemonsets_utilization":true,"balance_similar_node_groups":true,"expendable_pods_priority_cutoff":10,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77,"max_graceful_termination_sec":1337},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":"66609b41-6f0b-4e20-b1b1-adcebf968e47"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-autoscaler-01","description":"","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":true,"scale_down_delay_after_add":"20m","estimator":"binpacking","expander":"most_pods","ignore_daemonsets_utilization":true,"balance_similar_node_groups":true,"expendable_pods_priority_cutoff":10,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77,"max_graceful_termination_sec":1337},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"fc79e33c-2733-41ba-ab51-205753408640"}'
     form: {}
     headers:
       Content-Type:
@@ -118,16 +118,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://cfc86eab-8444-4b7d-ae52-e71326e3eb01.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:01.333778302Z","created_at":"2023-10-18T16:44:01.333778302Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cfc86eab-8444-4b7d-ae52-e71326e3eb01.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"cfc86eab-8444-4b7d-ae52-e71326e3eb01","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"66609b41-6f0b-4e20-b1b1-adcebf968e47","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-10-18T16:44:01.350689124Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027480893Z","created_at":"2023-11-07T16:21:05.027480893Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:05.043551677Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1525"
+      - "1480"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:01 GMT
+      - Tue, 07 Nov 2023 16:21:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5df0fee-1e6f-41c9-b7ce-8e036744cfd8
+      - e74074dc-e890-4261-8789-c747f8a9247d
     status: 200 OK
     code: 200
     duration: ""
@@ -148,19 +148,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/cfc86eab-8444-4b7d-ae52-e71326e3eb01
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://cfc86eab-8444-4b7d-ae52-e71326e3eb01.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:01.333778Z","created_at":"2023-10-18T16:44:01.333778Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cfc86eab-8444-4b7d-ae52-e71326e3eb01.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"cfc86eab-8444-4b7d-ae52-e71326e3eb01","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"66609b41-6f0b-4e20-b1b1-adcebf968e47","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-10-18T16:44:01.350689Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:05.043552Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:01 GMT
+      - Tue, 07 Nov 2023 16:21:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afcc792f-ca32-4db0-b2dc-df1de9c2ca6a
+      - 28b00bd7-3d97-48c5-9321-212bd7f9a3fd
     status: 200 OK
     code: 200
     duration: ""
@@ -181,19 +181,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/cfc86eab-8444-4b7d-ae52-e71326e3eb01
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://cfc86eab-8444-4b7d-ae52-e71326e3eb01.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:01.333778Z","created_at":"2023-10-18T16:44:01.333778Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cfc86eab-8444-4b7d-ae52-e71326e3eb01.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"cfc86eab-8444-4b7d-ae52-e71326e3eb01","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"66609b41-6f0b-4e20-b1b1-adcebf968e47","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-10-18T16:44:03.047383Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:09.311486Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1521"
+      - "1476"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:06 GMT
+      - Tue, 07 Nov 2023 16:21:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a99ce70f-81be-4337-b80e-ba072e54baf3
+      - 0d68c3e6-a35c-4430-9760-1a92802fce45
     status: 200 OK
     code: 200
     duration: ""
@@ -214,19 +214,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/cfc86eab-8444-4b7d-ae52-e71326e3eb01
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://cfc86eab-8444-4b7d-ae52-e71326e3eb01.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:01.333778Z","created_at":"2023-10-18T16:44:01.333778Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cfc86eab-8444-4b7d-ae52-e71326e3eb01.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"cfc86eab-8444-4b7d-ae52-e71326e3eb01","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"66609b41-6f0b-4e20-b1b1-adcebf968e47","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-10-18T16:44:03.047383Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:09.311486Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1521"
+      - "1476"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:06 GMT
+      - Tue, 07 Nov 2023 16:21:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20365bae-b484-425b-9bd7-06e4ad668901
+      - d4762701-415c-493e-8ccf-e4589244f0f7
     status: 200 OK
     code: 200
     duration: ""
@@ -247,19 +247,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/cfc86eab-8444-4b7d-ae52-e71326e3eb01/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVeVRrUlJkMDFzYjFoRVZFMTZUVlJCZUU1NlJUSk9SRkYzVFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSE0yQ21WeFR6RmlUMDAyT1dRdlUwMW9NRFJoYzNOeWJIbHZUVmRZTlhFeVJsZFJUbWxMV0RBelNuSkJRamRTTjI0d01uTnBNbGRFVmpGeGVVZGhaMHRsUm5vS1MyaEdObE5rTTNwTWEzZFBTMncyUmlzelNuZzNVR1pPVkd3ck4wSmlkM05KTmpFek5EZzFUbEJwUkRkaFJtSldhR29yT0hjNGVHSm9RM1pHVWxsTGRRcHVhVkJEY1ZJMFQwTjJOazVLUm1SU2MzWk5la3BwZVhveEsySXhRek5RUjNadE0wVm1NQzlXTTFKc1NXTmtSMDB5V2pRMVIxVmtLMVZZY0RaS05IRkxDbFJOVkcxb01tMDJhalJFWkRWdVN6VkdTRzVrU25KTU5GazBWR1lyUjI5WmRXaGlNbWxoYUZGTFZHeEJiMUpvUTBVMFkwRjRObVJpUm5kSWVWVjZTM2tLTmxsRVIzUlBUQzlHZEZreFZISkphbFUyV1ZsamJWbFpOV2RhSzBwcmJEZHdPR1ZMVjI5eWRHdFFVMGRXU0hKTmFtVnRTa3hFZEV0NlQySkhVRzFyT1FwUGIxTktSMHBYZDJWaGJWSmFjbWgwVVc0NFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUE1tcHNLMVp1UjI5YVN6RjZUVmxIYm1GVGVYRjFjSHBXZGl0TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1lrWnpRVFV6VjNGMllXUjBUVFJIVDFsWFpsTm9Vbmg1V21sclN6RXZNRlIzVmtSS1JEbExhbkZqT0RCSmRGZFFTUXBLUTB3clpUbDJVMWxIWWtoaVdHRTVWMjFhYjBabVpuZExOMjExWVZoQk1qZHdNazl1WTNadE5VUTNZM1paUXpFcmNXZzFNa2xZY2tkT0swazJkamQ1Q20xWGRHMHpjemNyYUhGQ2JXUkNRVnBMVEdwM1oyUTRSM0E1U0VGeE0yUlljWEJ3VkdKTVdtSkRUV0V5TW5oeE1GTTBRaTk2WXpGNFlrMU5WbG8wYm1nS2RuRTVabXRUT0dwdWJrNW1TWE5pVlRCM0t5c3JSMjlvTDFwUmFtWXpTRkoyVDA5NWNrd3hUV3BxTVROMmRIUkphM0Y2UlhKaWNVdFZRMnRVVHpCTmFBbzFNRWRLU1RaU1NrWmlWVVJEZVZnMlIxZFNVelF6WW5ob1oyZDNhU3RTVVdzNFptaERjMGhPWlZVNWNFaFJWWEZ6VHpNclNqWktXRFJyWVVOT1ZFZG5DalpsTXpFMWMxbzVSRzU2VEZVMFpqVkpNMFJHV0RnNVdrbEtiekpyVDBoeFZ6bDZhZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vY2ZjODZlYWItODQ0NC00YjdkLWFlNTItZTcxMzI2ZTNlYjAxLmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAxIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAxCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXaEU5SWVmWUNBSFlDaTY3WUNhOXFVR0swV1lwSzNsQmdUcWFRcVd4MVZuZ3d0NjJPeWNud2h2OQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEZkMDVzYjFoRVZFMTZUVlJGZDA1cVJUSk5ha1YzVG14dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUamxsQ2toaGVucEpVSEJpY25sS1ZsQkRabU5YTld4TFoyRTVaR1EyZWs5UGEyODBTMk5LUm5aS1ozVm5hbFl4V2tReFVsTklRMk5pZFZaMFNEbHBkR05VSzFVS1QwcHpZMHhxV0daelpYbHpVR3BKVEVSUVlTOHhWazVwTTJsUVoxRldSRWRMSzNZM1dFazRhbXh2TUZCclEwZEVjRXQ2YzJneGFqSXphRWhaYzBkUVF3cHZXRVZhZFVkbGRXeFJWWFpMTTBaVlJEa3daMjlaVUVFNFJFVXlUM05JYkU1eFVsbHFOMFIzWkdsdlNURkVURTAxY1ZaT1VsUkliVGRwTmpCS2FYRmlDbXh1WjBGMVZXaFRUbVJJVjAxUWFURmFlVFV6WVdSaVlVWlpRbXRZTWxoSmRucFJaM1JhWTJWV2RtMTNhRkJNWXpZemNXRnFkVGRXTVhZcmIweFFRa2tLS3pabGNuTk9jVzFYT1c1aWEwODJVemxEUXpWTVVsb3JaVUY0TjNaM1YzZHFkVTUxZGtsMFJrMHZUVmxhUVRKblVHTjVRa0YxTWxsRGNGcDZVRkZCTHdwNmRrbHZhMGwxWm5CSGFYRjFOVzVhVVhZNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRmVWY3hhRGxwYlVaYWJWQk1PREp0WW5aMU15dFNTR3QwYVd0TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2MwUTNMM1YzVlc1dlFsSTVSR2d5Vms1U1NURnNNVUZTYWxnNFUySkNWRmhIUldOdVRHbFhORkl5YjFabk9HZGxhUXB1ZFVoVVdteGpMMnBCTDBWb1NDOUNhRU5EV1dWTlpHbFJNR1F4VnpoaVJEbEliVkozTUhRME1FNUNlVEEwT0haeFZucGtWV2h2ZWxWNGQzTTBWek5GQ2pZMlJHOWxiVFEyTUdWdE9HZEhLM2xFU1VOUFVqTm9Ua2xIYjJWYVRHNTROVTVGUmtGQk1IZEZWR2N4UTBGeFNFMVVWbmQxVkVjdk0xUlNRV0pEWm5rS1NXUjNTRUUwUkZwU1kxTndTR1ZoVWxrclNXcHJkMklyV1dsamEySm9iak13ZG5GaWFuUndhRU5pU0ZsT05ITmlZWFkzUW05b2RESTNOVkZwUW1GcU1nbzJSbFZVY1hKWFRGZEhXRzB3SzJaWWNrWkNkamxNTVRZMFIxZFBXVkoxVTJwUE1UQlhWRkV6YVRaTVUweDNSbGQ0VjFGV1pVeHBlVE5GWm0xV2RVWTRDalF3TVZSeGFrZFlPWEI2U1ZoNVN6bDZVa1JCWVhSc2RITTRjbFkxZDFKbWVrTk1WQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZWU0Y2NmNzYtZDFjNy00OTM2LWFiYTEtN2JiNGY5NTM1MWY2LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAxIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAxCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBrYTZDR3dSZkFTM0tuNVh4OGNnM2pDa00xMkVYQ0xTZjVpblZtNExSYmNmbE4ycVRKWklXUWd5RA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2638"
+      - "2636"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:06 GMT
+      - Tue, 07 Nov 2023 16:21:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - edd9c5e4-3b74-4291-8407-079b8d0cbcb6
+      - 596eeba8-4912-4872-937c-bf6cb07fdc76
     status: 200 OK
     code: 200
     duration: ""
@@ -280,19 +280,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/cfc86eab-8444-4b7d-ae52-e71326e3eb01
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://cfc86eab-8444-4b7d-ae52-e71326e3eb01.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:01.333778Z","created_at":"2023-10-18T16:44:01.333778Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cfc86eab-8444-4b7d-ae52-e71326e3eb01.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"cfc86eab-8444-4b7d-ae52-e71326e3eb01","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"66609b41-6f0b-4e20-b1b1-adcebf968e47","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-10-18T16:44:03.047383Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:09.311486Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1521"
+      - "1476"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:07 GMT
+      - Tue, 07 Nov 2023 16:21:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9deb84cf-410c-4387-bbb2-718a703c2150
+      - c0237d3e-654a-4a25-a1e8-3ad284fc1694
     status: 200 OK
     code: 200
     duration: ""
@@ -313,19 +313,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/66609b41-6f0b-4e20-b1b1-adcebf968e47
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/fc79e33c-2733-41ba-ab51-205753408640
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:44:00.098797Z","dhcp_enabled":true,"id":"66609b41-6f0b-4e20-b1b1-adcebf968e47","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-18T16:44:00.098797Z","id":"9da3a37f-0bdc-47e2-bd67-e6c5dd55040c","subnet":"172.16.8.0/22","updated_at":"2023-10-18T16:44:00.098797Z"},{"created_at":"2023-10-18T16:44:00.098797Z","id":"71643564-6514-4b7d-b4f5-512d55efccdc","subnet":"fd68:d440:21c4:61e3::/64","updated_at":"2023-10-18T16:44:00.098797Z"}],"tags":[],"updated_at":"2023-10-18T16:44:00.098797Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-07T16:21:03.300586Z","dhcp_enabled":true,"id":"fc79e33c-2733-41ba-ab51-205753408640","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-07T16:21:03.300586Z","id":"001fa777-48cd-44e8-a1bf-5b36989c0eab","subnet":"172.16.16.0/22","updated_at":"2023-11-07T16:21:03.300586Z"},{"created_at":"2023-11-07T16:21:03.300586Z","id":"34932260-3937-4dd7-9bb2-6613881d2a75","subnet":"fd68:d440:21c4:9c5e::/64","updated_at":"2023-11-07T16:21:03.300586Z"}],"tags":[],"updated_at":"2023-11-07T16:21:03.300586Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "715"
+      - "699"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:07 GMT
+      - Tue, 07 Nov 2023 16:21:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -335,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c33f3f1-f8f5-4338-9d82-72f5b3b3295a
+      - dbc25809-a990-4c54-a518-40ff8a956a77
     status: 200 OK
     code: 200
     duration: ""
@@ -346,19 +346,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/cfc86eab-8444-4b7d-ae52-e71326e3eb01
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://cfc86eab-8444-4b7d-ae52-e71326e3eb01.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:01.333778Z","created_at":"2023-10-18T16:44:01.333778Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cfc86eab-8444-4b7d-ae52-e71326e3eb01.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"cfc86eab-8444-4b7d-ae52-e71326e3eb01","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"66609b41-6f0b-4e20-b1b1-adcebf968e47","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-10-18T16:44:03.047383Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:09.311486Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1521"
+      - "1476"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:07 GMT
+      - Tue, 07 Nov 2023 16:21:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -368,7 +368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 861135fe-6d76-49f8-8c5f-6124c5873400
+      - 9963eace-5f96-407b-9e56-59cce5cad0f9
     status: 200 OK
     code: 200
     duration: ""
@@ -379,19 +379,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/cfc86eab-8444-4b7d-ae52-e71326e3eb01/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVeVRrUlJkMDFzYjFoRVZFMTZUVlJCZUU1NlJUSk9SRkYzVFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSE0yQ21WeFR6RmlUMDAyT1dRdlUwMW9NRFJoYzNOeWJIbHZUVmRZTlhFeVJsZFJUbWxMV0RBelNuSkJRamRTTjI0d01uTnBNbGRFVmpGeGVVZGhaMHRsUm5vS1MyaEdObE5rTTNwTWEzZFBTMncyUmlzelNuZzNVR1pPVkd3ck4wSmlkM05KTmpFek5EZzFUbEJwUkRkaFJtSldhR29yT0hjNGVHSm9RM1pHVWxsTGRRcHVhVkJEY1ZJMFQwTjJOazVLUm1SU2MzWk5la3BwZVhveEsySXhRek5RUjNadE0wVm1NQzlXTTFKc1NXTmtSMDB5V2pRMVIxVmtLMVZZY0RaS05IRkxDbFJOVkcxb01tMDJhalJFWkRWdVN6VkdTRzVrU25KTU5GazBWR1lyUjI5WmRXaGlNbWxoYUZGTFZHeEJiMUpvUTBVMFkwRjRObVJpUm5kSWVWVjZTM2tLTmxsRVIzUlBUQzlHZEZreFZISkphbFUyV1ZsamJWbFpOV2RhSzBwcmJEZHdPR1ZMVjI5eWRHdFFVMGRXU0hKTmFtVnRTa3hFZEV0NlQySkhVRzFyT1FwUGIxTktSMHBYZDJWaGJWSmFjbWgwVVc0NFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUE1tcHNLMVp1UjI5YVN6RjZUVmxIYm1GVGVYRjFjSHBXZGl0TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1lrWnpRVFV6VjNGMllXUjBUVFJIVDFsWFpsTm9Vbmg1V21sclN6RXZNRlIzVmtSS1JEbExhbkZqT0RCSmRGZFFTUXBLUTB3clpUbDJVMWxIWWtoaVdHRTVWMjFhYjBabVpuZExOMjExWVZoQk1qZHdNazl1WTNadE5VUTNZM1paUXpFcmNXZzFNa2xZY2tkT0swazJkamQ1Q20xWGRHMHpjemNyYUhGQ2JXUkNRVnBMVEdwM1oyUTRSM0E1U0VGeE0yUlljWEJ3VkdKTVdtSkRUV0V5TW5oeE1GTTBRaTk2WXpGNFlrMU5WbG8wYm1nS2RuRTVabXRUT0dwdWJrNW1TWE5pVlRCM0t5c3JSMjlvTDFwUmFtWXpTRkoyVDA5NWNrd3hUV3BxTVROMmRIUkphM0Y2UlhKaWNVdFZRMnRVVHpCTmFBbzFNRWRLU1RaU1NrWmlWVVJEZVZnMlIxZFNVelF6WW5ob1oyZDNhU3RTVVdzNFptaERjMGhPWlZVNWNFaFJWWEZ6VHpNclNqWktXRFJyWVVOT1ZFZG5DalpsTXpFMWMxbzVSRzU2VEZVMFpqVkpNMFJHV0RnNVdrbEtiekpyVDBoeFZ6bDZhZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vY2ZjODZlYWItODQ0NC00YjdkLWFlNTItZTcxMzI2ZTNlYjAxLmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAxIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAxCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXaEU5SWVmWUNBSFlDaTY3WUNhOXFVR0swV1lwSzNsQmdUcWFRcVd4MVZuZ3d0NjJPeWNud2h2OQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEZkMDVzYjFoRVZFMTZUVlJGZDA1cVJUSk5ha1YzVG14dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUamxsQ2toaGVucEpVSEJpY25sS1ZsQkRabU5YTld4TFoyRTVaR1EyZWs5UGEyODBTMk5LUm5aS1ozVm5hbFl4V2tReFVsTklRMk5pZFZaMFNEbHBkR05VSzFVS1QwcHpZMHhxV0daelpYbHpVR3BKVEVSUVlTOHhWazVwTTJsUVoxRldSRWRMSzNZM1dFazRhbXh2TUZCclEwZEVjRXQ2YzJneGFqSXphRWhaYzBkUVF3cHZXRVZhZFVkbGRXeFJWWFpMTTBaVlJEa3daMjlaVUVFNFJFVXlUM05JYkU1eFVsbHFOMFIzWkdsdlNURkVURTAxY1ZaT1VsUkliVGRwTmpCS2FYRmlDbXh1WjBGMVZXaFRUbVJJVjAxUWFURmFlVFV6WVdSaVlVWlpRbXRZTWxoSmRucFJaM1JhWTJWV2RtMTNhRkJNWXpZemNXRnFkVGRXTVhZcmIweFFRa2tLS3pabGNuTk9jVzFYT1c1aWEwODJVemxEUXpWTVVsb3JaVUY0TjNaM1YzZHFkVTUxZGtsMFJrMHZUVmxhUVRKblVHTjVRa0YxTWxsRGNGcDZVRkZCTHdwNmRrbHZhMGwxWm5CSGFYRjFOVzVhVVhZNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRmVWY3hhRGxwYlVaYWJWQk1PREp0WW5aMU15dFNTR3QwYVd0TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2MwUTNMM1YzVlc1dlFsSTVSR2d5Vms1U1NURnNNVUZTYWxnNFUySkNWRmhIUldOdVRHbFhORkl5YjFabk9HZGxhUXB1ZFVoVVdteGpMMnBCTDBWb1NDOUNhRU5EV1dWTlpHbFJNR1F4VnpoaVJEbEliVkozTUhRME1FNUNlVEEwT0haeFZucGtWV2h2ZWxWNGQzTTBWek5GQ2pZMlJHOWxiVFEyTUdWdE9HZEhLM2xFU1VOUFVqTm9Ua2xIYjJWYVRHNTROVTVGUmtGQk1IZEZWR2N4UTBGeFNFMVVWbmQxVkVjdk0xUlNRV0pEWm5rS1NXUjNTRUUwUkZwU1kxTndTR1ZoVWxrclNXcHJkMklyV1dsamEySm9iak13ZG5GaWFuUndhRU5pU0ZsT05ITmlZWFkzUW05b2RESTNOVkZwUW1GcU1nbzJSbFZVY1hKWFRGZEhXRzB3SzJaWWNrWkNkamxNTVRZMFIxZFBXVkoxVTJwUE1UQlhWRkV6YVRaTVUweDNSbGQ0VjFGV1pVeHBlVE5GWm0xV2RVWTRDalF3TVZSeGFrZFlPWEI2U1ZoNVN6bDZVa1JCWVhSc2RITTRjbFkxZDFKbWVrTk1WQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZWU0Y2NmNzYtZDFjNy00OTM2LWFiYTEtN2JiNGY5NTM1MWY2LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAxIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAxCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBrYTZDR3dSZkFTM0tuNVh4OGNnM2pDa00xMkVYQ0xTZjVpblZtNExSYmNmbE4ycVRKWklXUWd5RA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2638"
+      - "2636"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:07 GMT
+      - Tue, 07 Nov 2023 16:21:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -401,7 +401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d9e9f2a-bd96-4051-93b0-43efc521a9e9
+      - 54d538bc-9555-49c8-9085-975c13244225
     status: 200 OK
     code: 200
     duration: ""
@@ -412,19 +412,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/66609b41-6f0b-4e20-b1b1-adcebf968e47
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/fc79e33c-2733-41ba-ab51-205753408640
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:44:00.098797Z","dhcp_enabled":true,"id":"66609b41-6f0b-4e20-b1b1-adcebf968e47","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-18T16:44:00.098797Z","id":"9da3a37f-0bdc-47e2-bd67-e6c5dd55040c","subnet":"172.16.8.0/22","updated_at":"2023-10-18T16:44:00.098797Z"},{"created_at":"2023-10-18T16:44:00.098797Z","id":"71643564-6514-4b7d-b4f5-512d55efccdc","subnet":"fd68:d440:21c4:61e3::/64","updated_at":"2023-10-18T16:44:00.098797Z"}],"tags":[],"updated_at":"2023-10-18T16:44:00.098797Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-07T16:21:03.300586Z","dhcp_enabled":true,"id":"fc79e33c-2733-41ba-ab51-205753408640","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-07T16:21:03.300586Z","id":"001fa777-48cd-44e8-a1bf-5b36989c0eab","subnet":"172.16.16.0/22","updated_at":"2023-11-07T16:21:03.300586Z"},{"created_at":"2023-11-07T16:21:03.300586Z","id":"34932260-3937-4dd7-9bb2-6613881d2a75","subnet":"fd68:d440:21c4:9c5e::/64","updated_at":"2023-11-07T16:21:03.300586Z"}],"tags":[],"updated_at":"2023-11-07T16:21:03.300586Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "715"
+      - "699"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:07 GMT
+      - Tue, 07 Nov 2023 16:21:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -434,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d66c6c1-a8a7-4d8b-a24c-55404e850215
+      - 719617ce-8926-4885-a397-94d90040e16f
     status: 200 OK
     code: 200
     duration: ""
@@ -445,19 +445,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/cfc86eab-8444-4b7d-ae52-e71326e3eb01
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://cfc86eab-8444-4b7d-ae52-e71326e3eb01.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:01.333778Z","created_at":"2023-10-18T16:44:01.333778Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cfc86eab-8444-4b7d-ae52-e71326e3eb01.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"cfc86eab-8444-4b7d-ae52-e71326e3eb01","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"66609b41-6f0b-4e20-b1b1-adcebf968e47","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-10-18T16:44:03.047383Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":true,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":10,"ignore_daemonsets_utilization":true,"max_graceful_termination_sec":1337,"scale_down_delay_after_add":"20m","scale_down_disabled":true,"scale_down_unneeded_time":"20m","scale_down_utilization_threshold":0.77},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-01","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:09.311486Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1521"
+      - "1476"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:08 GMT
+      - Tue, 07 Nov 2023 16:21:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -467,7 +467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 377ec869-7343-453d-ad11-02141bf736ad
+      - f134fa1b-6de2-4da0-aecd-0a210b3db7df
     status: 200 OK
     code: 200
     duration: ""
@@ -478,19 +478,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/cfc86eab-8444-4b7d-ae52-e71326e3eb01/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVeVRrUlJkMDFzYjFoRVZFMTZUVlJCZUU1NlJUSk9SRkYzVFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSE0yQ21WeFR6RmlUMDAyT1dRdlUwMW9NRFJoYzNOeWJIbHZUVmRZTlhFeVJsZFJUbWxMV0RBelNuSkJRamRTTjI0d01uTnBNbGRFVmpGeGVVZGhaMHRsUm5vS1MyaEdObE5rTTNwTWEzZFBTMncyUmlzelNuZzNVR1pPVkd3ck4wSmlkM05KTmpFek5EZzFUbEJwUkRkaFJtSldhR29yT0hjNGVHSm9RM1pHVWxsTGRRcHVhVkJEY1ZJMFQwTjJOazVLUm1SU2MzWk5la3BwZVhveEsySXhRek5RUjNadE0wVm1NQzlXTTFKc1NXTmtSMDB5V2pRMVIxVmtLMVZZY0RaS05IRkxDbFJOVkcxb01tMDJhalJFWkRWdVN6VkdTRzVrU25KTU5GazBWR1lyUjI5WmRXaGlNbWxoYUZGTFZHeEJiMUpvUTBVMFkwRjRObVJpUm5kSWVWVjZTM2tLTmxsRVIzUlBUQzlHZEZreFZISkphbFUyV1ZsamJWbFpOV2RhSzBwcmJEZHdPR1ZMVjI5eWRHdFFVMGRXU0hKTmFtVnRTa3hFZEV0NlQySkhVRzFyT1FwUGIxTktSMHBYZDJWaGJWSmFjbWgwVVc0NFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUE1tcHNLMVp1UjI5YVN6RjZUVmxIYm1GVGVYRjFjSHBXZGl0TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1lrWnpRVFV6VjNGMllXUjBUVFJIVDFsWFpsTm9Vbmg1V21sclN6RXZNRlIzVmtSS1JEbExhbkZqT0RCSmRGZFFTUXBLUTB3clpUbDJVMWxIWWtoaVdHRTVWMjFhYjBabVpuZExOMjExWVZoQk1qZHdNazl1WTNadE5VUTNZM1paUXpFcmNXZzFNa2xZY2tkT0swazJkamQ1Q20xWGRHMHpjemNyYUhGQ2JXUkNRVnBMVEdwM1oyUTRSM0E1U0VGeE0yUlljWEJ3VkdKTVdtSkRUV0V5TW5oeE1GTTBRaTk2WXpGNFlrMU5WbG8wYm1nS2RuRTVabXRUT0dwdWJrNW1TWE5pVlRCM0t5c3JSMjlvTDFwUmFtWXpTRkoyVDA5NWNrd3hUV3BxTVROMmRIUkphM0Y2UlhKaWNVdFZRMnRVVHpCTmFBbzFNRWRLU1RaU1NrWmlWVVJEZVZnMlIxZFNVelF6WW5ob1oyZDNhU3RTVVdzNFptaERjMGhPWlZVNWNFaFJWWEZ6VHpNclNqWktXRFJyWVVOT1ZFZG5DalpsTXpFMWMxbzVSRzU2VEZVMFpqVkpNMFJHV0RnNVdrbEtiekpyVDBoeFZ6bDZhZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vY2ZjODZlYWItODQ0NC00YjdkLWFlNTItZTcxMzI2ZTNlYjAxLmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAxIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAxCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXaEU5SWVmWUNBSFlDaTY3WUNhOXFVR0swV1lwSzNsQmdUcWFRcVd4MVZuZ3d0NjJPeWNud2h2OQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEZkMDVzYjFoRVZFMTZUVlJGZDA1cVJUSk5ha1YzVG14dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUamxsQ2toaGVucEpVSEJpY25sS1ZsQkRabU5YTld4TFoyRTVaR1EyZWs5UGEyODBTMk5LUm5aS1ozVm5hbFl4V2tReFVsTklRMk5pZFZaMFNEbHBkR05VSzFVS1QwcHpZMHhxV0daelpYbHpVR3BKVEVSUVlTOHhWazVwTTJsUVoxRldSRWRMSzNZM1dFazRhbXh2TUZCclEwZEVjRXQ2YzJneGFqSXphRWhaYzBkUVF3cHZXRVZhZFVkbGRXeFJWWFpMTTBaVlJEa3daMjlaVUVFNFJFVXlUM05JYkU1eFVsbHFOMFIzWkdsdlNURkVURTAxY1ZaT1VsUkliVGRwTmpCS2FYRmlDbXh1WjBGMVZXaFRUbVJJVjAxUWFURmFlVFV6WVdSaVlVWlpRbXRZTWxoSmRucFJaM1JhWTJWV2RtMTNhRkJNWXpZemNXRnFkVGRXTVhZcmIweFFRa2tLS3pabGNuTk9jVzFYT1c1aWEwODJVemxEUXpWTVVsb3JaVUY0TjNaM1YzZHFkVTUxZGtsMFJrMHZUVmxhUVRKblVHTjVRa0YxTWxsRGNGcDZVRkZCTHdwNmRrbHZhMGwxWm5CSGFYRjFOVzVhVVhZNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRmVWY3hhRGxwYlVaYWJWQk1PREp0WW5aMU15dFNTR3QwYVd0TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2MwUTNMM1YzVlc1dlFsSTVSR2d5Vms1U1NURnNNVUZTYWxnNFUySkNWRmhIUldOdVRHbFhORkl5YjFabk9HZGxhUXB1ZFVoVVdteGpMMnBCTDBWb1NDOUNhRU5EV1dWTlpHbFJNR1F4VnpoaVJEbEliVkozTUhRME1FNUNlVEEwT0haeFZucGtWV2h2ZWxWNGQzTTBWek5GQ2pZMlJHOWxiVFEyTUdWdE9HZEhLM2xFU1VOUFVqTm9Ua2xIYjJWYVRHNTROVTVGUmtGQk1IZEZWR2N4UTBGeFNFMVVWbmQxVkVjdk0xUlNRV0pEWm5rS1NXUjNTRUUwUkZwU1kxTndTR1ZoVWxrclNXcHJkMklyV1dsamEySm9iak13ZG5GaWFuUndhRU5pU0ZsT05ITmlZWFkzUW05b2RESTNOVkZwUW1GcU1nbzJSbFZVY1hKWFRGZEhXRzB3SzJaWWNrWkNkamxNTVRZMFIxZFBXVkoxVTJwUE1UQlhWRkV6YVRaTVUweDNSbGQ0VjFGV1pVeHBlVE5GWm0xV2RVWTRDalF3TVZSeGFrZFlPWEI2U1ZoNVN6bDZVa1JCWVhSc2RITTRjbFkxZDFKbWVrTk1WQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZWU0Y2NmNzYtZDFjNy00OTM2LWFiYTEtN2JiNGY5NTM1MWY2LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAxIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAxCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAxLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBrYTZDR3dSZkFTM0tuNVh4OGNnM2pDa00xMkVYQ0xTZjVpblZtNExSYmNmbE4ycVRKWklXUWd5RA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2638"
+      - "2636"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:08 GMT
+      - Tue, 07 Nov 2023 16:21:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -500,12 +500,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ee507cd-bfef-4db8-9725-ee65b2962df1
+      - 1e9e9601-6c4b-4865-85eb-31577f671f6c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-autoscaler-02","description":null,"tags":null,"autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33,"max_graceful_termination_sec":2664},"auto_upgrade":{"enable":null,"maintenance_window":null},"feature_gates":null,"admission_plugins":null,"open_id_connect_config":{"issuer_url":null,"client_id":null,"username_claim":null,"username_prefix":null,"groups_claim":null,"groups_prefix":null,"required_claim":null},"apiserver_cert_sans":null}'
+    body: '{"name":"test-autoscaler-02","autoscaler_config":{"scale_down_disabled":false,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":false,"balance_similar_node_groups":false,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33,"max_graceful_termination_sec":2664},"auto_upgrade":{"enable":null,"maintenance_window":null},"open_id_connect_config":{"issuer_url":null,"client_id":null,"username_claim":null,"username_prefix":null,"groups_claim":null,"groups_prefix":null,"required_claim":null}}'
     form: {}
     headers:
       Content-Type:
@@ -513,19 +513,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/cfc86eab-8444-4b7d-ae52-e71326e3eb01
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://cfc86eab-8444-4b7d-ae52-e71326e3eb01.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:01.333778Z","created_at":"2023-10-18T16:44:01.333778Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cfc86eab-8444-4b7d-ae52-e71326e3eb01.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"cfc86eab-8444-4b7d-ae52-e71326e3eb01","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"66609b41-6f0b-4e20-b1b1-adcebf968e47","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-10-18T16:44:08.667826238Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:12.192466805Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1520"
+      - "1475"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:08 GMT
+      - Tue, 07 Nov 2023 16:21:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b14b085-7d71-4a46-9d0d-fea425563367
+      - 6ae8f578-2264-4761-9c07-6f919c2a61a8
     status: 200 OK
     code: 200
     duration: ""
@@ -546,19 +546,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/cfc86eab-8444-4b7d-ae52-e71326e3eb01
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://cfc86eab-8444-4b7d-ae52-e71326e3eb01.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:01.333778Z","created_at":"2023-10-18T16:44:01.333778Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cfc86eab-8444-4b7d-ae52-e71326e3eb01.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"cfc86eab-8444-4b7d-ae52-e71326e3eb01","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"66609b41-6f0b-4e20-b1b1-adcebf968e47","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-10-18T16:44:08.667826Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:12.192467Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1517"
+      - "1472"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:08 GMT
+      - Tue, 07 Nov 2023 16:21:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da3dc8ea-db43-4c19-8bd0-f420ac27ce23
+      - 33627d3f-3ac3-4a3b-af4d-f90f0632f21d
     status: 200 OK
     code: 200
     duration: ""
@@ -579,19 +579,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/cfc86eab-8444-4b7d-ae52-e71326e3eb01
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://cfc86eab-8444-4b7d-ae52-e71326e3eb01.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:01.333778Z","created_at":"2023-10-18T16:44:01.333778Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cfc86eab-8444-4b7d-ae52-e71326e3eb01.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"cfc86eab-8444-4b7d-ae52-e71326e3eb01","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"66609b41-6f0b-4e20-b1b1-adcebf968e47","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-10-18T16:44:09.869754Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:13.359351Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1522"
+      - "1477"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:13 GMT
+      - Tue, 07 Nov 2023 16:21:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd99dc9a-43dd-49f1-b8f1-50d275705200
+      - 595e7251-3b16-4591-8522-6777110c5c14
     status: 200 OK
     code: 200
     duration: ""
@@ -612,19 +612,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/cfc86eab-8444-4b7d-ae52-e71326e3eb01
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://cfc86eab-8444-4b7d-ae52-e71326e3eb01.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:01.333778Z","created_at":"2023-10-18T16:44:01.333778Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cfc86eab-8444-4b7d-ae52-e71326e3eb01.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"cfc86eab-8444-4b7d-ae52-e71326e3eb01","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"66609b41-6f0b-4e20-b1b1-adcebf968e47","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-10-18T16:44:09.869754Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:13.359351Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1522"
+      - "1477"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:13 GMT
+      - Tue, 07 Nov 2023 16:21:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 583a421f-6b3e-4e72-a9b5-2a0595255b92
+      - 154f026f-d9a6-4dc5-8723-d880e734028f
     status: 200 OK
     code: 200
     duration: ""
@@ -645,19 +645,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/cfc86eab-8444-4b7d-ae52-e71326e3eb01/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVeVRrUlJkMDFzYjFoRVZFMTZUVlJCZUU1NlJUSk9SRkYzVFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSE0yQ21WeFR6RmlUMDAyT1dRdlUwMW9NRFJoYzNOeWJIbHZUVmRZTlhFeVJsZFJUbWxMV0RBelNuSkJRamRTTjI0d01uTnBNbGRFVmpGeGVVZGhaMHRsUm5vS1MyaEdObE5rTTNwTWEzZFBTMncyUmlzelNuZzNVR1pPVkd3ck4wSmlkM05KTmpFek5EZzFUbEJwUkRkaFJtSldhR29yT0hjNGVHSm9RM1pHVWxsTGRRcHVhVkJEY1ZJMFQwTjJOazVLUm1SU2MzWk5la3BwZVhveEsySXhRek5RUjNadE0wVm1NQzlXTTFKc1NXTmtSMDB5V2pRMVIxVmtLMVZZY0RaS05IRkxDbFJOVkcxb01tMDJhalJFWkRWdVN6VkdTRzVrU25KTU5GazBWR1lyUjI5WmRXaGlNbWxoYUZGTFZHeEJiMUpvUTBVMFkwRjRObVJpUm5kSWVWVjZTM2tLTmxsRVIzUlBUQzlHZEZreFZISkphbFUyV1ZsamJWbFpOV2RhSzBwcmJEZHdPR1ZMVjI5eWRHdFFVMGRXU0hKTmFtVnRTa3hFZEV0NlQySkhVRzFyT1FwUGIxTktSMHBYZDJWaGJWSmFjbWgwVVc0NFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUE1tcHNLMVp1UjI5YVN6RjZUVmxIYm1GVGVYRjFjSHBXZGl0TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1lrWnpRVFV6VjNGMllXUjBUVFJIVDFsWFpsTm9Vbmg1V21sclN6RXZNRlIzVmtSS1JEbExhbkZqT0RCSmRGZFFTUXBLUTB3clpUbDJVMWxIWWtoaVdHRTVWMjFhYjBabVpuZExOMjExWVZoQk1qZHdNazl1WTNadE5VUTNZM1paUXpFcmNXZzFNa2xZY2tkT0swazJkamQ1Q20xWGRHMHpjemNyYUhGQ2JXUkNRVnBMVEdwM1oyUTRSM0E1U0VGeE0yUlljWEJ3VkdKTVdtSkRUV0V5TW5oeE1GTTBRaTk2WXpGNFlrMU5WbG8wYm1nS2RuRTVabXRUT0dwdWJrNW1TWE5pVlRCM0t5c3JSMjlvTDFwUmFtWXpTRkoyVDA5NWNrd3hUV3BxTVROMmRIUkphM0Y2UlhKaWNVdFZRMnRVVHpCTmFBbzFNRWRLU1RaU1NrWmlWVVJEZVZnMlIxZFNVelF6WW5ob1oyZDNhU3RTVVdzNFptaERjMGhPWlZVNWNFaFJWWEZ6VHpNclNqWktXRFJyWVVOT1ZFZG5DalpsTXpFMWMxbzVSRzU2VEZVMFpqVkpNMFJHV0RnNVdrbEtiekpyVDBoeFZ6bDZhZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vY2ZjODZlYWItODQ0NC00YjdkLWFlNTItZTcxMzI2ZTNlYjAxLmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAyIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXaEU5SWVmWUNBSFlDaTY3WUNhOXFVR0swV1lwSzNsQmdUcWFRcVd4MVZuZ3d0NjJPeWNud2h2OQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEZkMDVzYjFoRVZFMTZUVlJGZDA1cVJUSk5ha1YzVG14dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUamxsQ2toaGVucEpVSEJpY25sS1ZsQkRabU5YTld4TFoyRTVaR1EyZWs5UGEyODBTMk5LUm5aS1ozVm5hbFl4V2tReFVsTklRMk5pZFZaMFNEbHBkR05VSzFVS1QwcHpZMHhxV0daelpYbHpVR3BKVEVSUVlTOHhWazVwTTJsUVoxRldSRWRMSzNZM1dFazRhbXh2TUZCclEwZEVjRXQ2YzJneGFqSXphRWhaYzBkUVF3cHZXRVZhZFVkbGRXeFJWWFpMTTBaVlJEa3daMjlaVUVFNFJFVXlUM05JYkU1eFVsbHFOMFIzWkdsdlNURkVURTAxY1ZaT1VsUkliVGRwTmpCS2FYRmlDbXh1WjBGMVZXaFRUbVJJVjAxUWFURmFlVFV6WVdSaVlVWlpRbXRZTWxoSmRucFJaM1JhWTJWV2RtMTNhRkJNWXpZemNXRnFkVGRXTVhZcmIweFFRa2tLS3pabGNuTk9jVzFYT1c1aWEwODJVemxEUXpWTVVsb3JaVUY0TjNaM1YzZHFkVTUxZGtsMFJrMHZUVmxhUVRKblVHTjVRa0YxTWxsRGNGcDZVRkZCTHdwNmRrbHZhMGwxWm5CSGFYRjFOVzVhVVhZNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRmVWY3hhRGxwYlVaYWJWQk1PREp0WW5aMU15dFNTR3QwYVd0TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2MwUTNMM1YzVlc1dlFsSTVSR2d5Vms1U1NURnNNVUZTYWxnNFUySkNWRmhIUldOdVRHbFhORkl5YjFabk9HZGxhUXB1ZFVoVVdteGpMMnBCTDBWb1NDOUNhRU5EV1dWTlpHbFJNR1F4VnpoaVJEbEliVkozTUhRME1FNUNlVEEwT0haeFZucGtWV2h2ZWxWNGQzTTBWek5GQ2pZMlJHOWxiVFEyTUdWdE9HZEhLM2xFU1VOUFVqTm9Ua2xIYjJWYVRHNTROVTVGUmtGQk1IZEZWR2N4UTBGeFNFMVVWbmQxVkVjdk0xUlNRV0pEWm5rS1NXUjNTRUUwUkZwU1kxTndTR1ZoVWxrclNXcHJkMklyV1dsamEySm9iak13ZG5GaWFuUndhRU5pU0ZsT05ITmlZWFkzUW05b2RESTNOVkZwUW1GcU1nbzJSbFZVY1hKWFRGZEhXRzB3SzJaWWNrWkNkamxNTVRZMFIxZFBXVkoxVTJwUE1UQlhWRkV6YVRaTVUweDNSbGQ0VjFGV1pVeHBlVE5GWm0xV2RVWTRDalF3TVZSeGFrZFlPWEI2U1ZoNVN6bDZVa1JCWVhSc2RITTRjbFkxZDFKbWVrTk1WQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZWU0Y2NmNzYtZDFjNy00OTM2LWFiYTEtN2JiNGY5NTM1MWY2LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAyIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBrYTZDR3dSZkFTM0tuNVh4OGNnM2pDa00xMkVYQ0xTZjVpblZtNExSYmNmbE4ycVRKWklXUWd5RA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2638"
+      - "2636"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:14 GMT
+      - Tue, 07 Nov 2023 16:21:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56697d24-319a-40a2-aba4-68fd8fab80aa
+      - 5064d253-d4b6-4232-88f9-a10b23d27c96
     status: 200 OK
     code: 200
     duration: ""
@@ -678,19 +678,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/cfc86eab-8444-4b7d-ae52-e71326e3eb01
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://cfc86eab-8444-4b7d-ae52-e71326e3eb01.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:01.333778Z","created_at":"2023-10-18T16:44:01.333778Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cfc86eab-8444-4b7d-ae52-e71326e3eb01.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"cfc86eab-8444-4b7d-ae52-e71326e3eb01","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"66609b41-6f0b-4e20-b1b1-adcebf968e47","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-10-18T16:44:09.869754Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:13.359351Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1522"
+      - "1477"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:14 GMT
+      - Tue, 07 Nov 2023 16:21:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 854cac55-3584-4c94-8cd3-28e852e6b6af
+      - 2ab32be8-080e-40e6-a74a-abf1501e1fcf
     status: 200 OK
     code: 200
     duration: ""
@@ -711,19 +711,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/66609b41-6f0b-4e20-b1b1-adcebf968e47
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/fc79e33c-2733-41ba-ab51-205753408640
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:44:00.098797Z","dhcp_enabled":true,"id":"66609b41-6f0b-4e20-b1b1-adcebf968e47","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-18T16:44:00.098797Z","id":"9da3a37f-0bdc-47e2-bd67-e6c5dd55040c","subnet":"172.16.8.0/22","updated_at":"2023-10-18T16:44:00.098797Z"},{"created_at":"2023-10-18T16:44:00.098797Z","id":"71643564-6514-4b7d-b4f5-512d55efccdc","subnet":"fd68:d440:21c4:61e3::/64","updated_at":"2023-10-18T16:44:00.098797Z"}],"tags":[],"updated_at":"2023-10-18T16:44:00.098797Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-07T16:21:03.300586Z","dhcp_enabled":true,"id":"fc79e33c-2733-41ba-ab51-205753408640","name":"test-autoscaler","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-11-07T16:21:03.300586Z","id":"001fa777-48cd-44e8-a1bf-5b36989c0eab","subnet":"172.16.16.0/22","updated_at":"2023-11-07T16:21:03.300586Z"},{"created_at":"2023-11-07T16:21:03.300586Z","id":"34932260-3937-4dd7-9bb2-6613881d2a75","subnet":"fd68:d440:21c4:9c5e::/64","updated_at":"2023-11-07T16:21:03.300586Z"}],"tags":[],"updated_at":"2023-11-07T16:21:03.300586Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "715"
+      - "699"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:14 GMT
+      - Tue, 07 Nov 2023 16:21:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71d71fa6-2d64-46f0-962b-14a55cde4d86
+      - c5c7c0c7-b6ef-498a-b8d8-80a7bcf39f09
     status: 200 OK
     code: 200
     duration: ""
@@ -744,19 +744,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/cfc86eab-8444-4b7d-ae52-e71326e3eb01
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://cfc86eab-8444-4b7d-ae52-e71326e3eb01.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:01.333778Z","created_at":"2023-10-18T16:44:01.333778Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cfc86eab-8444-4b7d-ae52-e71326e3eb01.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"cfc86eab-8444-4b7d-ae52-e71326e3eb01","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"66609b41-6f0b-4e20-b1b1-adcebf968e47","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-10-18T16:44:09.869754Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:13.359351Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1522"
+      - "1477"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:14 GMT
+      - Tue, 07 Nov 2023 16:21:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb4fe91b-d2b3-4279-9cf3-3a307aba4698
+      - 9e352f51-ec05-4902-bcd3-95759630ff85
     status: 200 OK
     code: 200
     duration: ""
@@ -777,19 +777,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/cfc86eab-8444-4b7d-ae52-e71326e3eb01/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVeVRrUlJkMDFzYjFoRVZFMTZUVlJCZUU1NlJUSk9SRkYzVFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUSE0yQ21WeFR6RmlUMDAyT1dRdlUwMW9NRFJoYzNOeWJIbHZUVmRZTlhFeVJsZFJUbWxMV0RBelNuSkJRamRTTjI0d01uTnBNbGRFVmpGeGVVZGhaMHRsUm5vS1MyaEdObE5rTTNwTWEzZFBTMncyUmlzelNuZzNVR1pPVkd3ck4wSmlkM05KTmpFek5EZzFUbEJwUkRkaFJtSldhR29yT0hjNGVHSm9RM1pHVWxsTGRRcHVhVkJEY1ZJMFQwTjJOazVLUm1SU2MzWk5la3BwZVhveEsySXhRek5RUjNadE0wVm1NQzlXTTFKc1NXTmtSMDB5V2pRMVIxVmtLMVZZY0RaS05IRkxDbFJOVkcxb01tMDJhalJFWkRWdVN6VkdTRzVrU25KTU5GazBWR1lyUjI5WmRXaGlNbWxoYUZGTFZHeEJiMUpvUTBVMFkwRjRObVJpUm5kSWVWVjZTM2tLTmxsRVIzUlBUQzlHZEZreFZISkphbFUyV1ZsamJWbFpOV2RhSzBwcmJEZHdPR1ZMVjI5eWRHdFFVMGRXU0hKTmFtVnRTa3hFZEV0NlQySkhVRzFyT1FwUGIxTktSMHBYZDJWaGJWSmFjbWgwVVc0NFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUE1tcHNLMVp1UjI5YVN6RjZUVmxIYm1GVGVYRjFjSHBXZGl0TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1lrWnpRVFV6VjNGMllXUjBUVFJIVDFsWFpsTm9Vbmg1V21sclN6RXZNRlIzVmtSS1JEbExhbkZqT0RCSmRGZFFTUXBLUTB3clpUbDJVMWxIWWtoaVdHRTVWMjFhYjBabVpuZExOMjExWVZoQk1qZHdNazl1WTNadE5VUTNZM1paUXpFcmNXZzFNa2xZY2tkT0swazJkamQ1Q20xWGRHMHpjemNyYUhGQ2JXUkNRVnBMVEdwM1oyUTRSM0E1U0VGeE0yUlljWEJ3VkdKTVdtSkRUV0V5TW5oeE1GTTBRaTk2WXpGNFlrMU5WbG8wYm1nS2RuRTVabXRUT0dwdWJrNW1TWE5pVlRCM0t5c3JSMjlvTDFwUmFtWXpTRkoyVDA5NWNrd3hUV3BxTVROMmRIUkphM0Y2UlhKaWNVdFZRMnRVVHpCTmFBbzFNRWRLU1RaU1NrWmlWVVJEZVZnMlIxZFNVelF6WW5ob1oyZDNhU3RTVVdzNFptaERjMGhPWlZVNWNFaFJWWEZ6VHpNclNqWktXRFJyWVVOT1ZFZG5DalpsTXpFMWMxbzVSRzU2VEZVMFpqVkpNMFJHV0RnNVdrbEtiekpyVDBoeFZ6bDZhZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vY2ZjODZlYWItODQ0NC00YjdkLWFlNTItZTcxMzI2ZTNlYjAxLmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAyIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXaEU5SWVmWUNBSFlDaTY3WUNhOXFVR0swV1lwSzNsQmdUcWFRcVd4MVZuZ3d0NjJPeWNud2h2OQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtYXV0b3NjYWxlci0wMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEZkMDVzYjFoRVZFMTZUVlJGZDA1cVJUSk5ha1YzVG14dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUamxsQ2toaGVucEpVSEJpY25sS1ZsQkRabU5YTld4TFoyRTVaR1EyZWs5UGEyODBTMk5LUm5aS1ozVm5hbFl4V2tReFVsTklRMk5pZFZaMFNEbHBkR05VSzFVS1QwcHpZMHhxV0daelpYbHpVR3BKVEVSUVlTOHhWazVwTTJsUVoxRldSRWRMSzNZM1dFazRhbXh2TUZCclEwZEVjRXQ2YzJneGFqSXphRWhaYzBkUVF3cHZXRVZhZFVkbGRXeFJWWFpMTTBaVlJEa3daMjlaVUVFNFJFVXlUM05JYkU1eFVsbHFOMFIzWkdsdlNURkVURTAxY1ZaT1VsUkliVGRwTmpCS2FYRmlDbXh1WjBGMVZXaFRUbVJJVjAxUWFURmFlVFV6WVdSaVlVWlpRbXRZTWxoSmRucFJaM1JhWTJWV2RtMTNhRkJNWXpZemNXRnFkVGRXTVhZcmIweFFRa2tLS3pabGNuTk9jVzFYT1c1aWEwODJVemxEUXpWTVVsb3JaVUY0TjNaM1YzZHFkVTUxZGtsMFJrMHZUVmxhUVRKblVHTjVRa0YxTWxsRGNGcDZVRkZCTHdwNmRrbHZhMGwxWm5CSGFYRjFOVzVhVVhZNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRmVWY3hhRGxwYlVaYWJWQk1PREp0WW5aMU15dFNTR3QwYVd0TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2MwUTNMM1YzVlc1dlFsSTVSR2d5Vms1U1NURnNNVUZTYWxnNFUySkNWRmhIUldOdVRHbFhORkl5YjFabk9HZGxhUXB1ZFVoVVdteGpMMnBCTDBWb1NDOUNhRU5EV1dWTlpHbFJNR1F4VnpoaVJEbEliVkozTUhRME1FNUNlVEEwT0haeFZucGtWV2h2ZWxWNGQzTTBWek5GQ2pZMlJHOWxiVFEyTUdWdE9HZEhLM2xFU1VOUFVqTm9Ua2xIYjJWYVRHNTROVTVGUmtGQk1IZEZWR2N4UTBGeFNFMVVWbmQxVkVjdk0xUlNRV0pEWm5rS1NXUjNTRUUwUkZwU1kxTndTR1ZoVWxrclNXcHJkMklyV1dsamEySm9iak13ZG5GaWFuUndhRU5pU0ZsT05ITmlZWFkzUW05b2RESTNOVkZwUW1GcU1nbzJSbFZVY1hKWFRGZEhXRzB3SzJaWWNrWkNkamxNTVRZMFIxZFBXVkoxVTJwUE1UQlhWRkV6YVRaTVUweDNSbGQ0VjFGV1pVeHBlVE5GWm0xV2RVWTRDalF3TVZSeGFrZFlPWEI2U1ZoNVN6bDZVa1JCWVhSc2RITTRjbFkxZDFKbWVrTk1WQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZWU0Y2NmNzYtZDFjNy00OTM2LWFiYTEtN2JiNGY5NTM1MWY2LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtYXV0b3NjYWxlci0wMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1hdXRvc2NhbGVyLTAyIgogICAgdXNlcjogdGVzdC1hdXRvc2NhbGVyLTAyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1hdXRvc2NhbGVyLTAyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1hdXRvc2NhbGVyLTAyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBrYTZDR3dSZkFTM0tuNVh4OGNnM2pDa00xMkVYQ0xTZjVpblZtNExSYmNmbE4ycVRKWklXUWd5RA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2638"
+      - "2636"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:14 GMT
+      - Tue, 07 Nov 2023 16:21:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d700034-4ecd-4dbd-afb3-0d2f5b688f84
+      - 6989c342-8239-4e4e-b9b2-43c97f9bd62d
     status: 200 OK
     code: 200
     duration: ""
@@ -810,19 +810,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/cfc86eab-8444-4b7d-ae52-e71326e3eb01?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://cfc86eab-8444-4b7d-ae52-e71326e3eb01.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:01.333778Z","created_at":"2023-10-18T16:44:01.333778Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cfc86eab-8444-4b7d-ae52-e71326e3eb01.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"cfc86eab-8444-4b7d-ae52-e71326e3eb01","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"66609b41-6f0b-4e20-b1b1-adcebf968e47","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-10-18T16:44:15.322099984Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:18.726789178Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1520"
+      - "1475"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:15 GMT
+      - Tue, 07 Nov 2023 16:21:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7bee4a9-09f4-4d20-947b-6026e15f73b6
+      - c1251e4e-d0bc-4e1c-91bf-de63a52b4159
     status: 200 OK
     code: 200
     duration: ""
@@ -843,19 +843,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/cfc86eab-8444-4b7d-ae52-e71326e3eb01
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://cfc86eab-8444-4b7d-ae52-e71326e3eb01.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:01.333778Z","created_at":"2023-10-18T16:44:01.333778Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cfc86eab-8444-4b7d-ae52-e71326e3eb01.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"cfc86eab-8444-4b7d-ae52-e71326e3eb01","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"66609b41-6f0b-4e20-b1b1-adcebf968e47","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-10-18T16:44:15.322100Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:18.726789Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1517"
+      - "1472"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:15 GMT
+      - Tue, 07 Nov 2023 16:21:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90ace2d9-1b37-4da1-8c42-a110f556a660
+      - 64258434-f5ad-4162-a430-4e67a28c4dec
     status: 200 OK
     code: 200
     duration: ""
@@ -876,19 +876,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/cfc86eab-8444-4b7d-ae52-e71326e3eb01
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://cfc86eab-8444-4b7d-ae52-e71326e3eb01.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:01.333778Z","created_at":"2023-10-18T16:44:01.333778Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.cfc86eab-8444-4b7d-ae52-e71326e3eb01.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"cfc86eab-8444-4b7d-ae52-e71326e3eb01","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"66609b41-6f0b-4e20-b1b1-adcebf968e47","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-10-18T16:44:15.322100Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"most_pods","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":2664,"scale_down_delay_after_add":"20m","scale_down_disabled":false,"scale_down_unneeded_time":"5m","scale_down_utilization_threshold":0.33},"cluster_url":"https://ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:21:05.027481Z","created_at":"2023-11-07T16:21:05.027481Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ee4ccf76-d1c7-4936-aba1-7bb4f95351f6.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","ingress":"none","name":"test-autoscaler-02","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"fc79e33c-2733-41ba-ab51-205753408640","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","autoscaler-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:18.726789Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1517"
+      - "1472"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:20 GMT
+      - Tue, 07 Nov 2023 16:21:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 089b23ee-b1cd-4482-ab70-5b5dc207862c
+      - 1714d80e-435e-4b07-bcd2-e8ece98e9f26
     status: 200 OK
     code: 200
     duration: ""
@@ -909,10 +909,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/cfc86eab-8444-4b7d-ae52-e71326e3eb01
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"cfc86eab-8444-4b7d-ae52-e71326e3eb01","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -921,7 +921,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:25 GMT
+      - Tue, 07 Nov 2023 16:21:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99a3de3d-c6d2-4347-9072-cc1b05869e45
+      - b1a643f7-651e-40b5-8fdf-998bc0427c61
     status: 404 Not Found
     code: 404
     duration: ""
@@ -942,10 +942,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/66609b41-6f0b-4e20-b1b1-adcebf968e47
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/fc79e33c-2733-41ba-ab51-205753408640
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"66609b41-6f0b-4e20-b1b1-adcebf968e47","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"fc79e33c-2733-41ba-ab51-205753408640","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -954,7 +954,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:25 GMT
+      - Tue, 07 Nov 2023 16:21:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c0e7638-5c3f-4b85-9c92-1e19e2e201f7
+      - fc516d75-563e-4777-a2bb-d1926c154eb8
     status: 404 Not Found
     code: 404
     duration: ""
@@ -975,10 +975,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/cfc86eab-8444-4b7d-ae52-e71326e3eb01
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ee4ccf76-d1c7-4936-aba1-7bb4f95351f6
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"cfc86eab-8444-4b7d-ae52-e71326e3eb01","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"ee4ccf76-d1c7-4936-aba1-7bb4f95351f6","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -987,7 +987,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:25 GMT
+      - Tue, 07 Nov 2023 16:21:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b31c1e8-2360-4efc-aa45-451fef385d4e
+      - 39d87a5f-36d0-439c-aa2e-6cba8cd8e6a6
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-basic.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-basic.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:41 GMT
+      - Tue, 07 Nov 2023 16:19:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c9edd39-2d34-4699-9f33-3e36b5b8b746
+      - 7f5bdfd6-77df-457a-82ee-cfbb79084782
     status: 200 OK
     code: 200
     duration: ""
@@ -61,7 +61,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:41 GMT
+      - Tue, 07 Nov 2023 16:19:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -71,12 +71,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 148ce013-9118-4bf3-a44e-d701a1221764
+      - 92713f32-3d97-42ee-897e-a3aaeb65f0e8
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-minimal","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"test-minimal","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -87,16 +87,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-18T16:44:13.182219Z","dhcp_enabled":true,"id":"f3137de7-572a-48e4-921c-20cbd352be1b","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:44:13.182219Z","id":"00541e5c-5a6f-48fe-bb5e-4b507b0d066e","subnet":"172.16.20.0/22","updated_at":"2023-10-18T16:44:13.182219Z"},{"created_at":"2023-10-18T16:44:13.182219Z","id":"1e83ba5a-7195-4b12-bc69-f89a59bcb25a","subnet":"fd63:256c:45f7:11b4::/64","updated_at":"2023-10-18T16:44:13.182219Z"}],"tags":[],"updated_at":"2023-10-18T16:44:13.182219Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:24:25.480410Z","dhcp_enabled":true,"id":"38d51a1a-233e-48da-9b96-feb735b75055","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:24:25.480410Z","id":"500e09ad-b117-4ed3-8beb-c5f91028994e","subnet":"172.16.24.0/22","updated_at":"2023-11-07T16:24:25.480410Z"},{"created_at":"2023-11-07T16:24:25.480410Z","id":"57516592-b62d-4f65-922e-f300d27921d9","subnet":"fd63:256c:45f7:4d04::/64","updated_at":"2023-11-07T16:24:25.480410Z"}],"tags":[],"updated_at":"2023-11-07T16:24:25.480410Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "713"
+      - "696"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:13 GMT
+      - Tue, 07 Nov 2023 16:24:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -106,7 +106,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c1042b6-5af1-46ad-9e1c-d80cf5ef46c4
+      - 07f55291-e785-4ee2-856c-055da2b4a602
     status: 200 OK
     code: 200
     duration: ""
@@ -117,19 +117,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f3137de7-572a-48e4-921c-20cbd352be1b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/38d51a1a-233e-48da-9b96-feb735b75055
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:44:13.182219Z","dhcp_enabled":true,"id":"f3137de7-572a-48e4-921c-20cbd352be1b","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:44:13.182219Z","id":"00541e5c-5a6f-48fe-bb5e-4b507b0d066e","subnet":"172.16.20.0/22","updated_at":"2023-10-18T16:44:13.182219Z"},{"created_at":"2023-10-18T16:44:13.182219Z","id":"1e83ba5a-7195-4b12-bc69-f89a59bcb25a","subnet":"fd63:256c:45f7:11b4::/64","updated_at":"2023-10-18T16:44:13.182219Z"}],"tags":[],"updated_at":"2023-10-18T16:44:13.182219Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:24:25.480410Z","dhcp_enabled":true,"id":"38d51a1a-233e-48da-9b96-feb735b75055","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:24:25.480410Z","id":"500e09ad-b117-4ed3-8beb-c5f91028994e","subnet":"172.16.24.0/22","updated_at":"2023-11-07T16:24:25.480410Z"},{"created_at":"2023-11-07T16:24:25.480410Z","id":"57516592-b62d-4f65-922e-f300d27921d9","subnet":"fd63:256c:45f7:4d04::/64","updated_at":"2023-11-07T16:24:25.480410Z"}],"tags":[],"updated_at":"2023-11-07T16:24:25.480410Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "713"
+      - "696"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:13 GMT
+      - Tue, 07 Nov 2023 16:24:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -139,12 +139,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a556ebd9-b91b-4cdd-9b69-346a899f5cf6
+      - 2e3735ee-001c-44f6-9020-ba04cf7a4011
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-minimal","description":"","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"version":"1.27.6","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":"f3137de7-572a-48e4-921c-20cbd352be1b"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-minimal","description":"","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"version":"1.27.6","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055"}'
     form: {}
     headers:
       Content-Type:
@@ -155,16 +155,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0d88eb0b-643e-430a-985b-564f31e3aaa4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:14.065549682Z","created_at":"2023-10-18T16:44:14.065549682Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d88eb0b-643e-430a-985b-564f31e3aaa4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0d88eb0b-643e-430a-985b-564f31e3aaa4","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f3137de7-572a-48e4-921c-20cbd352be1b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:44:14.077081658Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079101Z","created_at":"2023-11-07T16:24:26.509079101Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:26.520514787Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1503"
+      - "1458"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:14 GMT
+      - Tue, 07 Nov 2023 16:24:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -174,7 +174,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d972e3d5-b7b1-4f42-ac99-d0212786a9f6
+      - 270b89ec-5963-4336-926e-597304c3ce01
     status: 200 OK
     code: 200
     duration: ""
@@ -185,19 +185,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0d88eb0b-643e-430a-985b-564f31e3aaa4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:14.065550Z","created_at":"2023-10-18T16:44:14.065550Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d88eb0b-643e-430a-985b-564f31e3aaa4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0d88eb0b-643e-430a-985b-564f31e3aaa4","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f3137de7-572a-48e4-921c-20cbd352be1b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:44:14.077082Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:26.520515Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1494"
+      - "1449"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:14 GMT
+      - Tue, 07 Nov 2023 16:24:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -207,7 +207,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b190f97-6e8f-4c54-92a6-c88f7f65841a
+      - 8ac11dd9-92bd-463e-ad0d-ae64aeaf73e5
     status: 200 OK
     code: 200
     duration: ""
@@ -218,19 +218,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0d88eb0b-643e-430a-985b-564f31e3aaa4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:14.065550Z","created_at":"2023-10-18T16:44:14.065550Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d88eb0b-643e-430a-985b-564f31e3aaa4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0d88eb0b-643e-430a-985b-564f31e3aaa4","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f3137de7-572a-48e4-921c-20cbd352be1b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:44:15.566447Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:28.100988Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1499"
+      - "1454"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:19 GMT
+      - Tue, 07 Nov 2023 16:24:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -240,7 +240,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c85f0aa4-1481-4f0a-a761-f47475accd6e
+      - 08a15768-f141-46b2-bc4a-ad72bf5aeffd
     status: 200 OK
     code: 200
     duration: ""
@@ -251,19 +251,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0d88eb0b-643e-430a-985b-564f31e3aaa4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:14.065550Z","created_at":"2023-10-18T16:44:14.065550Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d88eb0b-643e-430a-985b-564f31e3aaa4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0d88eb0b-643e-430a-985b-564f31e3aaa4","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f3137de7-572a-48e4-921c-20cbd352be1b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:44:15.566447Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:28.100988Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1499"
+      - "1454"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:19 GMT
+      - Tue, 07 Nov 2023 16:24:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -273,7 +273,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce24cd65-07d9-406e-b999-20794dcef9e0
+      - 3f020937-ae2a-4758-88b0-e0730e355341
     status: 200 OK
     code: 200
     duration: ""
@@ -284,19 +284,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVeVRrUlJlRTVXYjFoRVZFMTZUVlJCZUU1NlJUSk9SRkY0VGxadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJVRVJKQ21sVmJEbEZNV0ZTUlRGcVowbEtXR1pJVGtKbFdXdFJUM1JYYUVaMVNWUjFSVU5WT1VwMWJuRnpha1p5YnpCYWFpdHBXRlJYTjNjcmRuRTJaemRFTlUwS2NYWTRTMmQxYTBreWJrSTVMMUoxZHpCelYxWXJOakpFYlhsaFdISlpTM2RPU21OeFJ6aFNOM0E0VjJSTFltaDNWU3QzTDNFeWRXOU1abVZ0TlUxWk13cHJTbmhwV1VWclNqSk5aRGswUjBwT2RreDZiRFIxUTNGbWRGbFFkSGxCTmxZMFkyZzNWR2xoTkd4Rk5HY3dOVE5EZGxKSk0wZDJPSEFyWWs1c1NIWTJDalJFZDA1SVpVWndNRWwxU0c5dVdWWnFZMjR4WVVOVk5qUXhRbGRZU1RJeWJUZzJkblEyYlVzdmVreFhRalozZDFkQldXRkdlVzlSVVRSeVdHcDZPVmdLT0ZwU1RtRnJTamxGUTJkSVpXMHhOREJMTHlzMlVYbDRSRlpHUkdsaE1ISjBUMDlvV0dsRFpVTlRUMkpVTkhocVlWUkVUakpyYkZrMlpFb3ZURFYyV2dwMmNrRXJUVEpPYWtOUGNqWklVMm96VkRoelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUVNuZEVZMFV2VVZkU1ZXYzJPRlZCVjFvdk5qaEVMMHR2UjJsTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRGVHWkJhM0p6VmtGdVowZHBPWGhUYm5wRGNUTXlZVVpET1RSM01XSnRVMjVZTkZaQ1VXaG1jVTV3YUhkbFUzaFRRUXAzWW0xWVpUSmpXVXBuTTFKQ2FHWXpVRE5FWlhGMGJYSkhlRnB4ZFU5SlNGUXJaalJ1UWxWb2FVVk9aM0JIZDIxMFMweHRTVFZ4Um1vM1oxRlNiRUZJQ21GME1FVlBTMWROVkZkQ2FHNW5hazFCVFRBM2MxWjZRMVpVUVZJd05FdDZlbk5EYUdkSmJHRkJOakJTU1ZrelVtNXlNM0p5ZEdSQkwyMVRTalpyT1ZRS2F6ZFdaSEJWUjNSamNIcG9hREJ3TWxSNFpFRmFURkJCVG5SSk5YZ3djQ3R6YW1oc1JGVkJka0kwVlVWdlExTldOV0pQY0U0eU1FdHNRV1JvT0RnMVdBbzRMMVp2YjB4c2RsTXpTaXRTYm5WTGNEUlZaRU55YjNOM2JreGxUR3czU21Fd1JHTXZla2xZY1hwRGFGQnRLMUF3SzJZeGFHeFBhMmh5ZG5ONlJVNVRDblJVVWpkcVMxWjZMMk12ZDNGeWJpOUZiM040YmsxMWQwMVRSSFpvVjNnMWJtMUdSQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMGQ4OGViMGItNjQzZS00MzBhLTk4NWItNTY0ZjMxZTNhYWE0LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiUmNDdHl4eFFyUTdHbm04RG9DT0E2RGk4TDJSdHg5N1dyM0g3VnNvWkQ3ZlBtbVhGbnJualZnRg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcFJlVTR4YjFoRVZFMTZUVlJGZDA1cVJUSk5hbEY1VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTM1V2Q2s1VFprMDNSM2hXY25selZuVjFRMDExYTNaTU5FNUtVVWxrYkZZNVoyaGpjVVJXVUZNMVNVdFVWMUpvVGtGaVVrVnpMM1JzYjNGcmFHaHRRV3BFZW1rS1JVWkRibFUzY2s5YWFHdzRSbUpqWlcxRFowUjBkMGRVUW10UE5EWjZSV2N3Tm5wVmNXSkhkMlJDUlVFMVRVWlpTMGxEYkRGUk5EaGxjbXcwVTFSNVZRcE9PVEpPY2pWRVdXUlVaakZXZGtSbE16TktRM0J5UnpKMlNUbFlOVEp4Y1d4UVNGUXpZVmsxTkZVMFRXbFNURmxYWW5oUVEzWTRNazFGVVVsMFVuQmFDbUpRYTJOWWJrNHJOWFZsUTBOdVIyMW1iMXBUWVVWek5GSjRka3R2YTJSRFZsSlJOMWhQVFdreGFVUjRZak01TVdVME9HeE5WbXBZV1VwNll6Y3lhVkFLUjBka1VreFVVazR6YUZGa2JHNUZUbk5sY0hrelpXSXpaMUJ5V1c5a09GTXJkV1YwTm5kR2EyeDZVaXQ1ZEc4eFFTOHpaRFp4TW1SUFFrUnlOWEJQTHdvNGNGYzJibWN3Tm1OTlNqSjNSa1F4ZEZSRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSWVITnJTa1kzZFdFM1dXZEJkSEUxYURZcmMyY3dSREJPYjNGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk5UQnVVMjk0YzB4eFltNU5aMlpuTlVad2FVTkZRekowVUhsRU5tUTNUbkpvWlNzd2RVdzRORXRWYVZKUlVpdDBjd3BJVkVaTFdXTldNM0pYU2tGNGVrMXlWVE16TUdaV1ZHOXJVV3RTT1U5U2JHSnpiVXRsU3psNGNIWXJTM1pCY0ZGelprOU9OelZ0UTJNck1tOUlUR0V2Q2pOalNUbFFUMlpzYWs5a01XbzBNRU5qZUZSM2NWRmtWaTlPT1U4eVZFbHZlR2R6UTB0NGVWQnRObWQ1ZW1SemFscHFkbkZ0U0VwNU5qQnNRWEEzWjJZS2RsQnlVRlo0Tm1oeVRqVXJhMUZ2S3pKdFdWWktRM0ozWTBKb2RTdHBkR3hhUzFJcmEycHVOV2haVERsSmVYVTBiR0U0YjAxR1VFTjFSa1J4VmxreU5ncG5TSGRhVjBGbWNEaFBSMVozU0VwM1drVXhVV3RXYzJVeUswMXdVek5wU1hWVWVISmhiMFVyTVZkdFYzaHhZazV5WWtaTWFtSlhWRWRxTkVScmFuQnpDbHBqT1VoVWJrWm9ZelJwWTFGQlFsQmxOVWhzTDBZM1FXTnhabEZvZDA1UFkxSlFad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOGViZTM4NzItN2E5Mi00ZGFiLThmMzItMjM3ODBkN2Y4MDU4LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXQ2t5OTB2dHoxVXlGdDFCVFJ2eEhYeklOSDNndU9OcUJQaG12WDhNM09SdFVBeHZpeXhoSUwyNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2590"
+      - "2588"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:19 GMT
+      - Tue, 07 Nov 2023 16:24:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -306,7 +306,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63153c41-3505-4c55-af17-96a4f9d0ca3c
+      - 0b49b8af-8358-4ed1-b48b-33498703ddbc
     status: 200 OK
     code: 200
     duration: ""
@@ -317,19 +317,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0d88eb0b-643e-430a-985b-564f31e3aaa4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:14.065550Z","created_at":"2023-10-18T16:44:14.065550Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d88eb0b-643e-430a-985b-564f31e3aaa4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0d88eb0b-643e-430a-985b-564f31e3aaa4","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f3137de7-572a-48e4-921c-20cbd352be1b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:44:15.566447Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:28.100988Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1499"
+      - "1454"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:19 GMT
+      - Tue, 07 Nov 2023 16:24:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -339,7 +339,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eec0ef2a-76ff-47d9-bd8b-5a7a6a0d4fb1
+      - 8837dc54-93f2-4132-a28d-08a0f502bdb8
     status: 200 OK
     code: 200
     duration: ""
@@ -350,19 +350,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f3137de7-572a-48e4-921c-20cbd352be1b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/38d51a1a-233e-48da-9b96-feb735b75055
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:44:13.182219Z","dhcp_enabled":true,"id":"f3137de7-572a-48e4-921c-20cbd352be1b","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:44:13.182219Z","id":"00541e5c-5a6f-48fe-bb5e-4b507b0d066e","subnet":"172.16.20.0/22","updated_at":"2023-10-18T16:44:13.182219Z"},{"created_at":"2023-10-18T16:44:13.182219Z","id":"1e83ba5a-7195-4b12-bc69-f89a59bcb25a","subnet":"fd63:256c:45f7:11b4::/64","updated_at":"2023-10-18T16:44:13.182219Z"}],"tags":[],"updated_at":"2023-10-18T16:44:13.182219Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:24:25.480410Z","dhcp_enabled":true,"id":"38d51a1a-233e-48da-9b96-feb735b75055","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:24:25.480410Z","id":"500e09ad-b117-4ed3-8beb-c5f91028994e","subnet":"172.16.24.0/22","updated_at":"2023-11-07T16:24:25.480410Z"},{"created_at":"2023-11-07T16:24:25.480410Z","id":"57516592-b62d-4f65-922e-f300d27921d9","subnet":"fd63:256c:45f7:4d04::/64","updated_at":"2023-11-07T16:24:25.480410Z"}],"tags":[],"updated_at":"2023-11-07T16:24:25.480410Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "713"
+      - "696"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:19 GMT
+      - Tue, 07 Nov 2023 16:24:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -372,7 +372,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f85919d9-c06c-4d66-8ea5-24136fa62139
+      - c07b508a-e6a9-476d-a197-d43cb6124188
     status: 200 OK
     code: 200
     duration: ""
@@ -383,19 +383,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0d88eb0b-643e-430a-985b-564f31e3aaa4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:14.065550Z","created_at":"2023-10-18T16:44:14.065550Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d88eb0b-643e-430a-985b-564f31e3aaa4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0d88eb0b-643e-430a-985b-564f31e3aaa4","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f3137de7-572a-48e4-921c-20cbd352be1b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:44:15.566447Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:28.100988Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1499"
+      - "1454"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:19 GMT
+      - Tue, 07 Nov 2023 16:24:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -405,7 +405,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1635184e-f0c2-49fb-80ac-7b021c87e3e3
+      - 7b1232a6-dd49-4f62-9820-4d8df9b01ec7
     status: 200 OK
     code: 200
     duration: ""
@@ -416,19 +416,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVeVRrUlJlRTVXYjFoRVZFMTZUVlJCZUU1NlJUSk9SRkY0VGxadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJVRVJKQ21sVmJEbEZNV0ZTUlRGcVowbEtXR1pJVGtKbFdXdFJUM1JYYUVaMVNWUjFSVU5WT1VwMWJuRnpha1p5YnpCYWFpdHBXRlJYTjNjcmRuRTJaemRFTlUwS2NYWTRTMmQxYTBreWJrSTVMMUoxZHpCelYxWXJOakpFYlhsaFdISlpTM2RPU21OeFJ6aFNOM0E0VjJSTFltaDNWU3QzTDNFeWRXOU1abVZ0TlUxWk13cHJTbmhwV1VWclNqSk5aRGswUjBwT2RreDZiRFIxUTNGbWRGbFFkSGxCTmxZMFkyZzNWR2xoTkd4Rk5HY3dOVE5EZGxKSk0wZDJPSEFyWWs1c1NIWTJDalJFZDA1SVpVWndNRWwxU0c5dVdWWnFZMjR4WVVOVk5qUXhRbGRZU1RJeWJUZzJkblEyYlVzdmVreFhRalozZDFkQldXRkdlVzlSVVRSeVdHcDZPVmdLT0ZwU1RtRnJTamxGUTJkSVpXMHhOREJMTHlzMlVYbDRSRlpHUkdsaE1ISjBUMDlvV0dsRFpVTlRUMkpVTkhocVlWUkVUakpyYkZrMlpFb3ZURFYyV2dwMmNrRXJUVEpPYWtOUGNqWklVMm96VkRoelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUVNuZEVZMFV2VVZkU1ZXYzJPRlZCVjFvdk5qaEVMMHR2UjJsTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRGVHWkJhM0p6VmtGdVowZHBPWGhUYm5wRGNUTXlZVVpET1RSM01XSnRVMjVZTkZaQ1VXaG1jVTV3YUhkbFUzaFRRUXAzWW0xWVpUSmpXVXBuTTFKQ2FHWXpVRE5FWlhGMGJYSkhlRnB4ZFU5SlNGUXJaalJ1UWxWb2FVVk9aM0JIZDIxMFMweHRTVFZ4Um1vM1oxRlNiRUZJQ21GME1FVlBTMWROVkZkQ2FHNW5hazFCVFRBM2MxWjZRMVpVUVZJd05FdDZlbk5EYUdkSmJHRkJOakJTU1ZrelVtNXlNM0p5ZEdSQkwyMVRTalpyT1ZRS2F6ZFdaSEJWUjNSamNIcG9hREJ3TWxSNFpFRmFURkJCVG5SSk5YZ3djQ3R6YW1oc1JGVkJka0kwVlVWdlExTldOV0pQY0U0eU1FdHNRV1JvT0RnMVdBbzRMMVp2YjB4c2RsTXpTaXRTYm5WTGNEUlZaRU55YjNOM2JreGxUR3czU21Fd1JHTXZla2xZY1hwRGFGQnRLMUF3SzJZeGFHeFBhMmh5ZG5ONlJVNVRDblJVVWpkcVMxWjZMMk12ZDNGeWJpOUZiM040YmsxMWQwMVRSSFpvVjNnMWJtMUdSQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMGQ4OGViMGItNjQzZS00MzBhLTk4NWItNTY0ZjMxZTNhYWE0LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiUmNDdHl4eFFyUTdHbm04RG9DT0E2RGk4TDJSdHg5N1dyM0g3VnNvWkQ3ZlBtbVhGbnJualZnRg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcFJlVTR4YjFoRVZFMTZUVlJGZDA1cVJUSk5hbEY1VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTM1V2Q2s1VFprMDNSM2hXY25selZuVjFRMDExYTNaTU5FNUtVVWxrYkZZNVoyaGpjVVJXVUZNMVNVdFVWMUpvVGtGaVVrVnpMM1JzYjNGcmFHaHRRV3BFZW1rS1JVWkRibFUzY2s5YWFHdzRSbUpqWlcxRFowUjBkMGRVUW10UE5EWjZSV2N3Tm5wVmNXSkhkMlJDUlVFMVRVWlpTMGxEYkRGUk5EaGxjbXcwVTFSNVZRcE9PVEpPY2pWRVdXUlVaakZXZGtSbE16TktRM0J5UnpKMlNUbFlOVEp4Y1d4UVNGUXpZVmsxTkZVMFRXbFNURmxYWW5oUVEzWTRNazFGVVVsMFVuQmFDbUpRYTJOWWJrNHJOWFZsUTBOdVIyMW1iMXBUWVVWek5GSjRka3R2YTJSRFZsSlJOMWhQVFdreGFVUjRZak01TVdVME9HeE5WbXBZV1VwNll6Y3lhVkFLUjBka1VreFVVazR6YUZGa2JHNUZUbk5sY0hrelpXSXpaMUJ5V1c5a09GTXJkV1YwTm5kR2EyeDZVaXQ1ZEc4eFFTOHpaRFp4TW1SUFFrUnlOWEJQTHdvNGNGYzJibWN3Tm1OTlNqSjNSa1F4ZEZSRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSWVITnJTa1kzZFdFM1dXZEJkSEUxYURZcmMyY3dSREJPYjNGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk5UQnVVMjk0YzB4eFltNU5aMlpuTlVad2FVTkZRekowVUhsRU5tUTNUbkpvWlNzd2RVdzRORXRWYVZKUlVpdDBjd3BJVkVaTFdXTldNM0pYU2tGNGVrMXlWVE16TUdaV1ZHOXJVV3RTT1U5U2JHSnpiVXRsU3psNGNIWXJTM1pCY0ZGelprOU9OelZ0UTJNck1tOUlUR0V2Q2pOalNUbFFUMlpzYWs5a01XbzBNRU5qZUZSM2NWRmtWaTlPT1U4eVZFbHZlR2R6UTB0NGVWQnRObWQ1ZW1SemFscHFkbkZ0U0VwNU5qQnNRWEEzWjJZS2RsQnlVRlo0Tm1oeVRqVXJhMUZ2S3pKdFdWWktRM0ozWTBKb2RTdHBkR3hhUzFJcmEycHVOV2haVERsSmVYVTBiR0U0YjAxR1VFTjFSa1J4VmxreU5ncG5TSGRhVjBGbWNEaFBSMVozU0VwM1drVXhVV3RXYzJVeUswMXdVek5wU1hWVWVISmhiMFVyTVZkdFYzaHhZazV5WWtaTWFtSlhWRWRxTkVScmFuQnpDbHBqT1VoVWJrWm9ZelJwWTFGQlFsQmxOVWhzTDBZM1FXTnhabEZvZDA1UFkxSlFad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOGViZTM4NzItN2E5Mi00ZGFiLThmMzItMjM3ODBkN2Y4MDU4LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXQ2t5OTB2dHoxVXlGdDFCVFJ2eEhYeklOSDNndU9OcUJQaG12WDhNM09SdFVBeHZpeXhoSUwyNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2590"
+      - "2588"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:19 GMT
+      - Tue, 07 Nov 2023 16:24:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -438,7 +438,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5728cf5c-7ed4-4258-8a63-43fa95bcf605
+      - 6aa1ef26-eae0-425e-8f83-6d6ace7edb06
     status: 200 OK
     code: 200
     duration: ""
@@ -449,19 +449,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f3137de7-572a-48e4-921c-20cbd352be1b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/38d51a1a-233e-48da-9b96-feb735b75055
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:44:13.182219Z","dhcp_enabled":true,"id":"f3137de7-572a-48e4-921c-20cbd352be1b","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:44:13.182219Z","id":"00541e5c-5a6f-48fe-bb5e-4b507b0d066e","subnet":"172.16.20.0/22","updated_at":"2023-10-18T16:44:13.182219Z"},{"created_at":"2023-10-18T16:44:13.182219Z","id":"1e83ba5a-7195-4b12-bc69-f89a59bcb25a","subnet":"fd63:256c:45f7:11b4::/64","updated_at":"2023-10-18T16:44:13.182219Z"}],"tags":[],"updated_at":"2023-10-18T16:44:13.182219Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:24:25.480410Z","dhcp_enabled":true,"id":"38d51a1a-233e-48da-9b96-feb735b75055","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:24:25.480410Z","id":"500e09ad-b117-4ed3-8beb-c5f91028994e","subnet":"172.16.24.0/22","updated_at":"2023-11-07T16:24:25.480410Z"},{"created_at":"2023-11-07T16:24:25.480410Z","id":"57516592-b62d-4f65-922e-f300d27921d9","subnet":"fd63:256c:45f7:4d04::/64","updated_at":"2023-11-07T16:24:25.480410Z"}],"tags":[],"updated_at":"2023-11-07T16:24:25.480410Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "713"
+      - "696"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:20 GMT
+      - Tue, 07 Nov 2023 16:24:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -471,7 +471,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9aa83ad5-2f72-431c-a05b-bc07a32e33ab
+      - de1380a8-5def-4368-9026-71cb9f953b16
     status: 200 OK
     code: 200
     duration: ""
@@ -482,19 +482,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0d88eb0b-643e-430a-985b-564f31e3aaa4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:14.065550Z","created_at":"2023-10-18T16:44:14.065550Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d88eb0b-643e-430a-985b-564f31e3aaa4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0d88eb0b-643e-430a-985b-564f31e3aaa4","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f3137de7-572a-48e4-921c-20cbd352be1b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:44:15.566447Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:28.100988Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1499"
+      - "1454"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:20 GMT
+      - Tue, 07 Nov 2023 16:24:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -504,7 +504,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c45f4909-ea4a-4db3-974a-113b849075ca
+      - 482881e2-f90a-441a-a62e-b606109a61fe
     status: 200 OK
     code: 200
     duration: ""
@@ -515,19 +515,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVeVRrUlJlRTVXYjFoRVZFMTZUVlJCZUU1NlJUSk9SRkY0VGxadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJVRVJKQ21sVmJEbEZNV0ZTUlRGcVowbEtXR1pJVGtKbFdXdFJUM1JYYUVaMVNWUjFSVU5WT1VwMWJuRnpha1p5YnpCYWFpdHBXRlJYTjNjcmRuRTJaemRFTlUwS2NYWTRTMmQxYTBreWJrSTVMMUoxZHpCelYxWXJOakpFYlhsaFdISlpTM2RPU21OeFJ6aFNOM0E0VjJSTFltaDNWU3QzTDNFeWRXOU1abVZ0TlUxWk13cHJTbmhwV1VWclNqSk5aRGswUjBwT2RreDZiRFIxUTNGbWRGbFFkSGxCTmxZMFkyZzNWR2xoTkd4Rk5HY3dOVE5EZGxKSk0wZDJPSEFyWWs1c1NIWTJDalJFZDA1SVpVWndNRWwxU0c5dVdWWnFZMjR4WVVOVk5qUXhRbGRZU1RJeWJUZzJkblEyYlVzdmVreFhRalozZDFkQldXRkdlVzlSVVRSeVdHcDZPVmdLT0ZwU1RtRnJTamxGUTJkSVpXMHhOREJMTHlzMlVYbDRSRlpHUkdsaE1ISjBUMDlvV0dsRFpVTlRUMkpVTkhocVlWUkVUakpyYkZrMlpFb3ZURFYyV2dwMmNrRXJUVEpPYWtOUGNqWklVMm96VkRoelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUVNuZEVZMFV2VVZkU1ZXYzJPRlZCVjFvdk5qaEVMMHR2UjJsTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRGVHWkJhM0p6VmtGdVowZHBPWGhUYm5wRGNUTXlZVVpET1RSM01XSnRVMjVZTkZaQ1VXaG1jVTV3YUhkbFUzaFRRUXAzWW0xWVpUSmpXVXBuTTFKQ2FHWXpVRE5FWlhGMGJYSkhlRnB4ZFU5SlNGUXJaalJ1UWxWb2FVVk9aM0JIZDIxMFMweHRTVFZ4Um1vM1oxRlNiRUZJQ21GME1FVlBTMWROVkZkQ2FHNW5hazFCVFRBM2MxWjZRMVpVUVZJd05FdDZlbk5EYUdkSmJHRkJOakJTU1ZrelVtNXlNM0p5ZEdSQkwyMVRTalpyT1ZRS2F6ZFdaSEJWUjNSamNIcG9hREJ3TWxSNFpFRmFURkJCVG5SSk5YZ3djQ3R6YW1oc1JGVkJka0kwVlVWdlExTldOV0pQY0U0eU1FdHNRV1JvT0RnMVdBbzRMMVp2YjB4c2RsTXpTaXRTYm5WTGNEUlZaRU55YjNOM2JreGxUR3czU21Fd1JHTXZla2xZY1hwRGFGQnRLMUF3SzJZeGFHeFBhMmh5ZG5ONlJVNVRDblJVVWpkcVMxWjZMMk12ZDNGeWJpOUZiM040YmsxMWQwMVRSSFpvVjNnMWJtMUdSQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMGQ4OGViMGItNjQzZS00MzBhLTk4NWItNTY0ZjMxZTNhYWE0LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiUmNDdHl4eFFyUTdHbm04RG9DT0E2RGk4TDJSdHg5N1dyM0g3VnNvWkQ3ZlBtbVhGbnJualZnRg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcFJlVTR4YjFoRVZFMTZUVlJGZDA1cVJUSk5hbEY1VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTM1V2Q2s1VFprMDNSM2hXY25selZuVjFRMDExYTNaTU5FNUtVVWxrYkZZNVoyaGpjVVJXVUZNMVNVdFVWMUpvVGtGaVVrVnpMM1JzYjNGcmFHaHRRV3BFZW1rS1JVWkRibFUzY2s5YWFHdzRSbUpqWlcxRFowUjBkMGRVUW10UE5EWjZSV2N3Tm5wVmNXSkhkMlJDUlVFMVRVWlpTMGxEYkRGUk5EaGxjbXcwVTFSNVZRcE9PVEpPY2pWRVdXUlVaakZXZGtSbE16TktRM0J5UnpKMlNUbFlOVEp4Y1d4UVNGUXpZVmsxTkZVMFRXbFNURmxYWW5oUVEzWTRNazFGVVVsMFVuQmFDbUpRYTJOWWJrNHJOWFZsUTBOdVIyMW1iMXBUWVVWek5GSjRka3R2YTJSRFZsSlJOMWhQVFdreGFVUjRZak01TVdVME9HeE5WbXBZV1VwNll6Y3lhVkFLUjBka1VreFVVazR6YUZGa2JHNUZUbk5sY0hrelpXSXpaMUJ5V1c5a09GTXJkV1YwTm5kR2EyeDZVaXQ1ZEc4eFFTOHpaRFp4TW1SUFFrUnlOWEJQTHdvNGNGYzJibWN3Tm1OTlNqSjNSa1F4ZEZSRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSWVITnJTa1kzZFdFM1dXZEJkSEUxYURZcmMyY3dSREJPYjNGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk5UQnVVMjk0YzB4eFltNU5aMlpuTlVad2FVTkZRekowVUhsRU5tUTNUbkpvWlNzd2RVdzRORXRWYVZKUlVpdDBjd3BJVkVaTFdXTldNM0pYU2tGNGVrMXlWVE16TUdaV1ZHOXJVV3RTT1U5U2JHSnpiVXRsU3psNGNIWXJTM1pCY0ZGelprOU9OelZ0UTJNck1tOUlUR0V2Q2pOalNUbFFUMlpzYWs5a01XbzBNRU5qZUZSM2NWRmtWaTlPT1U4eVZFbHZlR2R6UTB0NGVWQnRObWQ1ZW1SemFscHFkbkZ0U0VwNU5qQnNRWEEzWjJZS2RsQnlVRlo0Tm1oeVRqVXJhMUZ2S3pKdFdWWktRM0ozWTBKb2RTdHBkR3hhUzFJcmEycHVOV2haVERsSmVYVTBiR0U0YjAxR1VFTjFSa1J4VmxreU5ncG5TSGRhVjBGbWNEaFBSMVozU0VwM1drVXhVV3RXYzJVeUswMXdVek5wU1hWVWVISmhiMFVyTVZkdFYzaHhZazV5WWtaTWFtSlhWRWRxTkVScmFuQnpDbHBqT1VoVWJrWm9ZelJwWTFGQlFsQmxOVWhzTDBZM1FXTnhabEZvZDA1UFkxSlFad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOGViZTM4NzItN2E5Mi00ZGFiLThmMzItMjM3ODBkN2Y4MDU4LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXQ2t5OTB2dHoxVXlGdDFCVFJ2eEhYeklOSDNndU9OcUJQaG12WDhNM09SdFVBeHZpeXhoSUwyNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2590"
+      - "2588"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:20 GMT
+      - Tue, 07 Nov 2023 16:24:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -537,7 +537,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f66d3de-9573-4a66-b70f-5cc26d8d0c9b
+      - a0695590-10fa-4a06-8970-238058cde499
     status: 200 OK
     code: 200
     duration: ""
@@ -548,19 +548,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0d88eb0b-643e-430a-985b-564f31e3aaa4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:14.065550Z","created_at":"2023-10-18T16:44:14.065550Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d88eb0b-643e-430a-985b-564f31e3aaa4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0d88eb0b-643e-430a-985b-564f31e3aaa4","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f3137de7-572a-48e4-921c-20cbd352be1b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:44:15.566447Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:28.100988Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1499"
+      - "1454"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:20 GMT
+      - Tue, 07 Nov 2023 16:24:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -570,12 +570,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6970f4e6-1b6c-4242-949f-acebfd24895d
+      - b0d5f459-ab3f-4d94-8c5f-812dbc4a72c5
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":null,"description":null,"tags":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":null,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":null},"auto_upgrade":{"enable":null,"maintenance_window":null},"feature_gates":null,"admission_plugins":null,"open_id_connect_config":{"issuer_url":null,"client_id":null,"username_claim":null,"username_prefix":null,"groups_claim":null,"groups_prefix":null,"required_claim":null},"apiserver_cert_sans":null}'
+    body: '{"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":null,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":null},"auto_upgrade":{"enable":null,"maintenance_window":null},"open_id_connect_config":{"issuer_url":null,"client_id":null,"username_claim":null,"username_prefix":null,"groups_claim":null,"groups_prefix":null,"required_claim":null}}'
     form: {}
     headers:
       Content-Type:
@@ -583,19 +583,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0d88eb0b-643e-430a-985b-564f31e3aaa4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:14.065550Z","created_at":"2023-10-18T16:44:14.065550Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d88eb0b-643e-430a-985b-564f31e3aaa4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0d88eb0b-643e-430a-985b-564f31e3aaa4","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f3137de7-572a-48e4-921c-20cbd352be1b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:44:20.978398598Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:33.410493663Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1497"
+      - "1452"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:21 GMT
+      - Tue, 07 Nov 2023 16:24:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -605,7 +605,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04cc535a-9696-4302-abd2-28f509f1db6b
+      - 1b39647b-724d-4968-a6ee-9745526723b9
     status: 200 OK
     code: 200
     duration: ""
@@ -616,19 +616,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0d88eb0b-643e-430a-985b-564f31e3aaa4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:14.065550Z","created_at":"2023-10-18T16:44:14.065550Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d88eb0b-643e-430a-985b-564f31e3aaa4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0d88eb0b-643e-430a-985b-564f31e3aaa4","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f3137de7-572a-48e4-921c-20cbd352be1b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:44:20.978399Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:33.410494Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1494"
+      - "1449"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:21 GMT
+      - Tue, 07 Nov 2023 16:24:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -638,7 +638,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cfc86c31-18a0-4264-83b7-f6716d299c84
+      - 120087f6-908e-48b6-b45a-d32c3c234d9b
     status: 200 OK
     code: 200
     duration: ""
@@ -649,19 +649,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0d88eb0b-643e-430a-985b-564f31e3aaa4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:14.065550Z","created_at":"2023-10-18T16:44:14.065550Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d88eb0b-643e-430a-985b-564f31e3aaa4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0d88eb0b-643e-430a-985b-564f31e3aaa4","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f3137de7-572a-48e4-921c-20cbd352be1b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:44:22.097525Z","upgrade_available":true,"version":"1.27.6"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:34.520580Z","upgrade_available":true,"version":"1.27.6"}'
     headers:
       Content-Length:
-      - "1499"
+      - "1454"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:26 GMT
+      - Tue, 07 Nov 2023 16:24:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -671,7 +671,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca6d0a96-4054-426d-af92-fea6eb34940a
+      - e98ba4da-8a38-4519-ba8d-a649ad58e154
     status: 200 OK
     code: 200
     duration: ""
@@ -684,19 +684,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4/upgrade
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058/upgrade
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0d88eb0b-643e-430a-985b-564f31e3aaa4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:14.065550Z","created_at":"2023-10-18T16:44:14.065550Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d88eb0b-643e-430a-985b-564f31e3aaa4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0d88eb0b-643e-430a-985b-564f31e3aaa4","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f3137de7-572a-48e4-921c-20cbd352be1b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:44:26.185596296Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:38.620967533Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1498"
+      - "1453"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:26 GMT
+      - Tue, 07 Nov 2023 16:24:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -706,7 +706,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f037ecea-747b-486c-b7ce-4719ec5fd90b
+      - d24c7fbb-4002-4b08-8b23-753f5e1a5371
     status: 200 OK
     code: 200
     duration: ""
@@ -717,19 +717,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0d88eb0b-643e-430a-985b-564f31e3aaa4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:14.065550Z","created_at":"2023-10-18T16:44:14.065550Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d88eb0b-643e-430a-985b-564f31e3aaa4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0d88eb0b-643e-430a-985b-564f31e3aaa4","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f3137de7-572a-48e4-921c-20cbd352be1b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:44:26.185596Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:38.620968Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1495"
+      - "1450"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:26 GMT
+      - Tue, 07 Nov 2023 16:24:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -739,7 +739,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bccdbf99-ac92-4c5a-be3f-9a9d3526de4f
+      - be0e2aa7-8ca3-4467-a2de-b2115dbcce64
     status: 200 OK
     code: 200
     duration: ""
@@ -750,19 +750,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0d88eb0b-643e-430a-985b-564f31e3aaa4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:14.065550Z","created_at":"2023-10-18T16:44:14.065550Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d88eb0b-643e-430a-985b-564f31e3aaa4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0d88eb0b-643e-430a-985b-564f31e3aaa4","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f3137de7-572a-48e4-921c-20cbd352be1b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:44:27.301466Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:39.735191Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1500"
+      - "1455"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:31 GMT
+      - Tue, 07 Nov 2023 16:24:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -772,7 +772,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21d3bf27-33b7-4d3b-8cf9-5e1cde8bfb04
+      - 6b214c77-c04b-4a1b-8a89-7398e899f84f
     status: 200 OK
     code: 200
     duration: ""
@@ -783,19 +783,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0d88eb0b-643e-430a-985b-564f31e3aaa4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:14.065550Z","created_at":"2023-10-18T16:44:14.065550Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d88eb0b-643e-430a-985b-564f31e3aaa4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0d88eb0b-643e-430a-985b-564f31e3aaa4","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f3137de7-572a-48e4-921c-20cbd352be1b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:44:27.301466Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:39.735191Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1500"
+      - "1455"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:31 GMT
+      - Tue, 07 Nov 2023 16:24:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -805,7 +805,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b7d1e5a-d574-4a20-be8c-a7b559ba334a
+      - 6ed6a367-ac94-4d4b-aa29-1325b291239b
     status: 200 OK
     code: 200
     duration: ""
@@ -816,19 +816,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVeVRrUlJlRTVXYjFoRVZFMTZUVlJCZUU1NlJUSk9SRkY0VGxadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJVRVJKQ21sVmJEbEZNV0ZTUlRGcVowbEtXR1pJVGtKbFdXdFJUM1JYYUVaMVNWUjFSVU5WT1VwMWJuRnpha1p5YnpCYWFpdHBXRlJYTjNjcmRuRTJaemRFTlUwS2NYWTRTMmQxYTBreWJrSTVMMUoxZHpCelYxWXJOakpFYlhsaFdISlpTM2RPU21OeFJ6aFNOM0E0VjJSTFltaDNWU3QzTDNFeWRXOU1abVZ0TlUxWk13cHJTbmhwV1VWclNqSk5aRGswUjBwT2RreDZiRFIxUTNGbWRGbFFkSGxCTmxZMFkyZzNWR2xoTkd4Rk5HY3dOVE5EZGxKSk0wZDJPSEFyWWs1c1NIWTJDalJFZDA1SVpVWndNRWwxU0c5dVdWWnFZMjR4WVVOVk5qUXhRbGRZU1RJeWJUZzJkblEyYlVzdmVreFhRalozZDFkQldXRkdlVzlSVVRSeVdHcDZPVmdLT0ZwU1RtRnJTamxGUTJkSVpXMHhOREJMTHlzMlVYbDRSRlpHUkdsaE1ISjBUMDlvV0dsRFpVTlRUMkpVTkhocVlWUkVUakpyYkZrMlpFb3ZURFYyV2dwMmNrRXJUVEpPYWtOUGNqWklVMm96VkRoelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUVNuZEVZMFV2VVZkU1ZXYzJPRlZCVjFvdk5qaEVMMHR2UjJsTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRGVHWkJhM0p6VmtGdVowZHBPWGhUYm5wRGNUTXlZVVpET1RSM01XSnRVMjVZTkZaQ1VXaG1jVTV3YUhkbFUzaFRRUXAzWW0xWVpUSmpXVXBuTTFKQ2FHWXpVRE5FWlhGMGJYSkhlRnB4ZFU5SlNGUXJaalJ1UWxWb2FVVk9aM0JIZDIxMFMweHRTVFZ4Um1vM1oxRlNiRUZJQ21GME1FVlBTMWROVkZkQ2FHNW5hazFCVFRBM2MxWjZRMVpVUVZJd05FdDZlbk5EYUdkSmJHRkJOakJTU1ZrelVtNXlNM0p5ZEdSQkwyMVRTalpyT1ZRS2F6ZFdaSEJWUjNSamNIcG9hREJ3TWxSNFpFRmFURkJCVG5SSk5YZ3djQ3R6YW1oc1JGVkJka0kwVlVWdlExTldOV0pQY0U0eU1FdHNRV1JvT0RnMVdBbzRMMVp2YjB4c2RsTXpTaXRTYm5WTGNEUlZaRU55YjNOM2JreGxUR3czU21Fd1JHTXZla2xZY1hwRGFGQnRLMUF3SzJZeGFHeFBhMmh5ZG5ONlJVNVRDblJVVWpkcVMxWjZMMk12ZDNGeWJpOUZiM040YmsxMWQwMVRSSFpvVjNnMWJtMUdSQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMGQ4OGViMGItNjQzZS00MzBhLTk4NWItNTY0ZjMxZTNhYWE0LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiUmNDdHl4eFFyUTdHbm04RG9DT0E2RGk4TDJSdHg5N1dyM0g3VnNvWkQ3ZlBtbVhGbnJualZnRg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcFJlVTR4YjFoRVZFMTZUVlJGZDA1cVJUSk5hbEY1VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTM1V2Q2s1VFprMDNSM2hXY25selZuVjFRMDExYTNaTU5FNUtVVWxrYkZZNVoyaGpjVVJXVUZNMVNVdFVWMUpvVGtGaVVrVnpMM1JzYjNGcmFHaHRRV3BFZW1rS1JVWkRibFUzY2s5YWFHdzRSbUpqWlcxRFowUjBkMGRVUW10UE5EWjZSV2N3Tm5wVmNXSkhkMlJDUlVFMVRVWlpTMGxEYkRGUk5EaGxjbXcwVTFSNVZRcE9PVEpPY2pWRVdXUlVaakZXZGtSbE16TktRM0J5UnpKMlNUbFlOVEp4Y1d4UVNGUXpZVmsxTkZVMFRXbFNURmxYWW5oUVEzWTRNazFGVVVsMFVuQmFDbUpRYTJOWWJrNHJOWFZsUTBOdVIyMW1iMXBUWVVWek5GSjRka3R2YTJSRFZsSlJOMWhQVFdreGFVUjRZak01TVdVME9HeE5WbXBZV1VwNll6Y3lhVkFLUjBka1VreFVVazR6YUZGa2JHNUZUbk5sY0hrelpXSXpaMUJ5V1c5a09GTXJkV1YwTm5kR2EyeDZVaXQ1ZEc4eFFTOHpaRFp4TW1SUFFrUnlOWEJQTHdvNGNGYzJibWN3Tm1OTlNqSjNSa1F4ZEZSRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSWVITnJTa1kzZFdFM1dXZEJkSEUxYURZcmMyY3dSREJPYjNGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk5UQnVVMjk0YzB4eFltNU5aMlpuTlVad2FVTkZRekowVUhsRU5tUTNUbkpvWlNzd2RVdzRORXRWYVZKUlVpdDBjd3BJVkVaTFdXTldNM0pYU2tGNGVrMXlWVE16TUdaV1ZHOXJVV3RTT1U5U2JHSnpiVXRsU3psNGNIWXJTM1pCY0ZGelprOU9OelZ0UTJNck1tOUlUR0V2Q2pOalNUbFFUMlpzYWs5a01XbzBNRU5qZUZSM2NWRmtWaTlPT1U4eVZFbHZlR2R6UTB0NGVWQnRObWQ1ZW1SemFscHFkbkZ0U0VwNU5qQnNRWEEzWjJZS2RsQnlVRlo0Tm1oeVRqVXJhMUZ2S3pKdFdWWktRM0ozWTBKb2RTdHBkR3hhUzFJcmEycHVOV2haVERsSmVYVTBiR0U0YjAxR1VFTjFSa1J4VmxreU5ncG5TSGRhVjBGbWNEaFBSMVozU0VwM1drVXhVV3RXYzJVeUswMXdVek5wU1hWVWVISmhiMFVyTVZkdFYzaHhZazV5WWtaTWFtSlhWRWRxTkVScmFuQnpDbHBqT1VoVWJrWm9ZelJwWTFGQlFsQmxOVWhzTDBZM1FXTnhabEZvZDA1UFkxSlFad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOGViZTM4NzItN2E5Mi00ZGFiLThmMzItMjM3ODBkN2Y4MDU4LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXQ2t5OTB2dHoxVXlGdDFCVFJ2eEhYeklOSDNndU9OcUJQaG12WDhNM09SdFVBeHZpeXhoSUwyNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2590"
+      - "2588"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:31 GMT
+      - Tue, 07 Nov 2023 16:24:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -838,7 +838,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09a59a36-bc2d-4f7c-bbe8-beb5818bd489
+      - 3de4a548-3059-488a-82a4-3ea6acc8ffe7
     status: 200 OK
     code: 200
     duration: ""
@@ -849,19 +849,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0d88eb0b-643e-430a-985b-564f31e3aaa4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:14.065550Z","created_at":"2023-10-18T16:44:14.065550Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d88eb0b-643e-430a-985b-564f31e3aaa4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0d88eb0b-643e-430a-985b-564f31e3aaa4","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f3137de7-572a-48e4-921c-20cbd352be1b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:44:27.301466Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:39.735191Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1500"
+      - "1455"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:31 GMT
+      - Tue, 07 Nov 2023 16:24:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -871,7 +871,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f94ca6f-deea-4d06-8495-51850f820e98
+      - 1707f314-6ca3-4ca9-8e7c-463e85346f9e
     status: 200 OK
     code: 200
     duration: ""
@@ -882,19 +882,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f3137de7-572a-48e4-921c-20cbd352be1b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/38d51a1a-233e-48da-9b96-feb735b75055
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:44:13.182219Z","dhcp_enabled":true,"id":"f3137de7-572a-48e4-921c-20cbd352be1b","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:44:13.182219Z","id":"00541e5c-5a6f-48fe-bb5e-4b507b0d066e","subnet":"172.16.20.0/22","updated_at":"2023-10-18T16:44:13.182219Z"},{"created_at":"2023-10-18T16:44:13.182219Z","id":"1e83ba5a-7195-4b12-bc69-f89a59bcb25a","subnet":"fd63:256c:45f7:11b4::/64","updated_at":"2023-10-18T16:44:13.182219Z"}],"tags":[],"updated_at":"2023-10-18T16:44:13.182219Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:24:25.480410Z","dhcp_enabled":true,"id":"38d51a1a-233e-48da-9b96-feb735b75055","name":"test-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:24:25.480410Z","id":"500e09ad-b117-4ed3-8beb-c5f91028994e","subnet":"172.16.24.0/22","updated_at":"2023-11-07T16:24:25.480410Z"},{"created_at":"2023-11-07T16:24:25.480410Z","id":"57516592-b62d-4f65-922e-f300d27921d9","subnet":"fd63:256c:45f7:4d04::/64","updated_at":"2023-11-07T16:24:25.480410Z"}],"tags":[],"updated_at":"2023-11-07T16:24:25.480410Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "713"
+      - "696"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:31 GMT
+      - Tue, 07 Nov 2023 16:24:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -904,7 +904,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 524947ad-60f0-4c88-ad40-be567ed80927
+      - 83a70de4-82bf-405d-8c40-b268935f73e5
     status: 200 OK
     code: 200
     duration: ""
@@ -915,19 +915,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0d88eb0b-643e-430a-985b-564f31e3aaa4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:14.065550Z","created_at":"2023-10-18T16:44:14.065550Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d88eb0b-643e-430a-985b-564f31e3aaa4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0d88eb0b-643e-430a-985b-564f31e3aaa4","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f3137de7-572a-48e4-921c-20cbd352be1b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:44:27.301466Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:39.735191Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1500"
+      - "1455"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:31 GMT
+      - Tue, 07 Nov 2023 16:24:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -937,7 +937,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c50ae433-8704-4d61-baa5-abd4e59bd035
+      - 496dc40b-eab2-4b3d-a390-1080389cb73d
     status: 200 OK
     code: 200
     duration: ""
@@ -948,19 +948,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVeVRrUlJlRTVXYjFoRVZFMTZUVlJCZUU1NlJUSk9SRkY0VGxadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJVRVJKQ21sVmJEbEZNV0ZTUlRGcVowbEtXR1pJVGtKbFdXdFJUM1JYYUVaMVNWUjFSVU5WT1VwMWJuRnpha1p5YnpCYWFpdHBXRlJYTjNjcmRuRTJaemRFTlUwS2NYWTRTMmQxYTBreWJrSTVMMUoxZHpCelYxWXJOakpFYlhsaFdISlpTM2RPU21OeFJ6aFNOM0E0VjJSTFltaDNWU3QzTDNFeWRXOU1abVZ0TlUxWk13cHJTbmhwV1VWclNqSk5aRGswUjBwT2RreDZiRFIxUTNGbWRGbFFkSGxCTmxZMFkyZzNWR2xoTkd4Rk5HY3dOVE5EZGxKSk0wZDJPSEFyWWs1c1NIWTJDalJFZDA1SVpVWndNRWwxU0c5dVdWWnFZMjR4WVVOVk5qUXhRbGRZU1RJeWJUZzJkblEyYlVzdmVreFhRalozZDFkQldXRkdlVzlSVVRSeVdHcDZPVmdLT0ZwU1RtRnJTamxGUTJkSVpXMHhOREJMTHlzMlVYbDRSRlpHUkdsaE1ISjBUMDlvV0dsRFpVTlRUMkpVTkhocVlWUkVUakpyYkZrMlpFb3ZURFYyV2dwMmNrRXJUVEpPYWtOUGNqWklVMm96VkRoelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUVNuZEVZMFV2VVZkU1ZXYzJPRlZCVjFvdk5qaEVMMHR2UjJsTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRGVHWkJhM0p6VmtGdVowZHBPWGhUYm5wRGNUTXlZVVpET1RSM01XSnRVMjVZTkZaQ1VXaG1jVTV3YUhkbFUzaFRRUXAzWW0xWVpUSmpXVXBuTTFKQ2FHWXpVRE5FWlhGMGJYSkhlRnB4ZFU5SlNGUXJaalJ1UWxWb2FVVk9aM0JIZDIxMFMweHRTVFZ4Um1vM1oxRlNiRUZJQ21GME1FVlBTMWROVkZkQ2FHNW5hazFCVFRBM2MxWjZRMVpVUVZJd05FdDZlbk5EYUdkSmJHRkJOakJTU1ZrelVtNXlNM0p5ZEdSQkwyMVRTalpyT1ZRS2F6ZFdaSEJWUjNSamNIcG9hREJ3TWxSNFpFRmFURkJCVG5SSk5YZ3djQ3R6YW1oc1JGVkJka0kwVlVWdlExTldOV0pQY0U0eU1FdHNRV1JvT0RnMVdBbzRMMVp2YjB4c2RsTXpTaXRTYm5WTGNEUlZaRU55YjNOM2JreGxUR3czU21Fd1JHTXZla2xZY1hwRGFGQnRLMUF3SzJZeGFHeFBhMmh5ZG5ONlJVNVRDblJVVWpkcVMxWjZMMk12ZDNGeWJpOUZiM040YmsxMWQwMVRSSFpvVjNnMWJtMUdSQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMGQ4OGViMGItNjQzZS00MzBhLTk4NWItNTY0ZjMxZTNhYWE0LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiUmNDdHl4eFFyUTdHbm04RG9DT0E2RGk4TDJSdHg5N1dyM0g3VnNvWkQ3ZlBtbVhGbnJualZnRg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbWluaW1hbCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcFJlVTR4YjFoRVZFMTZUVlJGZDA1cVJUSk5hbEY1VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTM1V2Q2s1VFprMDNSM2hXY25selZuVjFRMDExYTNaTU5FNUtVVWxrYkZZNVoyaGpjVVJXVUZNMVNVdFVWMUpvVGtGaVVrVnpMM1JzYjNGcmFHaHRRV3BFZW1rS1JVWkRibFUzY2s5YWFHdzRSbUpqWlcxRFowUjBkMGRVUW10UE5EWjZSV2N3Tm5wVmNXSkhkMlJDUlVFMVRVWlpTMGxEYkRGUk5EaGxjbXcwVTFSNVZRcE9PVEpPY2pWRVdXUlVaakZXZGtSbE16TktRM0J5UnpKMlNUbFlOVEp4Y1d4UVNGUXpZVmsxTkZVMFRXbFNURmxYWW5oUVEzWTRNazFGVVVsMFVuQmFDbUpRYTJOWWJrNHJOWFZsUTBOdVIyMW1iMXBUWVVWek5GSjRka3R2YTJSRFZsSlJOMWhQVFdreGFVUjRZak01TVdVME9HeE5WbXBZV1VwNll6Y3lhVkFLUjBka1VreFVVazR6YUZGa2JHNUZUbk5sY0hrelpXSXpaMUJ5V1c5a09GTXJkV1YwTm5kR2EyeDZVaXQ1ZEc4eFFTOHpaRFp4TW1SUFFrUnlOWEJQTHdvNGNGYzJibWN3Tm1OTlNqSjNSa1F4ZEZSRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSWVITnJTa1kzZFdFM1dXZEJkSEUxYURZcmMyY3dSREJPYjNGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk5UQnVVMjk0YzB4eFltNU5aMlpuTlVad2FVTkZRekowVUhsRU5tUTNUbkpvWlNzd2RVdzRORXRWYVZKUlVpdDBjd3BJVkVaTFdXTldNM0pYU2tGNGVrMXlWVE16TUdaV1ZHOXJVV3RTT1U5U2JHSnpiVXRsU3psNGNIWXJTM1pCY0ZGelprOU9OelZ0UTJNck1tOUlUR0V2Q2pOalNUbFFUMlpzYWs5a01XbzBNRU5qZUZSM2NWRmtWaTlPT1U4eVZFbHZlR2R6UTB0NGVWQnRObWQ1ZW1SemFscHFkbkZ0U0VwNU5qQnNRWEEzWjJZS2RsQnlVRlo0Tm1oeVRqVXJhMUZ2S3pKdFdWWktRM0ozWTBKb2RTdHBkR3hhUzFJcmEycHVOV2haVERsSmVYVTBiR0U0YjAxR1VFTjFSa1J4VmxreU5ncG5TSGRhVjBGbWNEaFBSMVozU0VwM1drVXhVV3RXYzJVeUswMXdVek5wU1hWVWVISmhiMFVyTVZkdFYzaHhZazV5WWtaTWFtSlhWRWRxTkVScmFuQnpDbHBqT1VoVWJrWm9ZelJwWTFGQlFsQmxOVWhzTDBZM1FXTnhabEZvZDA1UFkxSlFad290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOGViZTM4NzItN2E5Mi00ZGFiLThmMzItMjM3ODBkN2Y4MDU4LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbWluaW1hbAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1taW5pbWFsLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1taW5pbWFsCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBXQ2t5OTB2dHoxVXlGdDFCVFJ2eEhYeklOSDNndU9OcUJQaG12WDhNM09SdFVBeHZpeXhoSUwyNQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2590"
+      - "2588"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:31 GMT
+      - Tue, 07 Nov 2023 16:24:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -970,7 +970,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fedcd10a-b130-41f0-af9d-de0ddcc8f968
+      - 777250b1-698f-4758-bfab-172f0284f919
     status: 200 OK
     code: 200
     duration: ""
@@ -981,19 +981,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0d88eb0b-643e-430a-985b-564f31e3aaa4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:14.065550Z","created_at":"2023-10-18T16:44:14.065550Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d88eb0b-643e-430a-985b-564f31e3aaa4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0d88eb0b-643e-430a-985b-564f31e3aaa4","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f3137de7-572a-48e4-921c-20cbd352be1b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:44:32.520482626Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:45.112062619Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1498"
+      - "1453"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:32 GMT
+      - Tue, 07 Nov 2023 16:24:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1003,7 +1003,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dfa76523-22fa-46ae-aca8-d83fe1e69863
+      - f867189e-09ee-4804-80ec-e910e3d8afeb
     status: 200 OK
     code: 200
     duration: ""
@@ -1014,19 +1014,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0d88eb0b-643e-430a-985b-564f31e3aaa4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:14.065550Z","created_at":"2023-10-18T16:44:14.065550Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d88eb0b-643e-430a-985b-564f31e3aaa4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0d88eb0b-643e-430a-985b-564f31e3aaa4","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f3137de7-572a-48e4-921c-20cbd352be1b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:44:32.520483Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:45.112063Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1495"
+      - "1450"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:32 GMT
+      - Tue, 07 Nov 2023 16:24:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1036,7 +1036,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9fd3e09c-9d42-44bc-bc20-fe79d10291e6
+      - 31e785b1-351b-4c83-8309-b58b3ca60f57
     status: 200 OK
     code: 200
     duration: ""
@@ -1047,19 +1047,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0d88eb0b-643e-430a-985b-564f31e3aaa4.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:44:14.065550Z","created_at":"2023-10-18T16:44:14.065550Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0d88eb0b-643e-430a-985b-564f31e3aaa4.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0d88eb0b-643e-430a-985b-564f31e3aaa4","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"f3137de7-572a-48e4-921c-20cbd352be1b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:44:32.520483Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8ebe3872-7a92-4dab-8f32-23780d7f8058.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:24:26.509079Z","created_at":"2023-11-07T16:24:26.509079Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8ebe3872-7a92-4dab-8f32-23780d7f8058.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","ingress":"none","name":"test-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"38d51a1a-233e-48da-9b96-feb735b75055","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:24:45.112063Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1495"
+      - "1450"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:37 GMT
+      - Tue, 07 Nov 2023 16:24:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1069,7 +1069,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4226c4c5-6ebc-47af-9fd6-516d42ede948
+      - b4aae3fc-70a7-4b91-a5d7-d69da82ee1ec
     status: 200 OK
     code: 200
     duration: ""
@@ -1080,10 +1080,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"0d88eb0b-643e-430a-985b-564f31e3aaa4","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -1092,7 +1092,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:42 GMT
+      - Tue, 07 Nov 2023 16:24:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1102,7 +1102,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 502d6e61-723e-44a8-97de-23d091e5fd41
+      - e4e71b15-cacb-45de-b569-2dbd23951e7c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1113,10 +1113,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f3137de7-572a-48e4-921c-20cbd352be1b
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/38d51a1a-233e-48da-9b96-feb735b75055
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"f3137de7-572a-48e4-921c-20cbd352be1b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"38d51a1a-233e-48da-9b96-feb735b75055","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -1125,7 +1125,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:42 GMT
+      - Tue, 07 Nov 2023 16:24:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1135,7 +1135,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f61d7c8b-b0e3-4866-b561-4c310f1ed1d1
+      - ce506257-a7ca-46e7-8a6a-a13314bf6bbd
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1146,10 +1146,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0d88eb0b-643e-430a-985b-564f31e3aaa4
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8ebe3872-7a92-4dab-8f32-23780d7f8058
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"0d88eb0b-643e-430a-985b-564f31e3aaa4","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"8ebe3872-7a92-4dab-8f32-23780d7f8058","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -1158,7 +1158,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:42 GMT
+      - Tue, 07 Nov 2023 16:24:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1168,7 +1168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b8730a7-e33a-4bf7-a4e4-47023e2a70f7
+      - 3e25a4be-ed6b-4631-b6dc-6a229ba67ff9
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-multicloud.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-multicloud.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:41 GMT
+      - Tue, 07 Nov 2023 16:19:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,12 +34,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0928f880-56c0-48b7-984f-2e168d9a8580
+      - e772d889-6982-4b3e-a4d5-26a5b884b08a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"multicloud","name":"test-multicloud","description":"","tags":null,"version":"1.28.2","cni":"kilo","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":null}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"multicloud","name":"test-multicloud","description":"","tags":null,"version":"1.28.2","cni":"kilo","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null}'
     form: {}
     headers:
       Content-Type:
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5145a129-3d9f-4959-bcba-14a0902c68e0.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:43:35.895128864Z","created_at":"2023-10-18T16:43:35.895128864Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5145a129-3d9f-4959-bcba-14a0902c68e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5145a129-3d9f-4959-bcba-14a0902c68e0","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-10-18T16:43:35.903088111Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842341Z","created_at":"2023-11-07T16:19:59.742842341Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753797713Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1423"
+      - "1380"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:35 GMT
+      - Tue, 07 Nov 2023 16:19:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a19c5add-fdd9-4614-8560-beab59a0aa1e
+      - 3397cd80-768f-4930-a28c-d5e70f09d885
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5145a129-3d9f-4959-bcba-14a0902c68e0.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:43:35.895129Z","created_at":"2023-10-18T16:43:35.895129Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5145a129-3d9f-4959-bcba-14a0902c68e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5145a129-3d9f-4959-bcba-14a0902c68e0","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-10-18T16:43:35.903088Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1414"
+      - "1371"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:35 GMT
+      - Tue, 07 Nov 2023 16:19:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,7 +102,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48cfb20c-e7ff-4b69-8a1f-913430122dbd
+      - aebf9c2f-de52-4519-9d0e-7f5110eb313d
     status: 200 OK
     code: 200
     duration: ""
@@ -113,19 +113,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5145a129-3d9f-4959-bcba-14a0902c68e0.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:43:35.895129Z","created_at":"2023-10-18T16:43:35.895129Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5145a129-3d9f-4959-bcba-14a0902c68e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5145a129-3d9f-4959-bcba-14a0902c68e0","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-10-18T16:43:35.903088Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1414"
+      - "1371"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:41 GMT
+      - Tue, 07 Nov 2023 16:20:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -135,7 +135,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82dd2ab4-be28-4e38-b70d-eb9a1f9d2351
+      - ce08e8c4-a882-4868-a1f5-93257f2d71b5
     status: 200 OK
     code: 200
     duration: ""
@@ -146,19 +146,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5145a129-3d9f-4959-bcba-14a0902c68e0.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:43:35.895129Z","created_at":"2023-10-18T16:43:35.895129Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5145a129-3d9f-4959-bcba-14a0902c68e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5145a129-3d9f-4959-bcba-14a0902c68e0","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-10-18T16:43:35.903088Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1414"
+      - "1371"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:46 GMT
+      - Tue, 07 Nov 2023 16:20:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -168,7 +168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 640caf83-cf8f-401c-8a1c-841218ed8917
+      - c5da12ef-c8e0-41d3-9a26-062b48640858
     status: 200 OK
     code: 200
     duration: ""
@@ -179,19 +179,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5145a129-3d9f-4959-bcba-14a0902c68e0.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:43:35.895129Z","created_at":"2023-10-18T16:43:35.895129Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5145a129-3d9f-4959-bcba-14a0902c68e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5145a129-3d9f-4959-bcba-14a0902c68e0","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-10-18T16:43:35.903088Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1414"
+      - "1371"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:51 GMT
+      - Tue, 07 Nov 2023 16:20:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -201,7 +201,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9638539f-21b0-4810-baf0-bf18c8265711
+      - 48e2316b-735f-40a5-8e50-675bc4738f38
     status: 200 OK
     code: 200
     duration: ""
@@ -212,19 +212,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5145a129-3d9f-4959-bcba-14a0902c68e0.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:43:35.895129Z","created_at":"2023-10-18T16:43:35.895129Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5145a129-3d9f-4959-bcba-14a0902c68e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5145a129-3d9f-4959-bcba-14a0902c68e0","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-10-18T16:43:35.903088Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1414"
+      - "1371"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:56 GMT
+      - Tue, 07 Nov 2023 16:20:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -234,7 +234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83d33585-1d86-4af4-8a6e-aaa03f09e104
+      - f131f0cd-08b9-4ca9-a1cb-2df3bdac87ce
     status: 200 OK
     code: 200
     duration: ""
@@ -245,19 +245,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5145a129-3d9f-4959-bcba-14a0902c68e0.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:43:35.895129Z","created_at":"2023-10-18T16:43:35.895129Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5145a129-3d9f-4959-bcba-14a0902c68e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5145a129-3d9f-4959-bcba-14a0902c68e0","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-10-18T16:43:35.903088Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1414"
+      - "1371"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:01 GMT
+      - Tue, 07 Nov 2023 16:20:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -267,7 +267,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 062e30f4-b4f8-4929-b6e8-0ae67c5b72b3
+      - d75d771a-3bad-45d9-a222-d5503705cd85
     status: 200 OK
     code: 200
     duration: ""
@@ -278,19 +278,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5145a129-3d9f-4959-bcba-14a0902c68e0.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:43:35.895129Z","created_at":"2023-10-18T16:43:35.895129Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5145a129-3d9f-4959-bcba-14a0902c68e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5145a129-3d9f-4959-bcba-14a0902c68e0","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-10-18T16:43:35.903088Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1414"
+      - "1371"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:06 GMT
+      - Tue, 07 Nov 2023 16:20:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -300,7 +300,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c2c8c8e-e93d-4b55-a3bd-a9e65bfd16e3
+      - 9f82a52d-81dd-4d0e-a6ec-a314618bf1ae
     status: 200 OK
     code: 200
     duration: ""
@@ -311,19 +311,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5145a129-3d9f-4959-bcba-14a0902c68e0.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:43:35.895129Z","created_at":"2023-10-18T16:43:35.895129Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5145a129-3d9f-4959-bcba-14a0902c68e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5145a129-3d9f-4959-bcba-14a0902c68e0","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-10-18T16:43:35.903088Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1414"
+      - "1371"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:11 GMT
+      - Tue, 07 Nov 2023 16:20:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -333,7 +333,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d98c00b4-2ae7-462b-a006-b5461147b391
+      - 759d8e98-f66f-41cd-a4ae-63a0f499ed2f
     status: 200 OK
     code: 200
     duration: ""
@@ -344,19 +344,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5145a129-3d9f-4959-bcba-14a0902c68e0.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:43:35.895129Z","created_at":"2023-10-18T16:43:35.895129Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5145a129-3d9f-4959-bcba-14a0902c68e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5145a129-3d9f-4959-bcba-14a0902c68e0","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-10-18T16:43:35.903088Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1414"
+      - "1371"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:16 GMT
+      - Tue, 07 Nov 2023 16:20:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -366,7 +366,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6cdc29f4-e82d-410d-afd5-30aad8f1ce82
+      - b8341a0e-1642-41c3-aa5c-f0f0f21f8471
     status: 200 OK
     code: 200
     duration: ""
@@ -377,19 +377,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5145a129-3d9f-4959-bcba-14a0902c68e0.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:43:35.895129Z","created_at":"2023-10-18T16:43:35.895129Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5145a129-3d9f-4959-bcba-14a0902c68e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5145a129-3d9f-4959-bcba-14a0902c68e0","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-10-18T16:43:35.903088Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1414"
+      - "1371"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:21 GMT
+      - Tue, 07 Nov 2023 16:20:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -399,7 +399,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb94000c-97b5-4f01-b4ce-59e2cba93aa6
+      - 3872bac1-aaf5-4d67-ae65-7c97fedb29ae
     status: 200 OK
     code: 200
     duration: ""
@@ -410,19 +410,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5145a129-3d9f-4959-bcba-14a0902c68e0.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:43:35.895129Z","created_at":"2023-10-18T16:43:35.895129Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5145a129-3d9f-4959-bcba-14a0902c68e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5145a129-3d9f-4959-bcba-14a0902c68e0","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-10-18T16:43:35.903088Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1414"
+      - "1371"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:26 GMT
+      - Tue, 07 Nov 2023 16:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -432,7 +432,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 509af00d-8646-4450-b630-02112f21650c
+      - 51ea29a9-0750-4bac-8ecf-1c7be327efdd
     status: 200 OK
     code: 200
     duration: ""
@@ -443,19 +443,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5145a129-3d9f-4959-bcba-14a0902c68e0.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:43:35.895129Z","created_at":"2023-10-18T16:43:35.895129Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5145a129-3d9f-4959-bcba-14a0902c68e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5145a129-3d9f-4959-bcba-14a0902c68e0","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-10-18T16:43:35.903088Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1414"
+      - "1371"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:31 GMT
+      - Tue, 07 Nov 2023 16:20:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -465,7 +465,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55d9dbef-c30e-47ec-87a6-02ee9fe03eab
+      - 39b0edf0-1a26-4fd4-8941-1bcd17628871
     status: 200 OK
     code: 200
     duration: ""
@@ -476,19 +476,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5145a129-3d9f-4959-bcba-14a0902c68e0.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:43:35.895129Z","created_at":"2023-10-18T16:43:35.895129Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5145a129-3d9f-4959-bcba-14a0902c68e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5145a129-3d9f-4959-bcba-14a0902c68e0","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-10-18T16:43:35.903088Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1414"
+      - "1371"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:36 GMT
+      - Tue, 07 Nov 2023 16:21:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -498,7 +498,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7cabd5f3-2457-4c2a-84e8-99eb41bee7f3
+      - e2040195-5251-4cb5-af19-1c58b53f1287
     status: 200 OK
     code: 200
     duration: ""
@@ -509,19 +509,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5145a129-3d9f-4959-bcba-14a0902c68e0.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:43:35.895129Z","created_at":"2023-10-18T16:43:35.895129Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5145a129-3d9f-4959-bcba-14a0902c68e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5145a129-3d9f-4959-bcba-14a0902c68e0","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-10-18T16:43:35.903088Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:19:59.753798Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1414"
+      - "1371"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:41 GMT
+      - Tue, 07 Nov 2023 16:21:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -531,7 +531,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e444a67-f35f-41fb-8719-2293ed49f8a0
+      - bd647727-aab9-45ee-9414-90af2f1533c3
     status: 200 OK
     code: 200
     duration: ""
@@ -542,19 +542,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5145a129-3d9f-4959-bcba-14a0902c68e0.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:43:35.895129Z","created_at":"2023-10-18T16:43:35.895129Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5145a129-3d9f-4959-bcba-14a0902c68e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5145a129-3d9f-4959-bcba-14a0902c68e0","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-10-18T16:44:42.914178Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:21:10.241756Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1411"
+      - "1368"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:46 GMT
+      - Tue, 07 Nov 2023 16:21:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -564,7 +564,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f94f34ad-95c0-4d5b-8728-777ff69472f0
+      - cf7b830a-5639-4efd-9134-b6670ac7bd02
     status: 200 OK
     code: 200
     duration: ""
@@ -575,19 +575,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5145a129-3d9f-4959-bcba-14a0902c68e0.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:43:35.895129Z","created_at":"2023-10-18T16:43:35.895129Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5145a129-3d9f-4959-bcba-14a0902c68e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5145a129-3d9f-4959-bcba-14a0902c68e0","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-10-18T16:44:42.914178Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:21:10.241756Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1411"
+      - "1368"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:46 GMT
+      - Tue, 07 Nov 2023 16:21:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -597,7 +597,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 339e1419-ca0b-4523-8545-437fbab720f5
+      - d1295dd0-e171-40a1-a7b6-5f216d7ecb6a
     status: 200 OK
     code: 200
     duration: ""
@@ -608,19 +608,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbXVsdGljbG91ZCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVeVRrUk5lazR4YjFoRVZFMTZUVlJCZUU1NlJUSk9SRTE2VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUMFJYQ2toRmFFdExNV3BSV25OYWFFdHdPRTlIUWpaWVQwTjVXREZuYUU5clZ6VlFVWGRoVGtsMGIwVnNNbk16Yms1aFR5dEdNMjl6UjA1eWNXZHJURnBNWnpnS1VUUkhkV3haTURobU5ERmlhRTF4VkVOd2FpdDBObGhYSzB4blUwaHpOSFpyWjNKTmFWcDNNRzE1Tm1GdmEzQnlOR3hwTHpCUlpWTnRiR2xZU25kNlNBcE9kSEJVYVVZMkwzVXhPR1ZaVTNvMFEydE9VRTVPTlRaUU5taGlhVFpsYUVGUlVXRXhTSFp3WVVKemRqaG1TMFpYYUhsS1VVWjZTVkJXWTFOak5sVXlDbXRHY0RRM1RWVTROREIwZFU1d1VISklXa1pQYmxWM2NYaEdSREpyU21KV1VWaDZhV1ptVDA0MWEyd3dXVVZLV1ZCNWRsZHFiMVJGU25GVmVEVnVSbFVLTVZWd05YaExRVzFFUVZKcVkwRk1TRFJOZDFscVNuVnBkVVJ2U2pOdWVTOXJjVlJwZVUxRGVYbGpSMGxSVkUxaE56WnhVR2ROU0d0aWNtdFpaRVl3UlFvd1VFOHlUMUpZY1dKUlpHUjRZbk5IT1ZwelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRWFHNUJibTFPYUVGa2IwTnhTbXhHZDI5RE16RjZOa0o1VFZaTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlRtcHRRakV6VGtORlZUUmpVRUZXWml0Wk9VbEdWRTVPVmxGRFkxaGhSMGxSUVVRek5WQlFNa0V3VEcwNVpGRkxjQXBQWVdsc1pEaG5hMWxsYnpSclJXMDFhWFF3YTBOTlVHVkhWa2t3VUU5RFdFYzBNR2xGV0dGWlVIb3JVRGhXUTBoeFkzUkZaRkZTVjFGV09HMTVhWFozQ2tneGR6WlJhRWhEYVhoamRUaElMMDRyVFhoUWRVRTFVRGRJY0dSYVIzWm5TR1ZZYURJeWNXRlFkbE15WVZaV1UzZGFhMHhOV0ZsMVFscE5SR1Z3U2tJS2JHa3ZPWFpUY201dFltUk5NbXR5YnpFNWNrUnlRMFZCVEZwNk9FOXpRbWd6T1hCTVRFWmFhbWRoWW1GRVN6QkdMelZUUnpkcVdYWlFTbm8zTHpKSFZ3cHZOR3hMVGtKSk5Yb3hkRzEzTkRBMGJEbDVaa2xDVGpoeVZtVnFlV2xxUXk4ckwyZHZLME5FZEZJeVYyNHpOVkpaUzFCWU1rUkpZakV3VGs1cFprZHBDaXRtWWxreVpFeHNjRE5sVlRaSlNFVjVkMmwzVkZKSVkzTlZjRFpSY2k5aFVERTVZZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTE0NWExMjktM2Q5Zi00OTU5LWJjYmEtMTRhMDkwMmM2OGUwLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbXVsdGljbG91ZAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1tdWx0aWNsb3VkIgogICAgdXNlcjogdGVzdC1tdWx0aWNsb3VkLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1tdWx0aWNsb3VkCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1tdWx0aWNsb3VkLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpbHZlTDZtYXowVFliRVFJRDM0SGpKUnVwTUpFSEVYV3hmRHJ3NlNTamdDUEtvS3BOSVpiRzhjYg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbXVsdGljbG91ZCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEJkMDFHYjFoRVZFMTZUVlJGZDA1cVJUSk5ha0YzVFVadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUbnBKQ21oV1RtTlhlSFV2Unpka2VFb3lWRzVKTVZoNVZUZ3plV0pMZEc1cU1rcEZXbGxQY1ZabVpHaFpTa2wxWVRGdU1qRlZTVlpNUVZOb1lsWmxlR1ZKTmpRS1FrNVRiR1l6TmxJeVdXaE5kM1l5U0dGSFVFRlpTVzUyWWpNMGNuRkNhbE5hVlZKREwyRnVlbTFXT1ZGeFFXcHpibk52V21aNFdVZHFkQzlMYUdOVlNRcERkbFZxV1hCWFNUWlFaR1J0V1ZKTVEwTlNNbG92UlVjMldqbEhUamhJV0VWUk0wOWlkM0ZHVGsxYVJEWTFjMUZNT1dGcE1FYzNlamxvTlZWMlUxUlJDa0oyY1hKbGFGTTBZV2xETmpaVVJVbG9XRmhKTW5obGIyNW5Wa2RoU25GUlNtTjVTRVJDUkUxM09XTXdNMVpaUm5oR2JqWjVUbUZrUm5OU1NXSnBPRmdLVldKd2FUSlNVVmQyZFhkWFZVcDBXa2xhZHk5VFVUSlpkRVJKVUZSVE0wWldhVTVoZUdSTkwzVTVURzQ1YW5KeWJYWlplRlZWTlVNeVdGUkpUbFpMVEFveGFqWnZUa1Z2Y0hSc1V6TTBaWE5JY1dSelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTmNTOXFkbEpGUlhaT1ptZ3ZLM0JUVTJvMFRFbEpTMnBWZW5aTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFREVjJjMGREVEc5c1MzZHNhMHc1VGtOSVZUSlNOVVZPYUc1NFEwWTBOalptWm1ZMWFuZGlTalZ2VkRBelZqTlFNUXBvTlVsTGFXZENWVzFJYVVVMVZHUjFWakl2WlRKT1QySTRRemxNUmxwYVNFNW5iRFpLYjBoVGVuSkZRMjFuYzBVMk5uVk5aeTl4ZWs1R09YZDVMek5qQ25CUUwxbDNkQzlVU2poYVFsQlZha2R1UzFKSk5rWkhkR2RsYlZKRlMyNUxVekpwWjNsaGRFeGhiVEkwWW5WRVNtSlpiVlp5Y25kUlJsWkpiV0ZoVG1NS04zZHFkamRYYzFOb1JVTkNPVUpaYzBwWWNqTldSbGwyVG1oRE1XaGxabGRJVVRkRmEwRmFNMVZEYm1kWlUxTnZTMjlFWVhKMFRraFlOMlJNY0ZwNWRRcExlRTgwWkdWd2REVjVNekpRTjNrM1dsVjJZM2Q2YzJSRVFWRTBiRVpZTWxJNWFrdzBWREp2Y2toVVduVktUVXRLZGxKME1uazVRMjlyVW5SaWNsTktDak5uWkZkMWR5c3llbVpNTTFoMlQzUk5Na2xWUTNsRGFHUnRSRlJhTkM5WmJtczJaUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMTdkMzhiMDItNzQ4NS00ZTZlLWFhN2EtZDgyNmRmZGUxY2NmLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbXVsdGljbG91ZAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1tdWx0aWNsb3VkIgogICAgdXNlcjogdGVzdC1tdWx0aWNsb3VkLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1tdWx0aWNsb3VkCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1tdWx0aWNsb3VkLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBRalBKYlJWZVlYVHBmczM1bTVjSXJpbklSZjFYcmVzQ1M2ZXNlMGFTTDM1RERPQ3BkNEdIRXpYbw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2614"
+      - "2612"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:46 GMT
+      - Tue, 07 Nov 2023 16:21:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -630,7 +630,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef1a82c0-bc78-40ab-8a98-dfd07f66e6b0
+      - cc550988-22ee-43f0-afe0-480442bc1236
     status: 200 OK
     code: 200
     duration: ""
@@ -641,19 +641,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5145a129-3d9f-4959-bcba-14a0902c68e0.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:43:35.895129Z","created_at":"2023-10-18T16:43:35.895129Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5145a129-3d9f-4959-bcba-14a0902c68e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5145a129-3d9f-4959-bcba-14a0902c68e0","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-10-18T16:44:42.914178Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:21:10.241756Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1411"
+      - "1368"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:46 GMT
+      - Tue, 07 Nov 2023 16:21:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -663,12 +663,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e58447c9-e9a8-4897-9023-c1139ff3a892
+      - 89c6e32f-cb7d-44c3-98bf-aadd0efa7151
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-multicloud","node_type":"DEV1-M","placement_group_id":null,"autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"upgrade_policy":null,"zone":"fr-par-1","root_volume_type":"default_volume_type","root_volume_size":null,"public_ip_disabled":false}'
+    body: '{"name":"test-multicloud","node_type":"DEV1-M","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"zone":"fr-par-1","root_volume_type":"default_volume_type","public_ip_disabled":false}'
     form: {}
     headers:
       Content-Type:
@@ -676,19 +676,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf/pools
     method: POST
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101105Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077577624Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "629"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:47 GMT
+      - Tue, 07 Nov 2023 16:21:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -698,7 +698,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19e4f5e7-15c9-44c9-af63-2cd54f41f36b
+      - 56eadcf0-a5d5-47e7-8031-7a815aac7bd6
     status: 200 OK
     code: 200
     duration: ""
@@ -709,19 +709,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:47 GMT
+      - Tue, 07 Nov 2023 16:21:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -731,7 +731,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d587ea5-af42-49cb-b76d-fcbf65891790
+      - 0ef229a7-45c1-472d-a978-7b78011604f3
     status: 200 OK
     code: 200
     duration: ""
@@ -742,19 +742,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:52 GMT
+      - Tue, 07 Nov 2023 16:21:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -764,7 +764,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e30e0b36-b017-4a43-b575-1f15720a4f33
+      - 831fa777-4e5b-4105-bdea-3f877d0ae7ee
     status: 200 OK
     code: 200
     duration: ""
@@ -775,19 +775,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:57 GMT
+      - Tue, 07 Nov 2023 16:21:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -797,7 +797,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac92498e-c354-49ae-b5ab-8ddc105ecfd5
+      - fa096427-4797-40f9-b296-bf12fcbbfd9d
     status: 200 OK
     code: 200
     duration: ""
@@ -808,19 +808,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:02 GMT
+      - Tue, 07 Nov 2023 16:21:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -830,7 +830,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - babd1777-c976-414d-88f0-0ec70bef70a8
+      - 492e01af-4dba-4c78-bfe6-be4230af4e62
     status: 200 OK
     code: 200
     duration: ""
@@ -841,19 +841,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:07 GMT
+      - Tue, 07 Nov 2023 16:21:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -863,7 +863,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a7f5b57-35d0-4344-a3b3-2e2b789a08dd
+      - 31efe15c-c599-4cbb-aa7a-1f99fc547fd7
     status: 200 OK
     code: 200
     duration: ""
@@ -874,19 +874,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:12 GMT
+      - Tue, 07 Nov 2023 16:21:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -896,7 +896,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3af2622c-24cc-4bc6-b808-3abf7cdd59ef
+      - 114ee06e-1b43-4fc1-bd3b-3bfc5b0064f4
     status: 200 OK
     code: 200
     duration: ""
@@ -907,19 +907,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:17 GMT
+      - Tue, 07 Nov 2023 16:21:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -929,7 +929,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5dfdf38a-8be2-4bb8-840b-df78212f734c
+      - 9f6dea32-cd18-4408-ab23-288ed58f053b
     status: 200 OK
     code: 200
     duration: ""
@@ -940,19 +940,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:22 GMT
+      - Tue, 07 Nov 2023 16:21:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -962,7 +962,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e790edb-0f55-4a21-b07e-7561a0c94b63
+      - d3eee73d-6d6e-4cc3-ba98-8b837742219e
     status: 200 OK
     code: 200
     duration: ""
@@ -973,19 +973,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:27 GMT
+      - Tue, 07 Nov 2023 16:21:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -995,7 +995,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f6878c9-5c64-4cfe-b137-520ceb121b0b
+      - 054a94ff-5e8c-4eaa-8c02-b333f51fbd66
     status: 200 OK
     code: 200
     duration: ""
@@ -1006,19 +1006,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:32 GMT
+      - Tue, 07 Nov 2023 16:21:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1028,7 +1028,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3bf9698e-4056-4f7d-84d3-b867e712f2eb
+      - a5dd6282-ff08-4713-bf3c-ba55359e2c09
     status: 200 OK
     code: 200
     duration: ""
@@ -1039,19 +1039,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:37 GMT
+      - Tue, 07 Nov 2023 16:22:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1061,7 +1061,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc73e678-24a1-4398-9d7a-2fafc2e0ff0c
+      - e30fdd45-c7a6-4abf-9452-b2a0f77e0a9a
     status: 200 OK
     code: 200
     duration: ""
@@ -1072,19 +1072,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:42 GMT
+      - Tue, 07 Nov 2023 16:22:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1094,7 +1094,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34376c87-7a4c-4d27-8f61-e2407e7c1862
+      - 09727117-b4e8-47ce-a5cb-cc6d87025ed0
     status: 200 OK
     code: 200
     duration: ""
@@ -1105,19 +1105,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:47 GMT
+      - Tue, 07 Nov 2023 16:22:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1127,7 +1127,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40e86f5f-c39f-4ddc-a7d6-1ffab37a85ee
+      - bb6d5c8c-ea9d-4341-97fd-02df1b4acb17
     status: 200 OK
     code: 200
     duration: ""
@@ -1138,19 +1138,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:52 GMT
+      - Tue, 07 Nov 2023 16:22:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1160,7 +1160,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b4ff309-04d3-4c3b-b6cd-f90f9dcef1c2
+      - 277d0512-16b3-467e-936a-d0c5274f2b65
     status: 200 OK
     code: 200
     duration: ""
@@ -1171,19 +1171,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:57 GMT
+      - Tue, 07 Nov 2023 16:22:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1193,7 +1193,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a05dbf7c-1ab9-4f01-8b2a-3b8b60e874e0
+      - ed47d484-d30e-434d-a06c-75c4c59cb050
     status: 200 OK
     code: 200
     duration: ""
@@ -1204,19 +1204,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:02 GMT
+      - Tue, 07 Nov 2023 16:22:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1226,7 +1226,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d940056d-7566-4cd1-a9a3-719fc15c385e
+      - 2de33e2e-06e6-43fc-8ddb-cabf734f714e
     status: 200 OK
     code: 200
     duration: ""
@@ -1237,19 +1237,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:08 GMT
+      - Tue, 07 Nov 2023 16:22:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1259,7 +1259,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2bf4b908-fb48-4d48-9d19-26076d8153fb
+      - 91f0428a-258c-488b-a116-8e353b42862b
     status: 200 OK
     code: 200
     duration: ""
@@ -1270,19 +1270,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:13 GMT
+      - Tue, 07 Nov 2023 16:22:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1292,7 +1292,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b82c6b19-3edf-4ecd-90e0-5135890b8570
+      - 9222904f-4acd-4a52-93b8-45226659dd77
     status: 200 OK
     code: 200
     duration: ""
@@ -1303,19 +1303,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:18 GMT
+      - Tue, 07 Nov 2023 16:22:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1325,7 +1325,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 624ee52b-9bd8-4550-8c85-397ae4523437
+      - bb517e7e-82ab-4c1a-a93a-ff38f56cc4b1
     status: 200 OK
     code: 200
     duration: ""
@@ -1336,19 +1336,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:23 GMT
+      - Tue, 07 Nov 2023 16:22:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1358,7 +1358,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3aa822e8-430a-4740-847f-4b1563cc8c2f
+      - e73d9e81-4d73-4065-9d96-abbe904ea3b0
     status: 200 OK
     code: 200
     duration: ""
@@ -1369,19 +1369,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:28 GMT
+      - Tue, 07 Nov 2023 16:22:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1391,7 +1391,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11bf8c40-cab5-442a-99f1-e625dac65bf0
+      - 71f4d28a-a29d-42d7-ba30-10ba6f6d9e70
     status: 200 OK
     code: 200
     duration: ""
@@ -1402,19 +1402,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:33 GMT
+      - Tue, 07 Nov 2023 16:22:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1424,7 +1424,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 298c13ff-46ab-4932-8753-f0e2ddb05b8a
+      - 6ceb5cef-05c2-470c-9610-8c9b955b65e2
     status: 200 OK
     code: 200
     duration: ""
@@ -1435,19 +1435,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:38 GMT
+      - Tue, 07 Nov 2023 16:23:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1457,7 +1457,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8af636d8-05a1-4616-9057-9969a47d9793
+      - 1ca4251a-b1af-4b75-931e-28aea068dc0f
     status: 200 OK
     code: 200
     duration: ""
@@ -1468,19 +1468,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:43 GMT
+      - Tue, 07 Nov 2023 16:23:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1490,7 +1490,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4f82ed2-7746-4497-bd37-39d27be19579
+      - a60fea5e-42b1-4958-ae64-e9f1d907008b
     status: 200 OK
     code: 200
     duration: ""
@@ -1501,19 +1501,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:21:11.077578Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:48 GMT
+      - Tue, 07 Nov 2023 16:23:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1523,7 +1523,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 741b35f2-82eb-412c-b9c0-d8c154d0ad60
+      - c7e0bf79-e04b-4b88-8d1e-ac3b8ead1460
     status: 200 OK
     code: 200
     duration: ""
@@ -1534,19 +1534,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:23:14.531362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "601"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:53 GMT
+      - Tue, 07 Nov 2023 16:23:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1556,7 +1556,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d70d0c38-2fb1-48b1-8274-204bc7ad9ab1
+      - 162c96ba-f216-4d68-aa69-6e95cb43aca2
     status: 200 OK
     code: 200
     duration: ""
@@ -1567,19 +1567,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:23:14.531362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "601"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:58 GMT
+      - Tue, 07 Nov 2023 16:23:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1589,7 +1589,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff9121eb-abd7-4a43-8695-3c6527a659e5
+      - dc33adc4-e827-4dce-95ce-e5c8b4704ec0
     status: 200 OK
     code: 200
     duration: ""
@@ -1600,19 +1600,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf/nodes?order_by=created_at_asc&page=1&pool_id=a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-11-07T16:21:11.554554Z","error_message":null,"id":"9417a537-4965-4302-9ae6-30f842f612d8","name":"scw-test-multicloud-test-multicloud-9417a53749","pool_id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","provider_id":"scaleway://instance/fr-par-1/c42d8e91-8d83-4de6-8dfb-295aa6ac49e2","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:23:14.517625Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "626"
+      - "607"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:03 GMT
+      - Tue, 07 Nov 2023 16:23:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1622,7 +1622,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42954f9e-b2b2-44b7-84b6-2ac6cdae9663
+      - 63edaff7-3872-4087-9e6b-c151d91c9a82
     status: 200 OK
     code: 200
     duration: ""
@@ -1633,19 +1633,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:21:10.241756Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "626"
+      - "1368"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:08 GMT
+      - Tue, 07 Nov 2023 16:23:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1655,7 +1655,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01d1b790-4e71-4eb1-ae79-ce769a9682e5
+      - 4d24eea9-3cae-49bd-be68-edc584a0a91d
     status: 200 OK
     code: 200
     duration: ""
@@ -1666,19 +1666,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:21:10.241756Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "626"
+      - "1368"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:13 GMT
+      - Tue, 07 Nov 2023 16:23:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1688,7 +1688,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd3076ac-7cec-4643-8e26-ad8b5b6285cd
+      - 33516721-ae9b-4912-b1ed-dbcb690e14df
     status: 200 OK
     code: 200
     duration: ""
@@ -1699,19 +1699,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbXVsdGljbG91ZCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEJkMDFHYjFoRVZFMTZUVlJGZDA1cVJUSk5ha0YzVFVadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUbnBKQ21oV1RtTlhlSFV2Unpka2VFb3lWRzVKTVZoNVZUZ3plV0pMZEc1cU1rcEZXbGxQY1ZabVpHaFpTa2wxWVRGdU1qRlZTVlpNUVZOb1lsWmxlR1ZKTmpRS1FrNVRiR1l6TmxJeVdXaE5kM1l5U0dGSFVFRlpTVzUyWWpNMGNuRkNhbE5hVlZKREwyRnVlbTFXT1ZGeFFXcHpibk52V21aNFdVZHFkQzlMYUdOVlNRcERkbFZxV1hCWFNUWlFaR1J0V1ZKTVEwTlNNbG92UlVjMldqbEhUamhJV0VWUk0wOWlkM0ZHVGsxYVJEWTFjMUZNT1dGcE1FYzNlamxvTlZWMlUxUlJDa0oyY1hKbGFGTTBZV2xETmpaVVJVbG9XRmhKTW5obGIyNW5Wa2RoU25GUlNtTjVTRVJDUkUxM09XTXdNMVpaUm5oR2JqWjVUbUZrUm5OU1NXSnBPRmdLVldKd2FUSlNVVmQyZFhkWFZVcDBXa2xhZHk5VFVUSlpkRVJKVUZSVE0wWldhVTVoZUdSTkwzVTVURzQ1YW5KeWJYWlplRlZWTlVNeVdGUkpUbFpMVEFveGFqWnZUa1Z2Y0hSc1V6TTBaWE5JY1dSelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTmNTOXFkbEpGUlhaT1ptZ3ZLM0JUVTJvMFRFbEpTMnBWZW5aTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFREVjJjMGREVEc5c1MzZHNhMHc1VGtOSVZUSlNOVVZPYUc1NFEwWTBOalptWm1ZMWFuZGlTalZ2VkRBelZqTlFNUXBvTlVsTGFXZENWVzFJYVVVMVZHUjFWakl2WlRKT1QySTRRemxNUmxwYVNFNW5iRFpLYjBoVGVuSkZRMjFuYzBVMk5uVk5aeTl4ZWs1R09YZDVMek5qQ25CUUwxbDNkQzlVU2poYVFsQlZha2R1UzFKSk5rWkhkR2RsYlZKRlMyNUxVekpwWjNsaGRFeGhiVEkwWW5WRVNtSlpiVlp5Y25kUlJsWkpiV0ZoVG1NS04zZHFkamRYYzFOb1JVTkNPVUpaYzBwWWNqTldSbGwyVG1oRE1XaGxabGRJVVRkRmEwRmFNMVZEYm1kWlUxTnZTMjlFWVhKMFRraFlOMlJNY0ZwNWRRcExlRTgwWkdWd2REVjVNekpRTjNrM1dsVjJZM2Q2YzJSRVFWRTBiRVpZTWxJNWFrdzBWREp2Y2toVVduVktUVXRLZGxKME1uazVRMjlyVW5SaWNsTktDak5uWkZkMWR5c3llbVpNTTFoMlQzUk5Na2xWUTNsRGFHUnRSRlJhTkM5WmJtczJaUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMTdkMzhiMDItNzQ4NS00ZTZlLWFhN2EtZDgyNmRmZGUxY2NmLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbXVsdGljbG91ZAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1tdWx0aWNsb3VkIgogICAgdXNlcjogdGVzdC1tdWx0aWNsb3VkLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1tdWx0aWNsb3VkCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1tdWx0aWNsb3VkLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBRalBKYlJWZVlYVHBmczM1bTVjSXJpbklSZjFYcmVzQ1M2ZXNlMGFTTDM1RERPQ3BkNEdIRXpYbw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "626"
+      - "2612"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:18 GMT
+      - Tue, 07 Nov 2023 16:23:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1721,7 +1721,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6643c7ef-3ff3-45fd-9a76-83a4e26d666c
+      - 78162fc0-40e3-40f8-912f-8880815c33a8
     status: 200 OK
     code: 200
     duration: ""
@@ -1732,19 +1732,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:23:14.531362Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "601"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:23 GMT
+      - Tue, 07 Nov 2023 16:23:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1754,7 +1754,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c31ee53c-d6ef-4560-b74e-a4fad45a04d6
+      - b0a1ac35-71b2-4b90-b680-82b8802b7d88
     status: 200 OK
     code: 200
     duration: ""
@@ -1765,19 +1765,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf/nodes?order_by=created_at_asc&page=1&pool_id=a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-11-07T16:21:11.554554Z","error_message":null,"id":"9417a537-4965-4302-9ae6-30f842f612d8","name":"scw-test-multicloud-test-multicloud-9417a53749","pool_id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","provider_id":"scaleway://instance/fr-par-1/c42d8e91-8d83-4de6-8dfb-295aa6ac49e2","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:23:14.517625Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "626"
+      - "607"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:28 GMT
+      - Tue, 07 Nov 2023 16:23:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1787,7 +1787,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7f0c582-f2d7-4b79-a5ec-8eb9409c4761
+      - ff4598a0-fcfb-462e-a387-7f3c855d5caa
     status: 200 OK
     code: 200
     duration: ""
@@ -1798,1108 +1798,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:47:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 796999a7-e779-45f6-b2d0-798c36e014f0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:47:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6d1acd42-fef4-4fc3-ace3-bfe18cbae2cb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:47:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5b54f048-13b2-4f0f-9b89-87449241d260
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:47:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f5c2631b-9880-480a-b26d-e4cb1a528bb7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:47:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4f597153-9bfd-49ee-91e9-88f702b104d6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:47:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c8fe9933-8638-4cf6-9a93-d273e2be9c76
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:48:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 581f303b-609b-4b0d-ae58-9859e5b9822e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:48:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 29eebd22-0243-4baf-8706-7a591d90e9b1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:48:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e02e4b5d-faf2-47f3-9fdc-a3276d1d13e4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:48:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a521b870-c7b3-4686-80b2-47d7b1ea3331
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:48:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 84843da2-98d0-4163-8e9c-645c4d28a9cb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:48:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7099c132-5eda-4074-82a9-fa60cb1f68f4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:48:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b71c772a-81ca-4a88-9353-023d42e02656
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:48:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5e300ac5-c287-443d-a2b8-02a24bfbd162
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:48:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7957f782-3cea-4bca-a2e8-ec74f743fe1b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:48:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6e095c09-0f6e-41ce-922e-36822fd4c58a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:48:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 24775dd7-60b2-4c89-a0c0-980841814a81
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:48:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6aa89d47-d77f-4553-accb-94c576d77801
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f5cb3014-0a2d-4dd3-a3e3-0bf4fabae82f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 49d09c35-cf16-4711-b8a3-42a045c26015
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 48810849-2701-4559-bf48-4eab120ff5da
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 390b98b3-029a-43f0-bf33-2fae9c5c453a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4000672e-d602-4be4-a19b-0db3032b345d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:30 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7737872d-8dfd-42c3-bbd3-00def2257702
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:44:46.894101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - eb76dc02-41b7-4128-bc7c-978c96a776ca
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-18T16:49:38.125336Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "624"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4ac82bab-6c94-4f31-bc3a-b63bafce2cb6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-18T16:49:38.125336Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "624"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - eeed9bb3-6103-497a-9daa-1951eea9d85a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0/nodes?order_by=created_at_asc&page=1&pool_id=2c3afa50-e727-4e28-8135-71b8327b563d&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-10-18T16:44:47.438616Z","error_message":null,"id":"0a828bda-398d-4614-b1cf-1c64f7064650","name":"scw-test-multicloud-test-multicloud-0a828bda39","pool_id":"2c3afa50-e727-4e28-8135-71b8327b563d","provider_id":"scaleway://instance/fr-par-1/16d55cb5-70e8-496c-b363-d885ebdfbaef","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:49:38.109228Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "623"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fb00321c-855d-49a2-8f51-72edbe0172c5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5145a129-3d9f-4959-bcba-14a0902c68e0.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:43:35.895129Z","created_at":"2023-10-18T16:43:35.895129Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5145a129-3d9f-4959-bcba-14a0902c68e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5145a129-3d9f-4959-bcba-14a0902c68e0","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-10-18T16:44:42.914178Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1411"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c1c54e00-98cf-494f-b9c4-b7bbb439c34a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5145a129-3d9f-4959-bcba-14a0902c68e0.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:43:35.895129Z","created_at":"2023-10-18T16:43:35.895129Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5145a129-3d9f-4959-bcba-14a0902c68e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5145a129-3d9f-4959-bcba-14a0902c68e0","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"multicloud","updated_at":"2023-10-18T16:44:42.914178Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1411"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2a39daa3-6eb2-4d50-b121-ac59702156ff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtbXVsdGljbG91ZCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVeVRrUk5lazR4YjFoRVZFMTZUVlJCZUU1NlJUSk9SRTE2VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUMFJYQ2toRmFFdExNV3BSV25OYWFFdHdPRTlIUWpaWVQwTjVXREZuYUU5clZ6VlFVWGRoVGtsMGIwVnNNbk16Yms1aFR5dEdNMjl6UjA1eWNXZHJURnBNWnpnS1VUUkhkV3haTURobU5ERmlhRTF4VkVOd2FpdDBObGhYSzB4blUwaHpOSFpyWjNKTmFWcDNNRzE1Tm1GdmEzQnlOR3hwTHpCUlpWTnRiR2xZU25kNlNBcE9kSEJVYVVZMkwzVXhPR1ZaVTNvMFEydE9VRTVPTlRaUU5taGlhVFpsYUVGUlVXRXhTSFp3WVVKemRqaG1TMFpYYUhsS1VVWjZTVkJXWTFOak5sVXlDbXRHY0RRM1RWVTROREIwZFU1d1VISklXa1pQYmxWM2NYaEdSREpyU21KV1VWaDZhV1ptVDA0MWEyd3dXVVZLV1ZCNWRsZHFiMVJGU25GVmVEVnVSbFVLTVZWd05YaExRVzFFUVZKcVkwRk1TRFJOZDFscVNuVnBkVVJ2U2pOdWVTOXJjVlJwZVUxRGVYbGpSMGxSVkUxaE56WnhVR2ROU0d0aWNtdFpaRVl3UlFvd1VFOHlUMUpZY1dKUlpHUjRZbk5IT1ZwelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaRWFHNUJibTFPYUVGa2IwTnhTbXhHZDI5RE16RjZOa0o1VFZaTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlRtcHRRakV6VGtORlZUUmpVRUZXWml0Wk9VbEdWRTVPVmxGRFkxaGhSMGxSUVVRek5WQlFNa0V3VEcwNVpGRkxjQXBQWVdsc1pEaG5hMWxsYnpSclJXMDFhWFF3YTBOTlVHVkhWa2t3VUU5RFdFYzBNR2xGV0dGWlVIb3JVRGhXUTBoeFkzUkZaRkZTVjFGV09HMTVhWFozQ2tneGR6WlJhRWhEYVhoamRUaElMMDRyVFhoUWRVRTFVRGRJY0dSYVIzWm5TR1ZZYURJeWNXRlFkbE15WVZaV1UzZGFhMHhOV0ZsMVFscE5SR1Z3U2tJS2JHa3ZPWFpUY201dFltUk5NbXR5YnpFNWNrUnlRMFZCVEZwNk9FOXpRbWd6T1hCTVRFWmFhbWRoWW1GRVN6QkdMelZUUnpkcVdYWlFTbm8zTHpKSFZ3cHZOR3hMVGtKSk5Yb3hkRzEzTkRBMGJEbDVaa2xDVGpoeVZtVnFlV2xxUXk4ckwyZHZLME5FZEZJeVYyNHpOVkpaUzFCWU1rUkpZakV3VGs1cFprZHBDaXRtWWxreVpFeHNjRE5sVlRaSlNFVjVkMmwzVkZKSVkzTlZjRFpSY2k5aFVERTVZZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTE0NWExMjktM2Q5Zi00OTU5LWJjYmEtMTRhMDkwMmM2OGUwLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtbXVsdGljbG91ZAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1tdWx0aWNsb3VkIgogICAgdXNlcjogdGVzdC1tdWx0aWNsb3VkLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1tdWx0aWNsb3VkCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1tdWx0aWNsb3VkLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpbHZlTDZtYXowVFliRVFJRDM0SGpKUnVwTUpFSEVYV3hmRHJ3NlNTamdDUEtvS3BOSVpiRzhjYg==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2614"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 36bfcc00-296a-4a25-97ae-81ff3e0cfb68
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-18T16:49:38.125336Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "624"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3c231a46-5b7e-400d-8b07-796f09c5cca8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0/nodes?order_by=created_at_asc&page=1&pool_id=2c3afa50-e727-4e28-8135-71b8327b563d&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-10-18T16:44:47.438616Z","error_message":null,"id":"0a828bda-398d-4614-b1cf-1c64f7064650","name":"scw-test-multicloud-test-multicloud-0a828bda39","pool_id":"2c3afa50-e727-4e28-8135-71b8327b563d","provider_id":"scaleway://instance/fr-par-1/16d55cb5-70e8-496c-b363-d885ebdfbaef","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:49:38.109228Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "623"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 777954a5-5340-4ccc-b478-4a6390c4ce82
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/2c3afa50-e727-4e28-8135-71b8327b563d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: DELETE
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","container_runtime":"containerd","created_at":"2023-10-18T16:44:46.885983Z","id":"2c3afa50-e727-4e28-8135-71b8327b563d","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-10-18T16:49:41.812585083Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:23:18.906233437Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "630"
+      - "607"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:41 GMT
+      - Tue, 07 Nov 2023 16:23:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2909,7 +1820,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04cc45c9-ce77-4760-a3a6-afe69b48d8ff
+      - 35c33d37-96b4-4b1a-8c6b-68fc8539b066
     status: 200 OK
     code: 200
     duration: ""
@@ -2920,52 +1831,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0?with_additional_resources=true
-    method: DELETE
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5145a129-3d9f-4959-bcba-14a0902c68e0.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:43:35.895129Z","created_at":"2023-10-18T16:43:35.895129Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5145a129-3d9f-4959-bcba-14a0902c68e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5145a129-3d9f-4959-bcba-14a0902c68e0","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-10-18T16:49:41.895527822Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1417"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e125d128-59d2-4a4c-b8f3-5e730809895a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5145a129-3d9f-4959-bcba-14a0902c68e0.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:43:35.895129Z","created_at":"2023-10-18T16:43:35.895129Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5145a129-3d9f-4959-bcba-14a0902c68e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5145a129-3d9f-4959-bcba-14a0902c68e0","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-10-18T16:49:41.895528Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:23:18.906233Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1414"
+      - "604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:42 GMT
+      - Tue, 07 Nov 2023 16:23:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2975,7 +1853,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2476e43-b954-480a-8674-1a09b4fac55f
+      - f0e1fb39-d094-48ef-924e-bc1e364bc1a6
     status: 200 OK
     code: 200
     duration: ""
@@ -2986,19 +1864,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5145a129-3d9f-4959-bcba-14a0902c68e0.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:43:35.895129Z","created_at":"2023-10-18T16:43:35.895129Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5145a129-3d9f-4959-bcba-14a0902c68e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5145a129-3d9f-4959-bcba-14a0902c68e0","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-10-18T16:49:41.895528Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:23:18.906233Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1414"
+      - "604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:47 GMT
+      - Tue, 07 Nov 2023 16:23:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3008,7 +1886,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0eb10c6-0433-4c21-96f2-e684635bd2c9
+      - e17a43dd-f264-40bb-bc83-affa5ddbfb25
     status: 200 OK
     code: 200
     duration: ""
@@ -3019,19 +1897,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5145a129-3d9f-4959-bcba-14a0902c68e0.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:43:35.895129Z","created_at":"2023-10-18T16:43:35.895129Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5145a129-3d9f-4959-bcba-14a0902c68e0.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5145a129-3d9f-4959-bcba-14a0902c68e0","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-10-18T16:49:41.895528Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:23:18.906233Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1414"
+      - "604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:52 GMT
+      - Tue, 07 Nov 2023 16:23:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3041,7 +1919,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99aa31cf-935d-4444-ad6f-f361f1558fe4
+      - 165c5990-5bbc-483e-9022-095e32bfef73
     status: 200 OK
     code: 200
     duration: ""
@@ -3052,19 +1930,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","type":"not_found"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","container_runtime":"containerd","created_at":"2023-11-07T16:21:11.068448Z","id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-multicloud","node_type":"dev1_m","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":40000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:23:18.906233Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "128"
+      - "604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:57 GMT
+      - Tue, 07 Nov 2023 16:23:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3074,7 +1952,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6ccc2b1-e0fc-43f0-8258-715b8af69c5a
+      - 1b408659-35d2-4067-8311-8b05726ffc04
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"a4ce0b5a-ea30-44f6-be7c-df6b20a8f6fb","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "125"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:23:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 20287aba-3a89-4f7d-9f17-23b17d4848e9
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3085,19 +1996,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5145a129-3d9f-4959-bcba-14a0902c68e0
-    method: GET
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf?with_additional_resources=true
+    method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"5145a129-3d9f-4959-bcba-14a0902c68e0","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:23:39.255802878Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "128"
+      - "1374"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:57 GMT
+      - Tue, 07 Nov 2023 16:23:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3107,7 +2018,370 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 497826fe-e6de-499f-960d-41d54a89443e
+      - bc6be094-8e5e-404d-a3ee-09806e845eb9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:23:39.255803Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1371"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:23:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 34d3c1de-c641-40ac-81c7-3de9c1dd73d4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:23:39.255803Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1371"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:23:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b35e551c-4749-42f9-8dbb-2e857587b170
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:23:39.255803Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1371"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:23:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e8e2f9b7-3b5d-4c5d-a427-cbe737d49a68
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:23:39.255803Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1371"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:23:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a3151e7f-441d-4166-b245-19a55bdf8dfb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:23:39.255803Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1371"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:23:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 895cec2d-687e-4c61-931c-881dd8022f39
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:23:39.255803Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1371"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:24:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7a64af48-2710-4549-8711-f5e3c36aa77c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:23:39.255803Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1371"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:24:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - af450e1d-a395-49fa-9660-ed860f46529a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:23:39.255803Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1371"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:24:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 89ba6dea-49ee-4733-9c33-b6e2933b2637
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://17d38b02-7485-4e6e-aa7a-d826dfde1ccf.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:19:59.742842Z","created_at":"2023-11-07T16:19:59.742842Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.17d38b02-7485-4e6e-aa7a-d826dfde1ccf.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","ingress":"none","name":"test-multicloud","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"multicloud","updated_at":"2023-11-07T16:23:39.255803Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1371"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:24:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2461f7f9-2768-40e2-85d5-438aaa089f24
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:24:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e23fca6f-67d4-42c6-b9a0-bea5358e2c1f
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/17d38b02-7485-4e6e-aa7a-d826dfde1ccf
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"17d38b02-7485-4e6e-aa7a-d826dfde1ccf","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:24:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 60791f34-5bc3-4c6e-ad20-3507871934ae
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-oidc.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-oidc.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:41 GMT
+      - Tue, 07 Nov 2023 16:19:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,12 +34,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af32e9ae-5dec-414c-8d95-a10dabb82b1f
+      - 2dc646c0-ee24-4b8f-8c74-ad9e67188c40
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-oidc","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"test-oidc","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-18T16:43:38.885896Z","dhcp_enabled":true,"id":"578ed20e-1dd8-4de6-8aa5-552261b9473f","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:38.885896Z","id":"306fa64d-dde0-4dcc-96d5-519d98391c44","subnet":"172.16.24.0/22","updated_at":"2023-10-18T16:43:38.885896Z"},{"created_at":"2023-10-18T16:43:38.885896Z","id":"0a508f71-c9e0-439d-87b7-b8725789e8ad","subnet":"fd63:256c:45f7:2ea1::/64","updated_at":"2023-10-18T16:43:38.885896Z"}],"tags":[],"updated_at":"2023-10-18T16:43:38.885896Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:21:29.698650Z","dhcp_enabled":true,"id":"8cdb7dd1-addc-4e11-8286-f31958aff852","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:21:29.698650Z","id":"fa8518cb-34ee-44b7-9ebf-678ecb16cecb","subnet":"172.16.4.0/22","updated_at":"2023-11-07T16:21:29.698650Z"},{"created_at":"2023-11-07T16:21:29.698650Z","id":"52e73ae2-ea88-4993-a468-159f746f6b56","subnet":"fd63:256c:45f7:c8d9::/64","updated_at":"2023-11-07T16:21:29.698650Z"}],"tags":[],"updated_at":"2023-11-07T16:21:29.698650Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "710"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:39 GMT
+      - Tue, 07 Nov 2023 16:21:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70c515eb-7c51-48d7-b50d-62ee6646786f
+      - 0fc122c9-89ce-412a-af08-59d415e1d184
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/578ed20e-1dd8-4de6-8aa5-552261b9473f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8cdb7dd1-addc-4e11-8286-f31958aff852
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:43:38.885896Z","dhcp_enabled":true,"id":"578ed20e-1dd8-4de6-8aa5-552261b9473f","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:38.885896Z","id":"306fa64d-dde0-4dcc-96d5-519d98391c44","subnet":"172.16.24.0/22","updated_at":"2023-10-18T16:43:38.885896Z"},{"created_at":"2023-10-18T16:43:38.885896Z","id":"0a508f71-c9e0-439d-87b7-b8725789e8ad","subnet":"fd63:256c:45f7:2ea1::/64","updated_at":"2023-10-18T16:43:38.885896Z"}],"tags":[],"updated_at":"2023-10-18T16:43:38.885896Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:21:29.698650Z","dhcp_enabled":true,"id":"8cdb7dd1-addc-4e11-8286-f31958aff852","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:21:29.698650Z","id":"fa8518cb-34ee-44b7-9ebf-678ecb16cecb","subnet":"172.16.4.0/22","updated_at":"2023-11-07T16:21:29.698650Z"},{"created_at":"2023-11-07T16:21:29.698650Z","id":"52e73ae2-ea88-4993-a468-159f746f6b56","subnet":"fd63:256c:45f7:c8d9::/64","updated_at":"2023-11-07T16:21:29.698650Z"}],"tags":[],"updated_at":"2023-11-07T16:21:29.698650Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "710"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:40 GMT
+      - Tue, 07 Nov 2023 16:21:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd3716d6-f9c3-4243-b7c7-848571288439
+      - c8b6e62e-94b0-413c-a0a8-0d99d4f91be7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-oidc","description":"","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":{"issuer_url":"https://accounts.google.com","client_id":"my-super-id","username_claim":"mario","username_prefix":null,"groups_claim":["k8s","admin"],"groups_prefix":"pouf","required_claim":null},"apiserver_cert_sans":null,"private_network_id":"578ed20e-1dd8-4de6-8aa5-552261b9473f"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-oidc","description":"","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"open_id_connect_config":{"issuer_url":"https://accounts.google.com","client_id":"my-super-id","username_claim":"mario","username_prefix":null,"groups_claim":["k8s","admin"],"groups_prefix":"pouf","required_claim":null},"apiserver_cert_sans":null,"private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852"}'
     form: {}
     headers:
       Content-Type:
@@ -118,16 +118,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1eb14530-5af4-4449-8119-f4543f21184f.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:43:40.198151245Z","created_at":"2023-10-18T16:43:40.198151245Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1eb14530-5af4-4449-8119-f4543f21184f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1eb14530-5af4-4449-8119-f4543f21184f","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"578ed20e-1dd8-4de6-8aa5-552261b9473f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-10-18T16:43:40.206955513Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281180Z","created_at":"2023-11-07T16:21:30.709281180Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:30.727658596Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1566"
+      - "1520"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:40 GMT
+      - Tue, 07 Nov 2023 16:21:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7bec22d-ee4e-4cc9-943f-684d2c9eb8c6
+      - 1ed6eeeb-4a41-4556-b72f-10afa206e96c
     status: 200 OK
     code: 200
     duration: ""
@@ -148,19 +148,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1eb14530-5af4-4449-8119-f4543f21184f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1eb14530-5af4-4449-8119-f4543f21184f.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:43:40.198151Z","created_at":"2023-10-18T16:43:40.198151Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1eb14530-5af4-4449-8119-f4543f21184f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1eb14530-5af4-4449-8119-f4543f21184f","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"578ed20e-1dd8-4de6-8aa5-552261b9473f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-10-18T16:43:40.206956Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:30.727659Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1557"
+      - "1511"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:40 GMT
+      - Tue, 07 Nov 2023 16:21:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c2dc20a-e0fe-4060-9079-7398445c78f1
+      - 85468541-e283-41d5-93f1-a493085fcb69
     status: 200 OK
     code: 200
     duration: ""
@@ -181,19 +181,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1eb14530-5af4-4449-8119-f4543f21184f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1eb14530-5af4-4449-8119-f4543f21184f.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:43:40.198151Z","created_at":"2023-10-18T16:43:40.198151Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1eb14530-5af4-4449-8119-f4543f21184f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1eb14530-5af4-4449-8119-f4543f21184f","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"578ed20e-1dd8-4de6-8aa5-552261b9473f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-10-18T16:43:41.662Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:32.315038Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1559"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:45 GMT
+      - Tue, 07 Nov 2023 16:21:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 715a0893-1d11-481b-8865-68466a69a80c
+      - 87a78f1e-6aa3-450d-9824-e82ac5452e36
     status: 200 OK
     code: 200
     duration: ""
@@ -214,19 +214,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1eb14530-5af4-4449-8119-f4543f21184f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1eb14530-5af4-4449-8119-f4543f21184f.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:43:40.198151Z","created_at":"2023-10-18T16:43:40.198151Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1eb14530-5af4-4449-8119-f4543f21184f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1eb14530-5af4-4449-8119-f4543f21184f","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"578ed20e-1dd8-4de6-8aa5-552261b9473f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-10-18T16:43:41.662Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:32.315038Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1559"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:45 GMT
+      - Tue, 07 Nov 2023 16:21:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf13ea25-6231-463f-80da-3044eb97bb55
+      - d5ba4705-7cce-4342-bea6-6f83577a850c
     status: 200 OK
     code: 200
     duration: ""
@@ -247,19 +247,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1eb14530-5af4-4449-8119-f4543f21184f/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVeVRrUk5NRTFXYjFoRVZFMTZUVlJCZUU1NlJUSk9SRTB3VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVXRCQ2tzNVRFVkhLMDlVVTNVNWVUQm5RVkpZUmtGUE9XeFVXVXRxVUVOQ1JrWjRObTFYV1ZKeGFEQXpRVVp6WkhwTlRXOVBaWEpEVW1oRWIwUkpaU3RwYVRFS056STJPSFI1YVRKclMzZzNaSG9ySzNWeFltdDRWSE56WjNsNWQxUmtiazU2V1VzeFIwZFlPRkIyVlVob01HUnpObXhyZEdWYVQySkdabk50Tm1nMVpBcFFTa3hoUW1GTWNrNXlZbWgyZEROdmQyMXFZbmxsY1daTE1sWkhlbWw2UVdwUWFIWmhTR0ZsYmpBelRsQktlbkZhWjJSNVJURlVUbmhRZUhwdGNuUjFDbEJ1YTFaeWFXTnljMVZPTmpab1UwOUtRV054WTNSclpIWmFXR0ZoWTFSd2IwOVdWRzVHVEZGd1MxcG5Vamt3Um5FeFlTdFFZVk5IUkcxNVpHWXliRXNLVnpsUFVVSTJZVzlpWjA1WlpWWlplWGwwUldSaVlYQkZVMEZCWW1SRFVtTlVWMHgxYVhFNVNIUnlUVzAzU21relZtbHljbmxTZEhCWFpYRkVTa3BMZWdwamNrODBTMVJWWldsWWRtSjJVaTh4TUZSelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSGJDOVlhMlF3U25kdGJFOXVSbkZ1ZWpoWVluQmxlVUZhYW1OTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk9EUlNPVFJzVlRWUmJYTmtPRzVDZG5OS2RYWXZRbWx2TURJMFZWRnNVMlZDVWxSYVIxRmtOblJRZUVoS0wySlpWQW92WkhCSldsZEdWM0JSUkVwR2NqUk1SR1V4VjJaQ01XTXhZVlJoZEVWR2JtNXBTMmd6TTIxME1rWmxZalp1YUU5cVZrSmxkR1Z0TTJOd2FUWmlZVnBIQ214dFNHc3ZTMjVCT1hWTldETlZaRUZGUkZoSWFUWXdOMkZTVFVGcGVYbEpRekpDU1Vsc05FY3pPVzFGUkhadVVVOUhTM050VEhoaFlYQlFSM0ZZWkhZS1NFMWxOVzR2UzNSUVdsTkdjRUphZEhwalNXaENkR1JhZDI5eFJGVTVOQzlOUzBsT2NXSTVia2RWTURJemFEZDNORzlZT0ZreU1UWTRRVkl3ZWt4SGRncE1ZbVJ0WmpJMFRuWXpWa0pyZUc1Q2JVVTViVU5zZW5WU1kxVlFURzlMYkdGdVl5OTBZekJ3VEdwcVNtNHJTMHBYY21RNE1tVnNkMDlsVHpKbFVtVklDbWRLVjBwS2VtcDBMMGhwSzJkRFZuQTFNMW8xYVZWVloyVTVhRmR3TDA5UllWSkhOQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMWViMTQ1MzAtNWFmNC00NDQ5LTgxMTktZjQ1NDNmMjExODRmLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB3N0Zpb045TzlKbHpuM21vQzJtdVl3bWx3dXU2OWlKTml2dHNxN3B2NXpTUmdseDhUYTBZa2tMNg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEZlazFXYjFoRVZFMTZUVlJGZDA1cVJUSk5ha1Y2VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMkpKQ2s5aWRXWnRaRU5oYkZsNk1YZ3lkSHB3YUdWS1IwMUJkRFZ4U1VsNGRtdzFOMVpIVlhGd2EyVmtlSE0zYkZBMFNIcExWVFJzT1ROM1dGZzNNeTlIYUZBS2RWUlROVE5UVUZOaE4zTk1PV3RHZUZCWGJsTmpabEZrTTJvMVJVODRNbGNyVkVSWWQzaFJjRFI1VTBzMFlXNDFXVnBsWW5GeFZWQmFVbTA1Y2l0blNBbzNjVGMxYzI1Q09GcG5RMmRJWTJkaGQyNVBWa3RHZUU4NVRITTFjVkZJYWtFME5tVlFZMVpCTW14VWMxTTBRMmhzVjFwT2JFTm9aRmM1Y1ZaVlZreDFDbFpYY0ZSeWNUWXdWRFJvZFM5aU5tWmxkMkZSVERSd2FGQnJSVkl3VDBWTFFWQlJTRUpGWW5sWFJUQnhSSFpJUmxacVozQktlRzFSV0Zwc0sxTjZjekVLYVd3eVNqQmFTVlpGY0VveGFYa3lWa1F5SzBKd1ZEbDBXSGgySzJNNVFtZHdlREpuVTFkSlRrdFdURmxqSzNaWFpqaDZaVVJpVEc1U1JFdEhTbUp6VHdwcFpraEpVMWdyTUhCblV5dDBNMnBPYkhJd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUGVHbDRWVkJCVEVOUUszVXlTVU1yU25wTWJtNVpRekZ1WjI1TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2NFcFRWM2RIWjI4clZsUXJUa0l5SzJVd1oxTnJUVE5sYldaM2VrUklRMjU1U1N0MGFsVm9URVkyUVdJeVpuRXhPUW95YjNWMU1VZzJTelJzUVVSNlFWcENUVEJZTlN0RFlUVlpjRmt2VTJGSVptdzNiWGRVYVdNemVrNWtRMUEwVW5KMFlpOXVkVlJvUldwWE5IbE5VR3AzQ2pNNFJVcG1VVXRRY1hsVGNGSlRNV0p2VGpGcFQxUnBObEZPVUVWNGVrMXNjMUp2WW1kT2RtWm9ZVnBJT0hoTlJIaDVjbE5XUkRkdmVVSkZXREpzVTFJS1RVODJZMkZsUzB4aVRteElWV1p4Yms5bE16VlVVQzlUY0cxSVkyVlhZak01Tkc1NGNHMUxSbTFLVTBOQ1VFeFVhakpOYlVnd1kwTXdXa1JqZW1NM1dncGliWEJVZEcxalZXcHlMelF5YVN0VU5VaFZkREpyYWxSRldtaDZabFJyTW1sQ0t6aDBiM0JqTUZkTlJrUlNjV1poVFRKM1pEbEpibGhTT1VJMk5YWk5DbU5ZZVRKVFRtUmhVVzQ1WlhoRWRGaE1NekkxY0hoWlJtdFRTVXhPY1ZSbEwyWm1hd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNGI5MTRiY2UtZjZlOC00MDQ5LWJiYzMtZmJhYWRlOGE2YTUyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB4N2xZNVRjV0hEbDhnbGljSTNNUXBiVnZXVUFXNGdkcmtpVGEzQ29pN3ZwWEZ5ejhoUDBPd285VA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2566"
+      - "2564"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:45 GMT
+      - Tue, 07 Nov 2023 16:21:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b51ceb47-2262-4574-8614-76ac06d1705b
+      - 341a18bf-dcef-46ba-bc9d-fa56150437c3
     status: 200 OK
     code: 200
     duration: ""
@@ -280,19 +280,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1eb14530-5af4-4449-8119-f4543f21184f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1eb14530-5af4-4449-8119-f4543f21184f.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:43:40.198151Z","created_at":"2023-10-18T16:43:40.198151Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1eb14530-5af4-4449-8119-f4543f21184f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1eb14530-5af4-4449-8119-f4543f21184f","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"578ed20e-1dd8-4de6-8aa5-552261b9473f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-10-18T16:43:41.662Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:32.315038Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1559"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:45 GMT
+      - Tue, 07 Nov 2023 16:21:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df5e5ada-fee1-4fa1-acbe-114741fca218
+      - 695f451f-d711-4b84-baba-332b76c5db77
     status: 200 OK
     code: 200
     duration: ""
@@ -313,19 +313,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/578ed20e-1dd8-4de6-8aa5-552261b9473f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8cdb7dd1-addc-4e11-8286-f31958aff852
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:43:38.885896Z","dhcp_enabled":true,"id":"578ed20e-1dd8-4de6-8aa5-552261b9473f","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:38.885896Z","id":"306fa64d-dde0-4dcc-96d5-519d98391c44","subnet":"172.16.24.0/22","updated_at":"2023-10-18T16:43:38.885896Z"},{"created_at":"2023-10-18T16:43:38.885896Z","id":"0a508f71-c9e0-439d-87b7-b8725789e8ad","subnet":"fd63:256c:45f7:2ea1::/64","updated_at":"2023-10-18T16:43:38.885896Z"}],"tags":[],"updated_at":"2023-10-18T16:43:38.885896Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:21:29.698650Z","dhcp_enabled":true,"id":"8cdb7dd1-addc-4e11-8286-f31958aff852","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:21:29.698650Z","id":"fa8518cb-34ee-44b7-9ebf-678ecb16cecb","subnet":"172.16.4.0/22","updated_at":"2023-11-07T16:21:29.698650Z"},{"created_at":"2023-11-07T16:21:29.698650Z","id":"52e73ae2-ea88-4993-a468-159f746f6b56","subnet":"fd63:256c:45f7:c8d9::/64","updated_at":"2023-11-07T16:21:29.698650Z"}],"tags":[],"updated_at":"2023-11-07T16:21:29.698650Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "710"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:45 GMT
+      - Tue, 07 Nov 2023 16:21:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -335,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c4c4a0a-116e-4329-804e-18fdaf43c04e
+      - 7ac296ec-b409-47bb-aaea-f3e1ea6e627b
     status: 200 OK
     code: 200
     duration: ""
@@ -346,19 +346,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1eb14530-5af4-4449-8119-f4543f21184f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1eb14530-5af4-4449-8119-f4543f21184f.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:43:40.198151Z","created_at":"2023-10-18T16:43:40.198151Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1eb14530-5af4-4449-8119-f4543f21184f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1eb14530-5af4-4449-8119-f4543f21184f","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"578ed20e-1dd8-4de6-8aa5-552261b9473f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-10-18T16:43:41.662Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:32.315038Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1559"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:45 GMT
+      - Tue, 07 Nov 2023 16:21:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -368,7 +368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69b3f7d8-ecf6-4b70-941a-c03c836e94bb
+      - dd8ac5d9-bdc2-4086-81eb-6eae6573f998
     status: 200 OK
     code: 200
     duration: ""
@@ -379,19 +379,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1eb14530-5af4-4449-8119-f4543f21184f/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVeVRrUk5NRTFXYjFoRVZFMTZUVlJCZUU1NlJUSk9SRTB3VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVXRCQ2tzNVRFVkhLMDlVVTNVNWVUQm5RVkpZUmtGUE9XeFVXVXRxVUVOQ1JrWjRObTFYV1ZKeGFEQXpRVVp6WkhwTlRXOVBaWEpEVW1oRWIwUkpaU3RwYVRFS056STJPSFI1YVRKclMzZzNaSG9ySzNWeFltdDRWSE56WjNsNWQxUmtiazU2V1VzeFIwZFlPRkIyVlVob01HUnpObXhyZEdWYVQySkdabk50Tm1nMVpBcFFTa3hoUW1GTWNrNXlZbWgyZEROdmQyMXFZbmxsY1daTE1sWkhlbWw2UVdwUWFIWmhTR0ZsYmpBelRsQktlbkZhWjJSNVJURlVUbmhRZUhwdGNuUjFDbEJ1YTFaeWFXTnljMVZPTmpab1UwOUtRV054WTNSclpIWmFXR0ZoWTFSd2IwOVdWRzVHVEZGd1MxcG5Vamt3Um5FeFlTdFFZVk5IUkcxNVpHWXliRXNLVnpsUFVVSTJZVzlpWjA1WlpWWlplWGwwUldSaVlYQkZVMEZCWW1SRFVtTlVWMHgxYVhFNVNIUnlUVzAzU21relZtbHljbmxTZEhCWFpYRkVTa3BMZWdwamNrODBTMVJWWldsWWRtSjJVaTh4TUZSelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSGJDOVlhMlF3U25kdGJFOXVSbkZ1ZWpoWVluQmxlVUZhYW1OTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk9EUlNPVFJzVlRWUmJYTmtPRzVDZG5OS2RYWXZRbWx2TURJMFZWRnNVMlZDVWxSYVIxRmtOblJRZUVoS0wySlpWQW92WkhCSldsZEdWM0JSUkVwR2NqUk1SR1V4VjJaQ01XTXhZVlJoZEVWR2JtNXBTMmd6TTIxME1rWmxZalp1YUU5cVZrSmxkR1Z0TTJOd2FUWmlZVnBIQ214dFNHc3ZTMjVCT1hWTldETlZaRUZGUkZoSWFUWXdOMkZTVFVGcGVYbEpRekpDU1Vsc05FY3pPVzFGUkhadVVVOUhTM050VEhoaFlYQlFSM0ZZWkhZS1NFMWxOVzR2UzNSUVdsTkdjRUphZEhwalNXaENkR1JhZDI5eFJGVTVOQzlOUzBsT2NXSTVia2RWTURJemFEZDNORzlZT0ZreU1UWTRRVkl3ZWt4SGRncE1ZbVJ0WmpJMFRuWXpWa0pyZUc1Q2JVVTViVU5zZW5WU1kxVlFURzlMYkdGdVl5OTBZekJ3VEdwcVNtNHJTMHBYY21RNE1tVnNkMDlsVHpKbFVtVklDbWRLVjBwS2VtcDBMMGhwSzJkRFZuQTFNMW8xYVZWVloyVTVhRmR3TDA5UllWSkhOQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMWViMTQ1MzAtNWFmNC00NDQ5LTgxMTktZjQ1NDNmMjExODRmLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB3N0Zpb045TzlKbHpuM21vQzJtdVl3bWx3dXU2OWlKTml2dHNxN3B2NXpTUmdseDhUYTBZa2tMNg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEZlazFXYjFoRVZFMTZUVlJGZDA1cVJUSk5ha1Y2VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMkpKQ2s5aWRXWnRaRU5oYkZsNk1YZ3lkSHB3YUdWS1IwMUJkRFZ4U1VsNGRtdzFOMVpIVlhGd2EyVmtlSE0zYkZBMFNIcExWVFJzT1ROM1dGZzNNeTlIYUZBS2RWUlROVE5UVUZOaE4zTk1PV3RHZUZCWGJsTmpabEZrTTJvMVJVODRNbGNyVkVSWWQzaFJjRFI1VTBzMFlXNDFXVnBsWW5GeFZWQmFVbTA1Y2l0blNBbzNjVGMxYzI1Q09GcG5RMmRJWTJkaGQyNVBWa3RHZUU4NVRITTFjVkZJYWtFME5tVlFZMVpCTW14VWMxTTBRMmhzVjFwT2JFTm9aRmM1Y1ZaVlZreDFDbFpYY0ZSeWNUWXdWRFJvZFM5aU5tWmxkMkZSVERSd2FGQnJSVkl3VDBWTFFWQlJTRUpGWW5sWFJUQnhSSFpJUmxacVozQktlRzFSV0Zwc0sxTjZjekVLYVd3eVNqQmFTVlpGY0VveGFYa3lWa1F5SzBKd1ZEbDBXSGgySzJNNVFtZHdlREpuVTFkSlRrdFdURmxqSzNaWFpqaDZaVVJpVEc1U1JFdEhTbUp6VHdwcFpraEpVMWdyTUhCblV5dDBNMnBPYkhJd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUGVHbDRWVkJCVEVOUUszVXlTVU1yU25wTWJtNVpRekZ1WjI1TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2NFcFRWM2RIWjI4clZsUXJUa0l5SzJVd1oxTnJUVE5sYldaM2VrUklRMjU1U1N0MGFsVm9URVkyUVdJeVpuRXhPUW95YjNWMU1VZzJTelJzUVVSNlFWcENUVEJZTlN0RFlUVlpjRmt2VTJGSVptdzNiWGRVYVdNemVrNWtRMUEwVW5KMFlpOXVkVlJvUldwWE5IbE5VR3AzQ2pNNFJVcG1VVXRRY1hsVGNGSlRNV0p2VGpGcFQxUnBObEZPVUVWNGVrMXNjMUp2WW1kT2RtWm9ZVnBJT0hoTlJIaDVjbE5XUkRkdmVVSkZXREpzVTFJS1RVODJZMkZsUzB4aVRteElWV1p4Yms5bE16VlVVQzlUY0cxSVkyVlhZak01Tkc1NGNHMUxSbTFLVTBOQ1VFeFVhakpOYlVnd1kwTXdXa1JqZW1NM1dncGliWEJVZEcxalZXcHlMelF5YVN0VU5VaFZkREpyYWxSRldtaDZabFJyTW1sQ0t6aDBiM0JqTUZkTlJrUlNjV1poVFRKM1pEbEpibGhTT1VJMk5YWk5DbU5ZZVRKVFRtUmhVVzQ1WlhoRWRGaE1NekkxY0hoWlJtdFRTVXhPY1ZSbEwyWm1hd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNGI5MTRiY2UtZjZlOC00MDQ5LWJiYzMtZmJhYWRlOGE2YTUyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB4N2xZNVRjV0hEbDhnbGljSTNNUXBiVnZXVUFXNGdkcmtpVGEzQ29pN3ZwWEZ5ejhoUDBPd285VA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2566"
+      - "2564"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:46 GMT
+      - Tue, 07 Nov 2023 16:21:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -401,7 +401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b8f0b9d-c01f-4a5a-b1ee-c597c2212d6c
+      - 03372729-0ae5-40a6-a85e-2689ae331448
     status: 200 OK
     code: 200
     duration: ""
@@ -412,19 +412,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/578ed20e-1dd8-4de6-8aa5-552261b9473f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8cdb7dd1-addc-4e11-8286-f31958aff852
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:43:38.885896Z","dhcp_enabled":true,"id":"578ed20e-1dd8-4de6-8aa5-552261b9473f","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:38.885896Z","id":"306fa64d-dde0-4dcc-96d5-519d98391c44","subnet":"172.16.24.0/22","updated_at":"2023-10-18T16:43:38.885896Z"},{"created_at":"2023-10-18T16:43:38.885896Z","id":"0a508f71-c9e0-439d-87b7-b8725789e8ad","subnet":"fd63:256c:45f7:2ea1::/64","updated_at":"2023-10-18T16:43:38.885896Z"}],"tags":[],"updated_at":"2023-10-18T16:43:38.885896Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:21:29.698650Z","dhcp_enabled":true,"id":"8cdb7dd1-addc-4e11-8286-f31958aff852","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:21:29.698650Z","id":"fa8518cb-34ee-44b7-9ebf-678ecb16cecb","subnet":"172.16.4.0/22","updated_at":"2023-11-07T16:21:29.698650Z"},{"created_at":"2023-11-07T16:21:29.698650Z","id":"52e73ae2-ea88-4993-a468-159f746f6b56","subnet":"fd63:256c:45f7:c8d9::/64","updated_at":"2023-11-07T16:21:29.698650Z"}],"tags":[],"updated_at":"2023-11-07T16:21:29.698650Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "710"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:46 GMT
+      - Tue, 07 Nov 2023 16:21:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -434,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e68d7e9-a670-488e-adc0-68974663400a
+      - e243f3c9-ed33-4000-bd58-69b394db11ad
     status: 200 OK
     code: 200
     duration: ""
@@ -445,19 +445,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1eb14530-5af4-4449-8119-f4543f21184f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1eb14530-5af4-4449-8119-f4543f21184f.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:43:40.198151Z","created_at":"2023-10-18T16:43:40.198151Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1eb14530-5af4-4449-8119-f4543f21184f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1eb14530-5af4-4449-8119-f4543f21184f","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"578ed20e-1dd8-4de6-8aa5-552261b9473f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-10-18T16:43:41.662Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-super-id","groups_claim":["k8s","admin"],"groups_prefix":"pouf","issuer_url":"https://accounts.google.com","required_claim":[],"username_claim":"mario","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:32.315038Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1559"
+      - "1516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:46 GMT
+      - Tue, 07 Nov 2023 16:21:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -467,7 +467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a00ad44-8b1e-4541-a3bf-557ececd9952
+      - cdf8b81d-107a-464c-a1bf-aeed6b504d14
     status: 200 OK
     code: 200
     duration: ""
@@ -478,19 +478,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1eb14530-5af4-4449-8119-f4543f21184f/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVeVRrUk5NRTFXYjFoRVZFMTZUVlJCZUU1NlJUSk9SRTB3VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVXRCQ2tzNVRFVkhLMDlVVTNVNWVUQm5RVkpZUmtGUE9XeFVXVXRxVUVOQ1JrWjRObTFYV1ZKeGFEQXpRVVp6WkhwTlRXOVBaWEpEVW1oRWIwUkpaU3RwYVRFS056STJPSFI1YVRKclMzZzNaSG9ySzNWeFltdDRWSE56WjNsNWQxUmtiazU2V1VzeFIwZFlPRkIyVlVob01HUnpObXhyZEdWYVQySkdabk50Tm1nMVpBcFFTa3hoUW1GTWNrNXlZbWgyZEROdmQyMXFZbmxsY1daTE1sWkhlbWw2UVdwUWFIWmhTR0ZsYmpBelRsQktlbkZhWjJSNVJURlVUbmhRZUhwdGNuUjFDbEJ1YTFaeWFXTnljMVZPTmpab1UwOUtRV054WTNSclpIWmFXR0ZoWTFSd2IwOVdWRzVHVEZGd1MxcG5Vamt3Um5FeFlTdFFZVk5IUkcxNVpHWXliRXNLVnpsUFVVSTJZVzlpWjA1WlpWWlplWGwwUldSaVlYQkZVMEZCWW1SRFVtTlVWMHgxYVhFNVNIUnlUVzAzU21relZtbHljbmxTZEhCWFpYRkVTa3BMZWdwamNrODBTMVJWWldsWWRtSjJVaTh4TUZSelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSGJDOVlhMlF3U25kdGJFOXVSbkZ1ZWpoWVluQmxlVUZhYW1OTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk9EUlNPVFJzVlRWUmJYTmtPRzVDZG5OS2RYWXZRbWx2TURJMFZWRnNVMlZDVWxSYVIxRmtOblJRZUVoS0wySlpWQW92WkhCSldsZEdWM0JSUkVwR2NqUk1SR1V4VjJaQ01XTXhZVlJoZEVWR2JtNXBTMmd6TTIxME1rWmxZalp1YUU5cVZrSmxkR1Z0TTJOd2FUWmlZVnBIQ214dFNHc3ZTMjVCT1hWTldETlZaRUZGUkZoSWFUWXdOMkZTVFVGcGVYbEpRekpDU1Vsc05FY3pPVzFGUkhadVVVOUhTM050VEhoaFlYQlFSM0ZZWkhZS1NFMWxOVzR2UzNSUVdsTkdjRUphZEhwalNXaENkR1JhZDI5eFJGVTVOQzlOUzBsT2NXSTVia2RWTURJemFEZDNORzlZT0ZreU1UWTRRVkl3ZWt4SGRncE1ZbVJ0WmpJMFRuWXpWa0pyZUc1Q2JVVTViVU5zZW5WU1kxVlFURzlMYkdGdVl5OTBZekJ3VEdwcVNtNHJTMHBYY21RNE1tVnNkMDlsVHpKbFVtVklDbWRLVjBwS2VtcDBMMGhwSzJkRFZuQTFNMW8xYVZWVloyVTVhRmR3TDA5UllWSkhOQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMWViMTQ1MzAtNWFmNC00NDQ5LTgxMTktZjQ1NDNmMjExODRmLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB3N0Zpb045TzlKbHpuM21vQzJtdVl3bWx3dXU2OWlKTml2dHNxN3B2NXpTUmdseDhUYTBZa2tMNg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEZlazFXYjFoRVZFMTZUVlJGZDA1cVJUSk5ha1Y2VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMkpKQ2s5aWRXWnRaRU5oYkZsNk1YZ3lkSHB3YUdWS1IwMUJkRFZ4U1VsNGRtdzFOMVpIVlhGd2EyVmtlSE0zYkZBMFNIcExWVFJzT1ROM1dGZzNNeTlIYUZBS2RWUlROVE5UVUZOaE4zTk1PV3RHZUZCWGJsTmpabEZrTTJvMVJVODRNbGNyVkVSWWQzaFJjRFI1VTBzMFlXNDFXVnBsWW5GeFZWQmFVbTA1Y2l0blNBbzNjVGMxYzI1Q09GcG5RMmRJWTJkaGQyNVBWa3RHZUU4NVRITTFjVkZJYWtFME5tVlFZMVpCTW14VWMxTTBRMmhzVjFwT2JFTm9aRmM1Y1ZaVlZreDFDbFpYY0ZSeWNUWXdWRFJvZFM5aU5tWmxkMkZSVERSd2FGQnJSVkl3VDBWTFFWQlJTRUpGWW5sWFJUQnhSSFpJUmxacVozQktlRzFSV0Zwc0sxTjZjekVLYVd3eVNqQmFTVlpGY0VveGFYa3lWa1F5SzBKd1ZEbDBXSGgySzJNNVFtZHdlREpuVTFkSlRrdFdURmxqSzNaWFpqaDZaVVJpVEc1U1JFdEhTbUp6VHdwcFpraEpVMWdyTUhCblV5dDBNMnBPYkhJd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUGVHbDRWVkJCVEVOUUszVXlTVU1yU25wTWJtNVpRekZ1WjI1TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2NFcFRWM2RIWjI4clZsUXJUa0l5SzJVd1oxTnJUVE5sYldaM2VrUklRMjU1U1N0MGFsVm9URVkyUVdJeVpuRXhPUW95YjNWMU1VZzJTelJzUVVSNlFWcENUVEJZTlN0RFlUVlpjRmt2VTJGSVptdzNiWGRVYVdNemVrNWtRMUEwVW5KMFlpOXVkVlJvUldwWE5IbE5VR3AzQ2pNNFJVcG1VVXRRY1hsVGNGSlRNV0p2VGpGcFQxUnBObEZPVUVWNGVrMXNjMUp2WW1kT2RtWm9ZVnBJT0hoTlJIaDVjbE5XUkRkdmVVSkZXREpzVTFJS1RVODJZMkZsUzB4aVRteElWV1p4Yms5bE16VlVVQzlUY0cxSVkyVlhZak01Tkc1NGNHMUxSbTFLVTBOQ1VFeFVhakpOYlVnd1kwTXdXa1JqZW1NM1dncGliWEJVZEcxalZXcHlMelF5YVN0VU5VaFZkREpyYWxSRldtaDZabFJyTW1sQ0t6aDBiM0JqTUZkTlJrUlNjV1poVFRKM1pEbEpibGhTT1VJMk5YWk5DbU5ZZVRKVFRtUmhVVzQ1WlhoRWRGaE1NekkxY0hoWlJtdFRTVXhPY1ZSbEwyWm1hd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNGI5MTRiY2UtZjZlOC00MDQ5LWJiYzMtZmJhYWRlOGE2YTUyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB4N2xZNVRjV0hEbDhnbGljSTNNUXBiVnZXVUFXNGdkcmtpVGEzQ29pN3ZwWEZ5ejhoUDBPd285VA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2566"
+      - "2564"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:46 GMT
+      - Tue, 07 Nov 2023 16:21:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -500,12 +500,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89ab8aa1-53bc-47e9-95c0-a66e39f15bd4
+      - 54c9907e-4578-4ea0-b871-a463a9739674
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":null,"description":null,"tags":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":null,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":null},"auto_upgrade":{"enable":null,"maintenance_window":null},"feature_gates":null,"admission_plugins":null,"open_id_connect_config":{"issuer_url":"https://gitlab.com","client_id":"my-even-more-awesome-id","username_claim":"luigi","username_prefix":"boo","groups_claim":[],"groups_prefix":"","required_claim":null},"apiserver_cert_sans":null}'
+    body: '{"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":null,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":null},"auto_upgrade":{"enable":null,"maintenance_window":null},"open_id_connect_config":{"issuer_url":"https://gitlab.com","client_id":"my-even-more-awesome-id","username_claim":"luigi","username_prefix":"boo","groups_claim":[],"groups_prefix":"","required_claim":null}}'
     form: {}
     headers:
       Content-Type:
@@ -513,19 +513,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1eb14530-5af4-4449-8119-f4543f21184f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1eb14530-5af4-4449-8119-f4543f21184f.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:43:40.198151Z","created_at":"2023-10-18T16:43:40.198151Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1eb14530-5af4-4449-8119-f4543f21184f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1eb14530-5af4-4449-8119-f4543f21184f","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"578ed20e-1dd8-4de6-8aa5-552261b9473f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-10-18T16:43:47.122321078Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:37.798781702Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1548"
+      - "1503"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:47 GMT
+      - Tue, 07 Nov 2023 16:21:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21f9dec4-56b4-4547-9c04-f6dd2cc84fa2
+      - af61d58e-675f-4975-bc5e-2d0c20372b1e
     status: 200 OK
     code: 200
     duration: ""
@@ -546,19 +546,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1eb14530-5af4-4449-8119-f4543f21184f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1eb14530-5af4-4449-8119-f4543f21184f.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:43:40.198151Z","created_at":"2023-10-18T16:43:40.198151Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1eb14530-5af4-4449-8119-f4543f21184f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1eb14530-5af4-4449-8119-f4543f21184f","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"578ed20e-1dd8-4de6-8aa5-552261b9473f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-10-18T16:43:47.122321Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:37.798782Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1545"
+      - "1500"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:47 GMT
+      - Tue, 07 Nov 2023 16:21:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad693453-8ebe-4f12-a0d9-e9f879df9925
+      - 7bd3e533-cb3c-4837-9f4d-0a79d24650fa
     status: 200 OK
     code: 200
     duration: ""
@@ -579,19 +579,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1eb14530-5af4-4449-8119-f4543f21184f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1eb14530-5af4-4449-8119-f4543f21184f.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:43:40.198151Z","created_at":"2023-10-18T16:43:40.198151Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1eb14530-5af4-4449-8119-f4543f21184f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1eb14530-5af4-4449-8119-f4543f21184f","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"578ed20e-1dd8-4de6-8aa5-552261b9473f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-10-18T16:43:48.308500Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:38.889272Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1550"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:52 GMT
+      - Tue, 07 Nov 2023 16:21:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 860abae0-fd99-4df5-b44b-c836c7a517bb
+      - 235ce950-c95c-4bd9-a33f-f7a18da60630
     status: 200 OK
     code: 200
     duration: ""
@@ -612,19 +612,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1eb14530-5af4-4449-8119-f4543f21184f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1eb14530-5af4-4449-8119-f4543f21184f.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:43:40.198151Z","created_at":"2023-10-18T16:43:40.198151Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1eb14530-5af4-4449-8119-f4543f21184f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1eb14530-5af4-4449-8119-f4543f21184f","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"578ed20e-1dd8-4de6-8aa5-552261b9473f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-10-18T16:43:48.308500Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:38.889272Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1550"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:52 GMT
+      - Tue, 07 Nov 2023 16:21:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f011e034-5912-4632-ba7d-733092878a60
+      - 87aac7b8-1017-4b4a-97bc-d0c1ac3084f0
     status: 200 OK
     code: 200
     duration: ""
@@ -645,19 +645,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1eb14530-5af4-4449-8119-f4543f21184f/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVeVRrUk5NRTFXYjFoRVZFMTZUVlJCZUU1NlJUSk9SRTB3VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVXRCQ2tzNVRFVkhLMDlVVTNVNWVUQm5RVkpZUmtGUE9XeFVXVXRxVUVOQ1JrWjRObTFYV1ZKeGFEQXpRVVp6WkhwTlRXOVBaWEpEVW1oRWIwUkpaU3RwYVRFS056STJPSFI1YVRKclMzZzNaSG9ySzNWeFltdDRWSE56WjNsNWQxUmtiazU2V1VzeFIwZFlPRkIyVlVob01HUnpObXhyZEdWYVQySkdabk50Tm1nMVpBcFFTa3hoUW1GTWNrNXlZbWgyZEROdmQyMXFZbmxsY1daTE1sWkhlbWw2UVdwUWFIWmhTR0ZsYmpBelRsQktlbkZhWjJSNVJURlVUbmhRZUhwdGNuUjFDbEJ1YTFaeWFXTnljMVZPTmpab1UwOUtRV054WTNSclpIWmFXR0ZoWTFSd2IwOVdWRzVHVEZGd1MxcG5Vamt3Um5FeFlTdFFZVk5IUkcxNVpHWXliRXNLVnpsUFVVSTJZVzlpWjA1WlpWWlplWGwwUldSaVlYQkZVMEZCWW1SRFVtTlVWMHgxYVhFNVNIUnlUVzAzU21relZtbHljbmxTZEhCWFpYRkVTa3BMZWdwamNrODBTMVJWWldsWWRtSjJVaTh4TUZSelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSGJDOVlhMlF3U25kdGJFOXVSbkZ1ZWpoWVluQmxlVUZhYW1OTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk9EUlNPVFJzVlRWUmJYTmtPRzVDZG5OS2RYWXZRbWx2TURJMFZWRnNVMlZDVWxSYVIxRmtOblJRZUVoS0wySlpWQW92WkhCSldsZEdWM0JSUkVwR2NqUk1SR1V4VjJaQ01XTXhZVlJoZEVWR2JtNXBTMmd6TTIxME1rWmxZalp1YUU5cVZrSmxkR1Z0TTJOd2FUWmlZVnBIQ214dFNHc3ZTMjVCT1hWTldETlZaRUZGUkZoSWFUWXdOMkZTVFVGcGVYbEpRekpDU1Vsc05FY3pPVzFGUkhadVVVOUhTM050VEhoaFlYQlFSM0ZZWkhZS1NFMWxOVzR2UzNSUVdsTkdjRUphZEhwalNXaENkR1JhZDI5eFJGVTVOQzlOUzBsT2NXSTVia2RWTURJemFEZDNORzlZT0ZreU1UWTRRVkl3ZWt4SGRncE1ZbVJ0WmpJMFRuWXpWa0pyZUc1Q2JVVTViVU5zZW5WU1kxVlFURzlMYkdGdVl5OTBZekJ3VEdwcVNtNHJTMHBYY21RNE1tVnNkMDlsVHpKbFVtVklDbWRLVjBwS2VtcDBMMGhwSzJkRFZuQTFNMW8xYVZWVloyVTVhRmR3TDA5UllWSkhOQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMWViMTQ1MzAtNWFmNC00NDQ5LTgxMTktZjQ1NDNmMjExODRmLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB3N0Zpb045TzlKbHpuM21vQzJtdVl3bWx3dXU2OWlKTml2dHNxN3B2NXpTUmdseDhUYTBZa2tMNg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEZlazFXYjFoRVZFMTZUVlJGZDA1cVJUSk5ha1Y2VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMkpKQ2s5aWRXWnRaRU5oYkZsNk1YZ3lkSHB3YUdWS1IwMUJkRFZ4U1VsNGRtdzFOMVpIVlhGd2EyVmtlSE0zYkZBMFNIcExWVFJzT1ROM1dGZzNNeTlIYUZBS2RWUlROVE5UVUZOaE4zTk1PV3RHZUZCWGJsTmpabEZrTTJvMVJVODRNbGNyVkVSWWQzaFJjRFI1VTBzMFlXNDFXVnBsWW5GeFZWQmFVbTA1Y2l0blNBbzNjVGMxYzI1Q09GcG5RMmRJWTJkaGQyNVBWa3RHZUU4NVRITTFjVkZJYWtFME5tVlFZMVpCTW14VWMxTTBRMmhzVjFwT2JFTm9aRmM1Y1ZaVlZreDFDbFpYY0ZSeWNUWXdWRFJvZFM5aU5tWmxkMkZSVERSd2FGQnJSVkl3VDBWTFFWQlJTRUpGWW5sWFJUQnhSSFpJUmxacVozQktlRzFSV0Zwc0sxTjZjekVLYVd3eVNqQmFTVlpGY0VveGFYa3lWa1F5SzBKd1ZEbDBXSGgySzJNNVFtZHdlREpuVTFkSlRrdFdURmxqSzNaWFpqaDZaVVJpVEc1U1JFdEhTbUp6VHdwcFpraEpVMWdyTUhCblV5dDBNMnBPYkhJd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUGVHbDRWVkJCVEVOUUszVXlTVU1yU25wTWJtNVpRekZ1WjI1TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2NFcFRWM2RIWjI4clZsUXJUa0l5SzJVd1oxTnJUVE5sYldaM2VrUklRMjU1U1N0MGFsVm9URVkyUVdJeVpuRXhPUW95YjNWMU1VZzJTelJzUVVSNlFWcENUVEJZTlN0RFlUVlpjRmt2VTJGSVptdzNiWGRVYVdNemVrNWtRMUEwVW5KMFlpOXVkVlJvUldwWE5IbE5VR3AzQ2pNNFJVcG1VVXRRY1hsVGNGSlRNV0p2VGpGcFQxUnBObEZPVUVWNGVrMXNjMUp2WW1kT2RtWm9ZVnBJT0hoTlJIaDVjbE5XUkRkdmVVSkZXREpzVTFJS1RVODJZMkZsUzB4aVRteElWV1p4Yms5bE16VlVVQzlUY0cxSVkyVlhZak01Tkc1NGNHMUxSbTFLVTBOQ1VFeFVhakpOYlVnd1kwTXdXa1JqZW1NM1dncGliWEJVZEcxalZXcHlMelF5YVN0VU5VaFZkREpyYWxSRldtaDZabFJyTW1sQ0t6aDBiM0JqTUZkTlJrUlNjV1poVFRKM1pEbEpibGhTT1VJMk5YWk5DbU5ZZVRKVFRtUmhVVzQ1WlhoRWRGaE1NekkxY0hoWlJtdFRTVXhPY1ZSbEwyWm1hd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNGI5MTRiY2UtZjZlOC00MDQ5LWJiYzMtZmJhYWRlOGE2YTUyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB4N2xZNVRjV0hEbDhnbGljSTNNUXBiVnZXVUFXNGdkcmtpVGEzQ29pN3ZwWEZ5ejhoUDBPd285VA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2566"
+      - "2564"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:52 GMT
+      - Tue, 07 Nov 2023 16:21:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e08cb850-7094-4c58-8ca7-cc2a9a10d2c9
+      - 7ca886c7-be28-4825-ae42-39da36d4e610
     status: 200 OK
     code: 200
     duration: ""
@@ -678,19 +678,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1eb14530-5af4-4449-8119-f4543f21184f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1eb14530-5af4-4449-8119-f4543f21184f.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:43:40.198151Z","created_at":"2023-10-18T16:43:40.198151Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1eb14530-5af4-4449-8119-f4543f21184f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1eb14530-5af4-4449-8119-f4543f21184f","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"578ed20e-1dd8-4de6-8aa5-552261b9473f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-10-18T16:43:48.308500Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:38.889272Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1550"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:52 GMT
+      - Tue, 07 Nov 2023 16:21:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c42681d6-d1cd-4a07-9996-6339538d677e
+      - 7b0b0888-4e71-4dab-a2c1-f2d25a332e6c
     status: 200 OK
     code: 200
     duration: ""
@@ -711,19 +711,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/578ed20e-1dd8-4de6-8aa5-552261b9473f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8cdb7dd1-addc-4e11-8286-f31958aff852
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:43:38.885896Z","dhcp_enabled":true,"id":"578ed20e-1dd8-4de6-8aa5-552261b9473f","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:38.885896Z","id":"306fa64d-dde0-4dcc-96d5-519d98391c44","subnet":"172.16.24.0/22","updated_at":"2023-10-18T16:43:38.885896Z"},{"created_at":"2023-10-18T16:43:38.885896Z","id":"0a508f71-c9e0-439d-87b7-b8725789e8ad","subnet":"fd63:256c:45f7:2ea1::/64","updated_at":"2023-10-18T16:43:38.885896Z"}],"tags":[],"updated_at":"2023-10-18T16:43:38.885896Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:21:29.698650Z","dhcp_enabled":true,"id":"8cdb7dd1-addc-4e11-8286-f31958aff852","name":"test-oidc","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:21:29.698650Z","id":"fa8518cb-34ee-44b7-9ebf-678ecb16cecb","subnet":"172.16.4.0/22","updated_at":"2023-11-07T16:21:29.698650Z"},{"created_at":"2023-11-07T16:21:29.698650Z","id":"52e73ae2-ea88-4993-a468-159f746f6b56","subnet":"fd63:256c:45f7:c8d9::/64","updated_at":"2023-11-07T16:21:29.698650Z"}],"tags":[],"updated_at":"2023-11-07T16:21:29.698650Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "710"
+      - "692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:52 GMT
+      - Tue, 07 Nov 2023 16:21:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea1e97e4-dfe1-4b47-9361-99971adfc5dc
+      - f29d9a37-132b-4064-a5ad-2166b7462aad
     status: 200 OK
     code: 200
     duration: ""
@@ -744,19 +744,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1eb14530-5af4-4449-8119-f4543f21184f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1eb14530-5af4-4449-8119-f4543f21184f.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:43:40.198151Z","created_at":"2023-10-18T16:43:40.198151Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1eb14530-5af4-4449-8119-f4543f21184f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1eb14530-5af4-4449-8119-f4543f21184f","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"578ed20e-1dd8-4de6-8aa5-552261b9473f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-10-18T16:43:48.308500Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:38.889272Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1550"
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:52 GMT
+      - Tue, 07 Nov 2023 16:21:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6b909fc-6303-4837-99f2-1335b6ec85c4
+      - 5a9ec5f0-b590-4849-ab91-407277c70082
     status: 200 OK
     code: 200
     duration: ""
@@ -777,19 +777,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1eb14530-5af4-4449-8119-f4543f21184f/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVeVRrUk5NRTFXYjFoRVZFMTZUVlJCZUU1NlJUSk9SRTB3VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVXRCQ2tzNVRFVkhLMDlVVTNVNWVUQm5RVkpZUmtGUE9XeFVXVXRxVUVOQ1JrWjRObTFYV1ZKeGFEQXpRVVp6WkhwTlRXOVBaWEpEVW1oRWIwUkpaU3RwYVRFS056STJPSFI1YVRKclMzZzNaSG9ySzNWeFltdDRWSE56WjNsNWQxUmtiazU2V1VzeFIwZFlPRkIyVlVob01HUnpObXhyZEdWYVQySkdabk50Tm1nMVpBcFFTa3hoUW1GTWNrNXlZbWgyZEROdmQyMXFZbmxsY1daTE1sWkhlbWw2UVdwUWFIWmhTR0ZsYmpBelRsQktlbkZhWjJSNVJURlVUbmhRZUhwdGNuUjFDbEJ1YTFaeWFXTnljMVZPTmpab1UwOUtRV054WTNSclpIWmFXR0ZoWTFSd2IwOVdWRzVHVEZGd1MxcG5Vamt3Um5FeFlTdFFZVk5IUkcxNVpHWXliRXNLVnpsUFVVSTJZVzlpWjA1WlpWWlplWGwwUldSaVlYQkZVMEZCWW1SRFVtTlVWMHgxYVhFNVNIUnlUVzAzU21relZtbHljbmxTZEhCWFpYRkVTa3BMZWdwamNrODBTMVJWWldsWWRtSjJVaTh4TUZSelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSGJDOVlhMlF3U25kdGJFOXVSbkZ1ZWpoWVluQmxlVUZhYW1OTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQk9EUlNPVFJzVlRWUmJYTmtPRzVDZG5OS2RYWXZRbWx2TURJMFZWRnNVMlZDVWxSYVIxRmtOblJRZUVoS0wySlpWQW92WkhCSldsZEdWM0JSUkVwR2NqUk1SR1V4VjJaQ01XTXhZVlJoZEVWR2JtNXBTMmd6TTIxME1rWmxZalp1YUU5cVZrSmxkR1Z0TTJOd2FUWmlZVnBIQ214dFNHc3ZTMjVCT1hWTldETlZaRUZGUkZoSWFUWXdOMkZTVFVGcGVYbEpRekpDU1Vsc05FY3pPVzFGUkhadVVVOUhTM050VEhoaFlYQlFSM0ZZWkhZS1NFMWxOVzR2UzNSUVdsTkdjRUphZEhwalNXaENkR1JhZDI5eFJGVTVOQzlOUzBsT2NXSTVia2RWTURJemFEZDNORzlZT0ZreU1UWTRRVkl3ZWt4SGRncE1ZbVJ0WmpJMFRuWXpWa0pyZUc1Q2JVVTViVU5zZW5WU1kxVlFURzlMYkdGdVl5OTBZekJ3VEdwcVNtNHJTMHBYY21RNE1tVnNkMDlsVHpKbFVtVklDbWRLVjBwS2VtcDBMMGhwSzJkRFZuQTFNMW8xYVZWVloyVTVhRmR3TDA5UllWSkhOQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMWViMTQ1MzAtNWFmNC00NDQ5LTgxMTktZjQ1NDNmMjExODRmLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB3N0Zpb045TzlKbHpuM21vQzJtdVl3bWx3dXU2OWlKTml2dHNxN3B2NXpTUmdseDhUYTBZa2tMNg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3Qtb2lkYyIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEZlazFXYjFoRVZFMTZUVlJGZDA1cVJUSk5ha1Y2VFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMkpKQ2s5aWRXWnRaRU5oYkZsNk1YZ3lkSHB3YUdWS1IwMUJkRFZ4U1VsNGRtdzFOMVpIVlhGd2EyVmtlSE0zYkZBMFNIcExWVFJzT1ROM1dGZzNNeTlIYUZBS2RWUlROVE5UVUZOaE4zTk1PV3RHZUZCWGJsTmpabEZrTTJvMVJVODRNbGNyVkVSWWQzaFJjRFI1VTBzMFlXNDFXVnBsWW5GeFZWQmFVbTA1Y2l0blNBbzNjVGMxYzI1Q09GcG5RMmRJWTJkaGQyNVBWa3RHZUU4NVRITTFjVkZJYWtFME5tVlFZMVpCTW14VWMxTTBRMmhzVjFwT2JFTm9aRmM1Y1ZaVlZreDFDbFpYY0ZSeWNUWXdWRFJvZFM5aU5tWmxkMkZSVERSd2FGQnJSVkl3VDBWTFFWQlJTRUpGWW5sWFJUQnhSSFpJUmxacVozQktlRzFSV0Zwc0sxTjZjekVLYVd3eVNqQmFTVlpGY0VveGFYa3lWa1F5SzBKd1ZEbDBXSGgySzJNNVFtZHdlREpuVTFkSlRrdFdURmxqSzNaWFpqaDZaVVJpVEc1U1JFdEhTbUp6VHdwcFpraEpVMWdyTUhCblV5dDBNMnBPYkhJd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUGVHbDRWVkJCVEVOUUszVXlTVU1yU25wTWJtNVpRekZ1WjI1TlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2NFcFRWM2RIWjI4clZsUXJUa0l5SzJVd1oxTnJUVE5sYldaM2VrUklRMjU1U1N0MGFsVm9URVkyUVdJeVpuRXhPUW95YjNWMU1VZzJTelJzUVVSNlFWcENUVEJZTlN0RFlUVlpjRmt2VTJGSVptdzNiWGRVYVdNemVrNWtRMUEwVW5KMFlpOXVkVlJvUldwWE5IbE5VR3AzQ2pNNFJVcG1VVXRRY1hsVGNGSlRNV0p2VGpGcFQxUnBObEZPVUVWNGVrMXNjMUp2WW1kT2RtWm9ZVnBJT0hoTlJIaDVjbE5XUkRkdmVVSkZXREpzVTFJS1RVODJZMkZsUzB4aVRteElWV1p4Yms5bE16VlVVQzlUY0cxSVkyVlhZak01Tkc1NGNHMUxSbTFLVTBOQ1VFeFVhakpOYlVnd1kwTXdXa1JqZW1NM1dncGliWEJVZEcxalZXcHlMelF5YVN0VU5VaFZkREpyYWxSRldtaDZabFJyTW1sQ0t6aDBiM0JqTUZkTlJrUlNjV1poVFRKM1pEbEpibGhTT1VJMk5YWk5DbU5ZZVRKVFRtUmhVVzQ1WlhoRWRGaE1NekkxY0hoWlJtdFRTVXhPY1ZSbEwyWm1hd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNGI5MTRiY2UtZjZlOC00MDQ5LWJiYzMtZmJhYWRlOGE2YTUyLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3Qtb2lkYwogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1vaWRjIgogICAgdXNlcjogdGVzdC1vaWRjLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1vaWRjCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1vaWRjLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB4N2xZNVRjV0hEbDhnbGljSTNNUXBiVnZXVUFXNGdkcmtpVGEzQ29pN3ZwWEZ5ejhoUDBPd285VA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2566"
+      - "2564"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:53 GMT
+      - Tue, 07 Nov 2023 16:21:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ed1810f-269c-4eb3-8d13-e3077b5518a5
+      - e0988a75-0903-4d2f-b592-cda0fccb7a5d
     status: 200 OK
     code: 200
     duration: ""
@@ -810,19 +810,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1eb14530-5af4-4449-8119-f4543f21184f?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1eb14530-5af4-4449-8119-f4543f21184f.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:43:40.198151Z","created_at":"2023-10-18T16:43:40.198151Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1eb14530-5af4-4449-8119-f4543f21184f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1eb14530-5af4-4449-8119-f4543f21184f","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"578ed20e-1dd8-4de6-8aa5-552261b9473f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-10-18T16:43:53.575656545Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:44.152962976Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1548"
+      - "1503"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:53 GMT
+      - Tue, 07 Nov 2023 16:21:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c42e5a03-a854-483d-85a3-be00f1b02a19
+      - e190eb33-88bb-4d81-9099-ea2f71f8785e
     status: 200 OK
     code: 200
     duration: ""
@@ -843,19 +843,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1eb14530-5af4-4449-8119-f4543f21184f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1eb14530-5af4-4449-8119-f4543f21184f.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:43:40.198151Z","created_at":"2023-10-18T16:43:40.198151Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1eb14530-5af4-4449-8119-f4543f21184f.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1eb14530-5af4-4449-8119-f4543f21184f","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"578ed20e-1dd8-4de6-8aa5-552261b9473f","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-10-18T16:43:53.575657Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:44.152963Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1545"
+      - "1500"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:53 GMT
+      - Tue, 07 Nov 2023 16:21:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e18ea20-488d-46d4-8e5a-14bc0ab956d8
+      - 19ffee05-beb6-487a-b10f-499ae44121bd
     status: 200 OK
     code: 200
     duration: ""
@@ -876,10 +876,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1eb14530-5af4-4449-8119-f4543f21184f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"1eb14530-5af4-4449-8119-f4543f21184f","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4b914bce-f6e8-4049-bbc3-fbaade8a6a52.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:21:30.709281Z","created_at":"2023-11-07T16:21:30.709281Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4b914bce-f6e8-4049-bbc3-fbaade8a6a52.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","ingress":"none","name":"test-oidc","open_id_connect_config":{"client_id":"my-even-more-awesome-id","groups_claim":[],"groups_prefix":"","issuer_url":"https://gitlab.com","required_claim":[],"username_claim":"luigi","username_prefix":"boo"},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","oidc-config"],"type":"kapsule","updated_at":"2023-11-07T16:21:44.152963Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1500"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:21:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3a874da6-be8a-41c7-a599-5b467a8bbff3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -888,7 +921,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:59 GMT
+      - Tue, 07 Nov 2023 16:21:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 171f5a10-1c23-48f7-b89a-c4bb93272598
+      - 230213d0-783b-4c1b-8616-871f54b6782e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -909,10 +942,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/578ed20e-1dd8-4de6-8aa5-552261b9473f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8cdb7dd1-addc-4e11-8286-f31958aff852
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"578ed20e-1dd8-4de6-8aa5-552261b9473f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"8cdb7dd1-addc-4e11-8286-f31958aff852","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -921,7 +954,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:59 GMT
+      - Tue, 07 Nov 2023 16:21:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7fe785e0-423b-489e-8864-92858cef33bc
+      - 8c5d658b-b7f2-4649-b940-efc0b184ff4e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -942,10 +975,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1eb14530-5af4-4449-8119-f4543f21184f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4b914bce-f6e8-4049-bbc3-fbaade8a6a52
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"1eb14530-5af4-4449-8119-f4543f21184f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"4b914bce-f6e8-4049-bbc3-fbaade8a6a52","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -954,7 +987,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:59 GMT
+      - Tue, 07 Nov 2023 16:21:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a269f47-caa7-477e-8178-e4a1e1be0b75
+      - 1f44d52e-7236-42a8-8fd9-0a7cafd13f16
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-basic.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-basic.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:41 GMT
+      - Tue, 07 Nov 2023 15:49:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,12 +34,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d724333-39a9-4c13-9b2f-a1ddb381335f
+      - 4877670d-8348-49e1-b0bc-f9fe59a7e304
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-minimal","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"test-pool-minimal","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-18T16:43:19.912799Z","dhcp_enabled":true,"id":"86352ce5-787c-449c-9998-79898166204d","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:19.912799Z","id":"e8dae137-1a4b-466e-835a-826dcf62fdd7","subnet":"172.16.40.0/22","updated_at":"2023-10-18T16:43:19.912799Z"},{"created_at":"2023-10-18T16:43:19.912799Z","id":"7ecbb54d-39e3-4c8a-b892-21165c91b24f","subnet":"fd63:256c:45f7:af6c::/64","updated_at":"2023-10-18T16:43:19.912799Z"}],"tags":[],"updated_at":"2023-10-18T16:43:19.912799Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T15:49:50.833519Z","dhcp_enabled":true,"id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","name":"test-pool-minimal","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.833519Z","id":"fb021b16-2494-457d-9d6c-2cf0028452b3","subnet":"172.16.20.0/22","updated_at":"2023-11-07T15:49:50.833519Z"},{"created_at":"2023-11-07T15:49:50.833519Z","id":"280feec4-d559-47b4-90f0-f9cf39fafe11","subnet":"fd5f:519c:6d46:1fd9::/64","updated_at":"2023-11-07T15:49:50.833519Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.833519Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "718"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:20 GMT
+      - Tue, 07 Nov 2023 15:49:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e7bf876-e32a-494e-90c3-d8bad8dad5ef
+      - c3bb2822-348c-4c2d-b1d2-ed6b610d6b0a
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/86352ce5-787c-449c-9998-79898166204d
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c0076356-a746-4ffa-ba2e-8731fd24cf1f
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:43:19.912799Z","dhcp_enabled":true,"id":"86352ce5-787c-449c-9998-79898166204d","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:19.912799Z","id":"e8dae137-1a4b-466e-835a-826dcf62fdd7","subnet":"172.16.40.0/22","updated_at":"2023-10-18T16:43:19.912799Z"},{"created_at":"2023-10-18T16:43:19.912799Z","id":"7ecbb54d-39e3-4c8a-b892-21165c91b24f","subnet":"fd63:256c:45f7:af6c::/64","updated_at":"2023-10-18T16:43:19.912799Z"}],"tags":[],"updated_at":"2023-10-18T16:43:19.912799Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T15:49:50.833519Z","dhcp_enabled":true,"id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","name":"test-pool-minimal","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.833519Z","id":"fb021b16-2494-457d-9d6c-2cf0028452b3","subnet":"172.16.20.0/22","updated_at":"2023-11-07T15:49:50.833519Z"},{"created_at":"2023-11-07T15:49:50.833519Z","id":"280feec4-d559-47b4-90f0-f9cf39fafe11","subnet":"fd5f:519c:6d46:1fd9::/64","updated_at":"2023-11-07T15:49:50.833519Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.833519Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "718"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:20 GMT
+      - Tue, 07 Nov 2023 15:49:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bd607bc-729c-4b97-8998-7c9a3ecb176a
+      - c16fed30-4ac3-473c-bb75-d9ea662920dd
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-minimal","description":"","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":"86352ce5-787c-449c-9998-79898166204d"}'
+    body: '{"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","type":"","name":"test-pool-minimal","description":"","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f"}'
     form: {}
     headers:
       Content-Type:
@@ -118,16 +118,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://422f3a0f-8672-47d0-ba43-e6f70fe573d3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:21.169294369Z","created_at":"2023-10-18T16:43:21.169294369Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.422f3a0f-8672-47d0-ba43-e6f70fe573d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"86352ce5-787c-449c-9998-79898166204d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:43:21.195949857Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503255Z","created_at":"2023-11-07T15:49:53.386503255Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:49:53.416457093Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1509"
+      - "1464"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:21 GMT
+      - Tue, 07 Nov 2023 15:49:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0447c4f7-2346-47c2-82f2-e66effad6000
+      - eb5d77e4-d80a-4efd-8e1d-211c77f4c082
     status: 200 OK
     code: 200
     duration: ""
@@ -148,19 +148,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://422f3a0f-8672-47d0-ba43-e6f70fe573d3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:21.169294Z","created_at":"2023-10-18T16:43:21.169294Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.422f3a0f-8672-47d0-ba43-e6f70fe573d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"86352ce5-787c-449c-9998-79898166204d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:43:21.195950Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:49:53.416457Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1500"
+      - "1455"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:21 GMT
+      - Tue, 07 Nov 2023 15:49:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a990f7f-1a15-4398-8bdf-0cf2e1114d52
+      - 69c83971-9ea9-4bab-a255-a8553988e9ba
     status: 200 OK
     code: 200
     duration: ""
@@ -181,19 +181,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://422f3a0f-8672-47d0-ba43-e6f70fe573d3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:21.169294Z","created_at":"2023-10-18T16:43:21.169294Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.422f3a0f-8672-47d0-ba43-e6f70fe573d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"86352ce5-787c-449c-9998-79898166204d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:43:24.648443Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:49:55.690516Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1505"
+      - "1460"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:26 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 116cdb12-186c-420c-bc70-e73235ec83c7
+      - 7f645a74-d840-4c21-9b88-85f87b5cea6a
     status: 200 OK
     code: 200
     duration: ""
@@ -214,19 +214,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://422f3a0f-8672-47d0-ba43-e6f70fe573d3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:21.169294Z","created_at":"2023-10-18T16:43:21.169294Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.422f3a0f-8672-47d0-ba43-e6f70fe573d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"86352ce5-787c-449c-9998-79898166204d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:43:24.648443Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:49:55.690516Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1505"
+      - "1460"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:26 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb2035f6-8421-4070-8426-25ac5182c11d
+      - 13c4a77e-7507-4d9d-a5a4-1d9cb640c392
     status: 200 OK
     code: 200
     duration: ""
@@ -247,19 +247,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VGtSTmVVMXNiMWhFVkUxNlRWUkJlRTU2UlRKT1JFMTVUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRYZzRDbmhMZVU4NGFIaFdaVVJGYTA0eWRtOUxjRlJzZDBoSlNrUXJiMlY0WjJaQllVUkNiV3B2YTBoSFZTdGxjekp5WkhWWE5qbEdiR3RWYWpaRlVGQjBiUzhLUm5sQ1NrUjBlR1JxWjFnelRsTlNVelppYVRGM1QwUnpSMnRwVEU1bloxcG9kRlIwVjFNM1RsaHZkeTl6VGpncmNUVXlkVWg2VURCcmNrbHdUMkZyT0FwalpscG5ORVo2VVhsMFpXOXJTbGMxTUd4eVlsZHROVW8wYzFaVEwwdGxibFI1T1UxM1NsRlRORU0yZW5oMlIweGtlakZUTjJGaFNXaHRLMHhNT1U5bkNtaDBMMGRNV1RGS1RVNXFPVXd3UXpaRVFuVTJiV2hoT0dOSGFVMUNSbUU1VFdWTWFrcE5Namt4V1ROU1lYQk1OR3hVUkhBekt6ZEVNemREUjA4MlJVZ0tRblJ5UVdaMmQxVnFkbXhLTVRKM2QySlZZbVZTTWtaaWJEaFlhMU5VUzFWRVQwdHRSbWhoVFRnNFZtSnpNamxOTTBGck1VeHNhMnBxUldKNVdHNUllQXBaWTJOMllqSXdaazlzVDBKRVpsaG9ORUV3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpDTVVab2RYSTVUVGhaTTJwa2MzbFVlbUp1ZDNGSlZHSjJSakpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDTkVneFdFbDNNVkZ4VG1oWGNtb3dZbGxZTm10NmVuSkpjMEZTYVVJdlpFTkliSEZGYzBkRkwyRktVVlJ6Y25CUlZncFNSWHB5VFVzNFZuUm9Za3huUzNwblQwRmFObkJYV1hWRmFuTkZTbnBoU0ZsdE1EbDNhRFZNTUZGUWQwTnVUaXRUU25FNE1uUmxkRU0wT0RoM2JGbFJDbGwwYlVscU5VZExOVW8zYWxocFUzWjNSa016YlVwTFVHMTVhSFpIU2tGV1lWRlNSMWR2WVVORVJIcG5VMjVOUTBwbWVYTTBTSHBFY0VGSWNHbHFWRmdLTUhSclNFcENVMk0wYlVWWlNXbEZiRTlTUVhSNEswdFRhMGhFYkRWSmNFVkxZM1ptWVRnMmFXTlRPR1JDU1dKSVMyaEVVV2htTnpsUE9ERTRWVTVWUndveWFqUmFSbTlsU2xBcmRHcE9XRnBITkhobWMyRnNSVXBMWWtSb1VYZEtZa2xWWTBONk5VaFFUREpHWms1amQzZ3lOREZ3ZGk5b1dpdEthR3hDV2prNUNubGtPVGg1V2xweFlsaFNWWEJIUm1VdlNrcHNXa2hHVWxOTVJrbDBhVXA2U2taNE1Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly80MjJmM2EwZi04NjcyLTQ3ZDAtYmE0My1lNmY3MGZlNTczZDMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBIVU1YeENkOFd0MnJRSnRvWmdqN3pVcUxSa2UwdHp6Vm9aT0Rvb3JUdURFcjltT2Zxc0NlMXU0Uw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNVdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUbFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyWmlDa0ZwV0ZaV2JXNUpORVIyZDFsUlJHWlFUR1JIY25GbFVqRXZUV05NUVdkeFowRm5WVmt5U0VwcGMyaE9Ubmt6ZUVSd1VtbzFPRGhqTTFSaWVUaE1MM01LY0V4RWNHbHJNWG96TWpOc05GcHFhRnBPVm1KRVRscHRRekpOTTJsV2JXZHplbXBMVEc1VFVrb3habTFvVW04ck5XZ3llRmRPUzNJeWRVUkRSM0JSVHdwT1JFOXlSVFpMWTNBMU55dGFVelZYTVc5VVRVYzBTVlZWTWpkSlVYRnJkVzFwUkVkRGNYbzJZMHBKUm1ac1NXWnNTMjlTWVZNM1dteEVabWR3U25scUNsZGtOMWhpTVZSWlQzUkZaemg0YkV0WFpXOVBlamM0V1ZodVVtbGlNVnBRUXpFNGNrWnVla3d4UkZZMlJIcGljaXR5T0hSQllVRnBUbXBsWXpKSFdWUUtXakpoVUdwSldUWjRRMlpHUVc1MlUySm1kVzV0TmtvcmMzRnlVMWN5VkZkSmRGbFZUaTlhUkdsRWJFaERkbVJQTWxCdVJFdHBZVlp6ZW5ST09XWXdRd295YkdWYVJXZ3hXVWcyWkZoUkwxSmFjbWR6UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpEYTJ0NFYyRlFVM2RHZVVwb0wzWXljVU14U1ZSdVpXRnpjV05OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCY1c5b1dYaHJUalpITUdSWVNFVTRRbUpNYkRCcmEzaGlkRUZKTVZsRmNYUlJNM0JrWVhOWkwyeDJWR1JrZGpobVFRbzJLMUJRT1VSdU5tWk9jWEp6YVVVeVYweDFVbXR1WXpRelkwcEdaWGRxV2xoRVlXRjJZV05YVlhnelJFa3hja0U0Y1dSeGMwNTBWV1ExVmtWRlVFZERDbkZyVkM5b05sTkNkM1pWTkZWd05TdERia2hFUW1rMWRYZGxaSGdyV1RoRlVFZ3pZMUo2UlN0QlRXRjJTbFJDUWtWaE0xQlFjVXhQUlhCaWJtMURhbGdLZEdjNE9UZHVUMFJKTDFoalpURTRWazF2VFcxU1VIWkxTSGhqY1dWV1MzSkdkbmcxU1VaNmVEQlFhV1ZJVjJaV2VqVkZlSEJNVm1sSFMxZ3dTalp6T0FvMVVsaFhOakZoVWxOT1pVTjRUVWhoTVZVMlRubE9heTlFYkdoNkwydG1hVVJZVDNWaFZtVnFPVzQ0WW1SR1JsRmxVak5VVVVaRmIwZFVibTVGYWs4ekNqbENMMUZ3VUdSTlUyb3plVTAxYWxoaE0xVmFZelV3T0U1UVVtTktkelo2ZFVsTU53b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGZlZjNkMC0yMzAwLTQ5NTYtYjMzYi1jZjk3NGVlMzBhMDEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpNFBUb3RWVzJ1bExqQVZuUWNDdXNJRDJLNml1Tmt3aHM2V24xQlNEdVFhYjhBdnNkeXBCMmZmTg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2630"
+      - "2628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:26 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2388ef4d-d82b-493f-9173-d14caf39a02a
+      - c1506371-4eea-420e-a819-b511cfa7aab9
     status: 200 OK
     code: 200
     duration: ""
@@ -280,19 +280,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://422f3a0f-8672-47d0-ba43-e6f70fe573d3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:21.169294Z","created_at":"2023-10-18T16:43:21.169294Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.422f3a0f-8672-47d0-ba43-e6f70fe573d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"86352ce5-787c-449c-9998-79898166204d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:43:24.648443Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:49:55.690516Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1505"
+      - "1460"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:26 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,12 +302,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22f61ce1-f704-4dad-b3bf-5a3a02746610
+      - 878b7a5f-423b-4200-9c09-06f677c50d55
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"kubelet_args":{},"upgrade_policy":null,"zone":"fr-par-1","root_volume_type":"default_volume_type","root_volume_size":null,"public_ip_disabled":false}'
+    body: '{"name":"test-pool-minimal","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","default"],"kubelet_args":{},"zone":"fr-par-1","root_volume_type":"default_volume_type","public_ip_disabled":false}'
     form: {}
     headers:
       Content-Type:
@@ -315,19 +315,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465424Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867037882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "681"
+      - "656"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:26 GMT
+      - Tue, 07 Nov 2023 15:49:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -337,7 +337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7f75786-33bc-45a5-93ca-d8468a012ec6
+      - 9c2e70df-26fc-46d6-9da7-b5d6d0eb0955
     status: 200 OK
     code: 200
     duration: ""
@@ -348,19 +348,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:26 GMT
+      - Tue, 07 Nov 2023 15:49:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -370,7 +370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2bbff2b-6866-4e33-b597-00c8faa10251
+      - 7ab2716c-1e83-4c05-bda5-297e139dc8e7
     status: 200 OK
     code: 200
     duration: ""
@@ -381,19 +381,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:31 GMT
+      - Tue, 07 Nov 2023 15:50:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -403,7 +403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68aca5be-5ed1-4244-ae44-e4647230f1ca
+      - 373c2f98-33e3-45ba-9470-7bc6e110a7a2
     status: 200 OK
     code: 200
     duration: ""
@@ -414,19 +414,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:36 GMT
+      - Tue, 07 Nov 2023 15:50:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -436,7 +436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83078717-eb30-439c-b540-c781402d8af8
+      - 95fef894-911a-4a26-b57b-d874f2828bd4
     status: 200 OK
     code: 200
     duration: ""
@@ -447,19 +447,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:42 GMT
+      - Tue, 07 Nov 2023 15:50:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -469,7 +469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6a43c14-cdf8-45f2-9096-ea715d02c7b7
+      - bf31eabc-d711-4d0d-be5a-5ab1a0b34a11
     status: 200 OK
     code: 200
     duration: ""
@@ -480,19 +480,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:47 GMT
+      - Tue, 07 Nov 2023 15:50:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5af619af-0b55-45b6-9d67-7d896843a7c7
+      - ced4d004-1225-4a18-b14c-f3cd1fb5ad99
     status: 200 OK
     code: 200
     duration: ""
@@ -513,19 +513,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:52 GMT
+      - Tue, 07 Nov 2023 15:50:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a72987ed-c286-4af3-b14c-461d1bce2ead
+      - 259c939c-552f-4282-b370-7951df0531ae
     status: 200 OK
     code: 200
     duration: ""
@@ -546,19 +546,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:57 GMT
+      - Tue, 07 Nov 2023 15:50:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb08b17d-4ef6-4db7-aa49-9d8aeb4f081e
+      - dbf52ae6-a615-4640-a857-a601b03aca84
     status: 200 OK
     code: 200
     duration: ""
@@ -579,19 +579,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:02 GMT
+      - Tue, 07 Nov 2023 15:50:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4db044f-a9a9-4763-b122-d3cdf2df7324
+      - 376d83f5-aca0-490c-98eb-fbc74b28b5ff
     status: 200 OK
     code: 200
     duration: ""
@@ -612,19 +612,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:07 GMT
+      - Tue, 07 Nov 2023 15:50:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa1d9707-1a66-4bfa-8336-c0ce2783511a
+      - 6f06cc32-db37-4f5e-8770-5eecbc9aca47
     status: 200 OK
     code: 200
     duration: ""
@@ -645,19 +645,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:12 GMT
+      - Tue, 07 Nov 2023 15:50:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7d3ec95-89d0-49cd-9567-3209d1afca6b
+      - f91aa7ad-18bb-4a6e-9745-71709780433a
     status: 200 OK
     code: 200
     duration: ""
@@ -678,19 +678,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:17 GMT
+      - Tue, 07 Nov 2023 15:50:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3bf22598-2880-447f-b3bf-1671e7d8fdff
+      - cece5114-293b-4bb9-aab6-a31bfe6d96e8
     status: 200 OK
     code: 200
     duration: ""
@@ -711,19 +711,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:22 GMT
+      - Tue, 07 Nov 2023 15:50:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f57391b5-793e-4e35-ba46-e4273cafc574
+      - 1a2a77a5-eaec-4cc7-b0aa-09378345bf21
     status: 200 OK
     code: 200
     duration: ""
@@ -744,19 +744,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:27 GMT
+      - Tue, 07 Nov 2023 15:51:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb96fd23-b62f-4988-a63e-f25aa2766e1a
+      - f2275e62-890a-4ff2-9f89-4956f4209881
     status: 200 OK
     code: 200
     duration: ""
@@ -777,19 +777,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:32 GMT
+      - Tue, 07 Nov 2023 15:51:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9232651-1e80-4ccc-b099-94e2b2a67eb9
+      - 0cdb51d6-0ea7-4486-a03c-a994f46aedc0
     status: 200 OK
     code: 200
     duration: ""
@@ -810,19 +810,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:37 GMT
+      - Tue, 07 Nov 2023 15:51:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0ff2eb3-ec20-4107-8669-a303c15fcade
+      - 77ec7840-53b7-4a3d-a511-ef033c02e2a9
     status: 200 OK
     code: 200
     duration: ""
@@ -843,19 +843,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:42 GMT
+      - Tue, 07 Nov 2023 15:51:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e0c7240-b083-4641-a548-7e16c1f93f71
+      - 4a9832df-4650-4818-8319-ed15fa46ee9a
     status: 200 OK
     code: 200
     duration: ""
@@ -876,19 +876,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:47 GMT
+      - Tue, 07 Nov 2023 15:51:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b572c801-380c-4652-b0d2-e2b63d85991d
+      - 01c1afcd-6280-4c8b-a22f-b86cc250d369
     status: 200 OK
     code: 200
     duration: ""
@@ -909,19 +909,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:52 GMT
+      - Tue, 07 Nov 2023 15:51:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98e3601b-60e1-4412-aa12-a6ec0b000656
+      - c711bb87-8560-4baf-bedb-b3784511c192
     status: 200 OK
     code: 200
     duration: ""
@@ -942,19 +942,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:57 GMT
+      - Tue, 07 Nov 2023 15:51:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab2e2b89-73c3-4366-ad20-1dad758b014d
+      - f05e4dd0-80e6-4943-b850-323722284050
     status: 200 OK
     code: 200
     duration: ""
@@ -975,19 +975,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:02 GMT
+      - Tue, 07 Nov 2023 15:51:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ffaa690-bad3-4c1a-97b9-f9ea3bb4a961
+      - ce091863-dc59-469a-a20b-f314e72b36da
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,19 +1008,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:07 GMT
+      - Tue, 07 Nov 2023 15:51:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b55d5f2-72d8-431d-a4bb-27967f959dbc
+      - 932a8be9-2115-4379-a8c1-363d53a03ab8
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,19 +1041,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:12 GMT
+      - Tue, 07 Nov 2023 15:51:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f117b0ef-ef43-4371-b247-5592bf825e71
+      - 60680f78-a1a1-41c0-8485-179cd1f7cb33
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,19 +1074,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:17 GMT
+      - Tue, 07 Nov 2023 15:51:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2960e96c-eb95-4e2e-ab0b-f9c80dce60b0
+      - ec06d766-f411-4f05-a6f5-a5bbc5da1dfb
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,19 +1107,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:23 GMT
+      - Tue, 07 Nov 2023 15:51:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1129,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9967280b-9b4d-4a04-b1cc-5b311fbf47af
+      - 2ab7cec3-7c32-4138-89fb-ef6ed8707d2e
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,19 +1140,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:28 GMT
+      - Tue, 07 Nov 2023 15:52:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 459a5318-08f7-46a3-8836-d91c34a55886
+      - 8930c57b-5695-4ed1-add7-b7f2e7e76482
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,19 +1173,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:33 GMT
+      - Tue, 07 Nov 2023 15:52:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bba4fe3-2a71-4565-9047-52823fd5f31a
+      - 49895f89-df11-4704-bf24-49702accfa09
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,19 +1206,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:38 GMT
+      - Tue, 07 Nov 2023 15:52:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6fa9aa1f-3ffb-4ebd-a2c5-4e6d2c04f244
+      - 2ca85257-b1f1-4ff6-8a8a-115e6fae1668
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,19 +1239,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:43 GMT
+      - Tue, 07 Nov 2023 15:52:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d028f3c0-8aa8-4441-abcf-97999dc29e42
+      - acdbde9a-04c2-44ce-bf20-0980c2d822d5
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,19 +1272,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:48 GMT
+      - Tue, 07 Nov 2023 15:52:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1106484e-6290-49e3-aa98-4345fe303d3a
+      - 7e95d85b-8d0c-47d5-a80e-65f7be2c20e8
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,19 +1305,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:53 GMT
+      - Tue, 07 Nov 2023 15:52:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ab01854-26de-4ce3-b5a7-5411f87e4996
+      - bfa4b34f-f483-43e7-b154-b0594eae7bb7
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,19 +1338,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:58 GMT
+      - Tue, 07 Nov 2023 15:52:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1360,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46cd6b68-2015-45e4-b30a-7ef90d43b2b7
+      - c05c2ca6-197e-464a-832c-17e79dd3e2a1
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,19 +1371,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:03 GMT
+      - Tue, 07 Nov 2023 15:52:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1393,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bde805bb-51c9-4163-8ec1-ed3b5481c970
+      - 069a75d6-3ee9-4ad5-bbd6-4589788b6543
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,19 +1404,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:08 GMT
+      - Tue, 07 Nov 2023 15:52:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1426,7 +1426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56ae732a-cb9f-48b6-9fc0-bc3552d90290
+      - d818dfe4-fc69-4dc2-8463-6809c7bbc713
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,19 +1437,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:13 GMT
+      - Tue, 07 Nov 2023 15:52:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1459,7 +1459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55b30172-f0f0-456e-b304-5e05551a0c19
+      - 67014b06-d366-4fde-8a01-588a693e5004
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,19 +1470,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:18 GMT
+      - Tue, 07 Nov 2023 15:52:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1492,7 +1492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d92d6c5-5fe9-4561-bc41-074152eb54f5
+      - 1c5902e1-f6e4-45ef-9633-d55cc00190c9
     status: 200 OK
     code: 200
     duration: ""
@@ -1503,19 +1503,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:23 GMT
+      - Tue, 07 Nov 2023 15:52:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b4013ce-2f6d-4b8c-9f23-954f91ed6166
+      - 08ad9460-0cbf-4840-8053-9b2be77c2bbf
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,19 +1536,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:28 GMT
+      - Tue, 07 Nov 2023 15:53:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1558,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8d232c7-6ed6-4420-b952-fcfd3424ef7f
+      - 9429696e-63b9-4689-bd0e-78f3563b7c28
     status: 200 OK
     code: 200
     duration: ""
@@ -1569,19 +1569,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:33 GMT
+      - Tue, 07 Nov 2023 15:53:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1591,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e04f4926-0fcf-4df2-8c7e-77a9366c63d1
+      - b80f0231-2d91-4cb6-95c6-41c9fa1ff51b
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,19 +1602,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:38 GMT
+      - Tue, 07 Nov 2023 15:53:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70eb6a94-7433-418d-8c8e-c05ed5fa96c2
+      - 16941dd1-8cff-4500-921c-b99485fffb9c
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,19 +1635,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:43 GMT
+      - Tue, 07 Nov 2023 15:53:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1657,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b2a619f-ab38-4cfa-8a27-808282321f84
+      - 39080ace-0b00-4b5a-a59f-4019ddf139b3
     status: 200 OK
     code: 200
     duration: ""
@@ -1668,19 +1668,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:48 GMT
+      - Tue, 07 Nov 2023 15:53:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1690,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f9b3b17-733f-458c-bc6b-b5dbb0ed91bf
+      - b40708a8-4be2-4aec-8346-519316a270a0
     status: 200 OK
     code: 200
     duration: ""
@@ -1701,19 +1701,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:54 GMT
+      - Tue, 07 Nov 2023 15:53:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1723,7 +1723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e475284f-dadd-4a83-a97a-d165d7182304
+      - 3f64046d-26d8-4553-9aed-f6fb110fc51b
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,19 +1734,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:59 GMT
+      - Tue, 07 Nov 2023 15:53:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1756,7 +1756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed7fe71c-b3dc-4b21-9b20-3482b367bf4b
+      - f8a17e41-c0c5-4d64-8d06-2fd8cdd1f938
     status: 200 OK
     code: 200
     duration: ""
@@ -1767,19 +1767,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:04 GMT
+      - Tue, 07 Nov 2023 15:53:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1789,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4013bb9-9a6b-424b-a6b6-5c5847757517
+      - 1a9ae899-8e2b-4489-a036-668b66e276f3
     status: 200 OK
     code: 200
     duration: ""
@@ -1800,19 +1800,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:09 GMT
+      - Tue, 07 Nov 2023 15:53:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1822,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80493207-223a-47d5-8dd2-aafeccf1a4a0
+      - 46ca0e21-9811-434b-b590-fd0794085f9a
     status: 200 OK
     code: 200
     duration: ""
@@ -1833,19 +1833,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:14 GMT
+      - Tue, 07 Nov 2023 15:53:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1855,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a67b3cfa-f196-4fc7-8829-9f8fe88d959b
+      - 83683237-e5ec-49da-870f-a7e7e8487223
     status: 200 OK
     code: 200
     duration: ""
@@ -1866,19 +1866,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:19 GMT
+      - Tue, 07 Nov 2023 15:53:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1888,7 +1888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 482dcb4a-5221-46fc-b3ab-f1535beb131f
+      - fbdcd247-8e85-43d9-9b70-7b50a6a971be
     status: 200 OK
     code: 200
     duration: ""
@@ -1899,19 +1899,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:24 GMT
+      - Tue, 07 Nov 2023 15:53:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1921,7 +1921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88092092-f8c0-4b3c-a5d5-cbbe36e91b22
+      - 21d80369-3a52-42a5-8f3b-9a80fd030062
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,19 +1932,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:29 GMT
+      - Tue, 07 Nov 2023 15:54:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1954,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c530ee3-3691-4982-b4a9-7457afed031c
+      - eb7b4ae9-f375-474c-95c4-5110664bf999
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,19 +1965,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:34 GMT
+      - Tue, 07 Nov 2023 15:54:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1987,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8256a5ec-620c-46fc-bb63-23b799126ff3
+      - 103b9c93-934e-466b-ba8f-3af7aead01bf
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,19 +1998,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:39 GMT
+      - Tue, 07 Nov 2023 15:54:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2020,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8468bcd4-f449-423f-a605-a540df7bb0a1
+      - e5dbc01c-e4e5-4b95-90c2-ffdcb670c639
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,19 +2031,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:49:58.867038Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:44 GMT
+      - Tue, 07 Nov 2023 15:54:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2053,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 361e5724-f131-48bb-9474-6e9d8b9b39c7
+      - c0f7065f-bd3f-469f-bd6f-db64aa15f0e7
     status: 200 OK
     code: 200
     duration: ""
@@ -2064,19 +2064,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:54:22.757519Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "651"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:49 GMT
+      - Tue, 07 Nov 2023 15:54:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2086,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d33cbac-24f4-4daa-b34e-e4a1e527cbfe
+      - e86774cb-7d29-4d32-8f19-ac9861e18b22
     status: 200 OK
     code: 200
     duration: ""
@@ -2097,19 +2097,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.749824Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "678"
+      - "1452"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:54 GMT
+      - Tue, 07 Nov 2023 15:54:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2119,7 +2119,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b57e1e0-9c9e-4c2a-8d12-e7b2083eb928
+      - 803e7a9f-519c-4ebb-a688-4d8366ffa600
     status: 200 OK
     code: 200
     duration: ""
@@ -2130,19 +2130,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:54:22.757519Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "651"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:59 GMT
+      - Tue, 07 Nov 2023 15:54:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2152,7 +2152,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8e5ebf3-4cd4-4cda-a2f3-b1ad9cc8f998
+      - 9ab2e99d-4d51-49a6-9098-133bf7f8c06b
     status: 200 OK
     code: 200
     duration: ""
@@ -2163,19 +2163,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/nodes?order_by=created_at_asc&page=1&pool_id=0149b1d8-63d9-4735-8fa6-3256b5a76ddc&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:47.022178Z","error_message":null,"id":"158fc3fe-d8bd-476d-8fc5-64d84224df41","name":"scw-test-pool-minimal-test-pool-minimal-158fc3","pool_id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","provider_id":"scaleway://instance/fr-par-1/44de6ba8-c06f-4dec-9cb3-da3090369984","public_ip_v4":"51.15.132.168","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:22.740213Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "678"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:48:04 GMT
+      - Tue, 07 Nov 2023 15:54:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2185,7 +2185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c206e65a-683f-49dc-a337-bd3995adf294
+      - a3536b9c-87b0-4205-bafc-4761d42d4415
     status: 200 OK
     code: 200
     duration: ""
@@ -2196,19 +2196,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.749824Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "678"
+      - "1452"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:48:09 GMT
+      - Tue, 07 Nov 2023 15:54:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2218,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4b60799-af24-4942-94f0-36b5ee7fe4d8
+      - 2e073309-5e13-4d8e-8a54-53e443dfee65
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,19 +2229,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:54:22.757519Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "651"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:48:14 GMT
+      - Tue, 07 Nov 2023 15:54:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2251,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e02d0f72-975d-4d4a-9e5d-3507193dc50d
+      - 5ba1b714-12c1-4b39-9e66-e72a0ee60a45
     status: 200 OK
     code: 200
     duration: ""
@@ -2262,19 +2262,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c0076356-a746-4ffa-ba2e-8731fd24cf1f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-07T15:49:50.833519Z","dhcp_enabled":true,"id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","name":"test-pool-minimal","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.833519Z","id":"fb021b16-2494-457d-9d6c-2cf0028452b3","subnet":"172.16.20.0/22","updated_at":"2023-11-07T15:49:50.833519Z"},{"created_at":"2023-11-07T15:49:50.833519Z","id":"280feec4-d559-47b4-90f0-f9cf39fafe11","subnet":"fd5f:519c:6d46:1fd9::/64","updated_at":"2023-11-07T15:49:50.833519Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.833519Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "678"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:48:19 GMT
+      - Tue, 07 Nov 2023 15:54:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2284,7 +2284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85588d19-8c9e-4021-ad90-a0ae15b9309e
+      - 3c4ae48d-b624-4931-b7ba-cff9ac6cf185
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,19 +2295,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.749824Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "678"
+      - "1452"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:48:24 GMT
+      - Tue, 07 Nov 2023 15:54:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2317,7 +2317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a027e90-132b-46fb-9bcc-6a2cd81a8092
+      - f1acdd6c-7780-4363-bc18-673c1ca13a1f
     status: 200 OK
     code: 200
     duration: ""
@@ -2328,19 +2328,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNVdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUbFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyWmlDa0ZwV0ZaV2JXNUpORVIyZDFsUlJHWlFUR1JIY25GbFVqRXZUV05NUVdkeFowRm5WVmt5U0VwcGMyaE9Ubmt6ZUVSd1VtbzFPRGhqTTFSaWVUaE1MM01LY0V4RWNHbHJNWG96TWpOc05GcHFhRnBPVm1KRVRscHRRekpOTTJsV2JXZHplbXBMVEc1VFVrb3habTFvVW04ck5XZ3llRmRPUzNJeWRVUkRSM0JSVHdwT1JFOXlSVFpMWTNBMU55dGFVelZYTVc5VVRVYzBTVlZWTWpkSlVYRnJkVzFwUkVkRGNYbzJZMHBKUm1ac1NXWnNTMjlTWVZNM1dteEVabWR3U25scUNsZGtOMWhpTVZSWlQzUkZaemg0YkV0WFpXOVBlamM0V1ZodVVtbGlNVnBRUXpFNGNrWnVla3d4UkZZMlJIcGljaXR5T0hSQllVRnBUbXBsWXpKSFdWUUtXakpoVUdwSldUWjRRMlpHUVc1MlUySm1kVzV0TmtvcmMzRnlVMWN5VkZkSmRGbFZUaTlhUkdsRWJFaERkbVJQTWxCdVJFdHBZVlp6ZW5ST09XWXdRd295YkdWYVJXZ3hXVWcyWkZoUkwxSmFjbWR6UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpEYTJ0NFYyRlFVM2RHZVVwb0wzWXljVU14U1ZSdVpXRnpjV05OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCY1c5b1dYaHJUalpITUdSWVNFVTRRbUpNYkRCcmEzaGlkRUZKTVZsRmNYUlJNM0JrWVhOWkwyeDJWR1JrZGpobVFRbzJLMUJRT1VSdU5tWk9jWEp6YVVVeVYweDFVbXR1WXpRelkwcEdaWGRxV2xoRVlXRjJZV05YVlhnelJFa3hja0U0Y1dSeGMwNTBWV1ExVmtWRlVFZERDbkZyVkM5b05sTkNkM1pWTkZWd05TdERia2hFUW1rMWRYZGxaSGdyV1RoRlVFZ3pZMUo2UlN0QlRXRjJTbFJDUWtWaE0xQlFjVXhQUlhCaWJtMURhbGdLZEdjNE9UZHVUMFJKTDFoalpURTRWazF2VFcxU1VIWkxTSGhqY1dWV1MzSkdkbmcxU1VaNmVEQlFhV1ZJVjJaV2VqVkZlSEJNVm1sSFMxZ3dTalp6T0FvMVVsaFhOakZoVWxOT1pVTjRUVWhoTVZVMlRubE9heTlFYkdoNkwydG1hVVJZVDNWaFZtVnFPVzQ0WW1SR1JsRmxVak5VVVVaRmIwZFVibTVGYWs4ekNqbENMMUZ3VUdSTlUyb3plVTAxYWxoaE0xVmFZelV3T0U1UVVtTktkelo2ZFVsTU53b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGZlZjNkMC0yMzAwLTQ5NTYtYjMzYi1jZjk3NGVlMzBhMDEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpNFBUb3RWVzJ1bExqQVZuUWNDdXNJRDJLNml1Tmt3aHM2V24xQlNEdVFhYjhBdnNkeXBCMmZmTg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "678"
+      - "2628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:48:29 GMT
+      - Tue, 07 Nov 2023 15:54:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2350,7 +2350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03bc2119-9722-4603-90a2-43da893ccf1b
+      - b7af329a-b907-43bc-9ca4-f7c63c9f97a5
     status: 200 OK
     code: 200
     duration: ""
@@ -2361,19 +2361,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:54:22.757519Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "651"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:48:35 GMT
+      - Tue, 07 Nov 2023 15:54:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2383,7 +2383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 594ccba7-7aaf-408b-b804-a17b835bfdb0
+      - 34c72fb4-e0a9-4b8a-ab02-8994db0dff8e
     status: 200 OK
     code: 200
     duration: ""
@@ -2394,19 +2394,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/nodes?order_by=created_at_asc&page=1&pool_id=0149b1d8-63d9-4735-8fa6-3256b5a76ddc&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:47.022178Z","error_message":null,"id":"158fc3fe-d8bd-476d-8fc5-64d84224df41","name":"scw-test-pool-minimal-test-pool-minimal-158fc3","pool_id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","provider_id":"scaleway://instance/fr-par-1/44de6ba8-c06f-4dec-9cb3-da3090369984","public_ip_v4":"51.15.132.168","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:22.740213Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "678"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:48:40 GMT
+      - Tue, 07 Nov 2023 15:54:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2416,7 +2416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f64366a-1bd9-4dcd-90bc-8d2c7d319c64
+      - 1ad1b5c4-fb78-4fc7-8015-20ad21c6e5d6
     status: 200 OK
     code: 200
     duration: ""
@@ -2427,19 +2427,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c0076356-a746-4ffa-ba2e-8731fd24cf1f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-07T15:49:50.833519Z","dhcp_enabled":true,"id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","name":"test-pool-minimal","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.833519Z","id":"fb021b16-2494-457d-9d6c-2cf0028452b3","subnet":"172.16.20.0/22","updated_at":"2023-11-07T15:49:50.833519Z"},{"created_at":"2023-11-07T15:49:50.833519Z","id":"280feec4-d559-47b4-90f0-f9cf39fafe11","subnet":"fd5f:519c:6d46:1fd9::/64","updated_at":"2023-11-07T15:49:50.833519Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.833519Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "678"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:48:45 GMT
+      - Tue, 07 Nov 2023 15:54:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2449,7 +2449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8e4a43a-7204-4129-903c-1528cd4c5f9e
+      - fae1db4b-93bb-4aee-86f1-6f0e0a0ef8ce
     status: 200 OK
     code: 200
     duration: ""
@@ -2460,19 +2460,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.749824Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "678"
+      - "1452"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:48:50 GMT
+      - Tue, 07 Nov 2023 15:54:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2482,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a185aa5e-0f90-4728-babf-2db8367abeeb
+      - 77eb6e47-c9dc-42c7-9f36-a7c5e517047b
     status: 200 OK
     code: 200
     duration: ""
@@ -2493,19 +2493,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNVdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUbFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyWmlDa0ZwV0ZaV2JXNUpORVIyZDFsUlJHWlFUR1JIY25GbFVqRXZUV05NUVdkeFowRm5WVmt5U0VwcGMyaE9Ubmt6ZUVSd1VtbzFPRGhqTTFSaWVUaE1MM01LY0V4RWNHbHJNWG96TWpOc05GcHFhRnBPVm1KRVRscHRRekpOTTJsV2JXZHplbXBMVEc1VFVrb3habTFvVW04ck5XZ3llRmRPUzNJeWRVUkRSM0JSVHdwT1JFOXlSVFpMWTNBMU55dGFVelZYTVc5VVRVYzBTVlZWTWpkSlVYRnJkVzFwUkVkRGNYbzJZMHBKUm1ac1NXWnNTMjlTWVZNM1dteEVabWR3U25scUNsZGtOMWhpTVZSWlQzUkZaemg0YkV0WFpXOVBlamM0V1ZodVVtbGlNVnBRUXpFNGNrWnVla3d4UkZZMlJIcGljaXR5T0hSQllVRnBUbXBsWXpKSFdWUUtXakpoVUdwSldUWjRRMlpHUVc1MlUySm1kVzV0TmtvcmMzRnlVMWN5VkZkSmRGbFZUaTlhUkdsRWJFaERkbVJQTWxCdVJFdHBZVlp6ZW5ST09XWXdRd295YkdWYVJXZ3hXVWcyWkZoUkwxSmFjbWR6UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpEYTJ0NFYyRlFVM2RHZVVwb0wzWXljVU14U1ZSdVpXRnpjV05OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCY1c5b1dYaHJUalpITUdSWVNFVTRRbUpNYkRCcmEzaGlkRUZKTVZsRmNYUlJNM0JrWVhOWkwyeDJWR1JrZGpobVFRbzJLMUJRT1VSdU5tWk9jWEp6YVVVeVYweDFVbXR1WXpRelkwcEdaWGRxV2xoRVlXRjJZV05YVlhnelJFa3hja0U0Y1dSeGMwNTBWV1ExVmtWRlVFZERDbkZyVkM5b05sTkNkM1pWTkZWd05TdERia2hFUW1rMWRYZGxaSGdyV1RoRlVFZ3pZMUo2UlN0QlRXRjJTbFJDUWtWaE0xQlFjVXhQUlhCaWJtMURhbGdLZEdjNE9UZHVUMFJKTDFoalpURTRWazF2VFcxU1VIWkxTSGhqY1dWV1MzSkdkbmcxU1VaNmVEQlFhV1ZJVjJaV2VqVkZlSEJNVm1sSFMxZ3dTalp6T0FvMVVsaFhOakZoVWxOT1pVTjRUVWhoTVZVMlRubE9heTlFYkdoNkwydG1hVVJZVDNWaFZtVnFPVzQ0WW1SR1JsRmxVak5VVVVaRmIwZFVibTVGYWs4ekNqbENMMUZ3VUdSTlUyb3plVTAxYWxoaE0xVmFZelV3T0U1UVVtTktkelo2ZFVsTU53b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGZlZjNkMC0yMzAwLTQ5NTYtYjMzYi1jZjk3NGVlMzBhMDEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpNFBUb3RWVzJ1bExqQVZuUWNDdXNJRDJLNml1Tmt3aHM2V24xQlNEdVFhYjhBdnNkeXBCMmZmTg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "678"
+      - "2628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:48:55 GMT
+      - Tue, 07 Nov 2023 15:54:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2515,7 +2515,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 397f52c7-6cb1-48db-9acc-5dbd2887a98f
+      - 592f7afe-e09e-41d3-8176-3108bf06580d
     status: 200 OK
     code: 200
     duration: ""
@@ -2526,19 +2526,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:54:22.757519Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "678"
+      - "651"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:00 GMT
+      - Tue, 07 Nov 2023 15:54:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2548,7 +2548,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f482cd90-c80d-4f0d-a8a6-de0657049f5d
+      - 32dd99ff-2e63-4dc1-8e59-3193b637982b
     status: 200 OK
     code: 200
     duration: ""
@@ -2559,19 +2559,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/nodes?order_by=created_at_asc&page=1&pool_id=0149b1d8-63d9-4735-8fa6-3256b5a76ddc&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:47.022178Z","error_message":null,"id":"158fc3fe-d8bd-476d-8fc5-64d84224df41","name":"scw-test-pool-minimal-test-pool-minimal-158fc3","pool_id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","provider_id":"scaleway://instance/fr-par-1/44de6ba8-c06f-4dec-9cb3-da3090369984","public_ip_v4":"51.15.132.168","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:22.740213Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "678"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:05 GMT
+      - Tue, 07 Nov 2023 15:54:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2581,7 +2581,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d120853-6d5d-4321-a81c-a09828ea2cde
+      - b8320043-f8d5-4c36-8658-83bc3387ab99
     status: 200 OK
     code: 200
     duration: ""
@@ -2592,19 +2592,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.749824Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "678"
+      - "1452"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:10 GMT
+      - Tue, 07 Nov 2023 15:54:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2614,1035 +2614,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c54eb0ee-7fbc-4da8-879f-0a44558da85f
+      - 8e1cd056-38df-423d-8623-0541763d9d67
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "678"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1c32ff57-f872-4cde-9ea4-a5e8d8d1c882
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "678"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6447b7f8-7f16-424a-90d1-f2347d669f45
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "678"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d4ee6d74-e0ea-4288-9a65-24d9f535f1a2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "678"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:30 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1ec368f2-8dd0-493e-b12b-300e7066ddd4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "678"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2d99b8db-699a-40bb-b9fa-23becd168d7c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "678"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8cb536c4-952e-464d-aeea-278c5669b77c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "678"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 414df701-d652-4652-9ebe-198482e51847
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "678"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f813a661-ac6c-4d64-a97f-22bd325fad4e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "678"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - be8a8e90-4fec-41b5-888a-343e5824c174
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "678"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:50:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 403d8c2b-6422-4f0d-b7fe-0a8d24adc291
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "678"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:50:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5d2df25c-7459-499a-bc7b-4e9ba01a3f64
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "678"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:50:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 250cbdc3-1b3c-4e8b-8173-d792fc45e068
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "678"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:50:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b165c289-1201-4130-89ec-b991aafefd61
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:43:26.647465Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "678"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:50:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 75599431-c7e4-4e7e-987f-5dedbbcf1e14
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:50:25.595417Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "676"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:50:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1d05a91a-d000-4d56-a9c4-f0cd7362f3d9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://422f3a0f-8672-47d0-ba43-e6f70fe573d3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:21.169294Z","created_at":"2023-10-18T16:43:21.169294Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.422f3a0f-8672-47d0-ba43-e6f70fe573d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"86352ce5-787c-449c-9998-79898166204d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:45:13.613947Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1497"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:50:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7cd0e3e7-68e0-4000-9629-00875dadda3a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:50:25.595417Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "676"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:50:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c9fbf4aa-f70e-451d-be07-90abb632766c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3/nodes?order_by=created_at_asc&page=1&pool_id=e903ea26-fed8-4d2e-83ac-80da5478e6f6&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:45:22.864846Z","error_message":null,"id":"763cccf3-28bc-4a71-bf3f-50743fa64646","name":"scw-test-pool-minimal-test-pool-minimal-763ccc","pool_id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","provider_id":"scaleway://instance/fr-par-1/c6df0307-f00a-4a58-89b5-7d39cfeff63b","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:50:25.561389Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "659"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:50:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 09a405b5-f509-4c22-bbe5-cca17bac5a87
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://422f3a0f-8672-47d0-ba43-e6f70fe573d3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:21.169294Z","created_at":"2023-10-18T16:43:21.169294Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.422f3a0f-8672-47d0-ba43-e6f70fe573d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"86352ce5-787c-449c-9998-79898166204d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:45:13.613947Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1497"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:50:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 99d790cb-a29b-49b3-9506-77fcada0242c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:50:25.595417Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "676"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:50:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7bd9c4b7-f1e3-48e2-b62f-ae31abd11de8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/86352ce5-787c-449c-9998-79898166204d
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-18T16:43:19.912799Z","dhcp_enabled":true,"id":"86352ce5-787c-449c-9998-79898166204d","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:19.912799Z","id":"e8dae137-1a4b-466e-835a-826dcf62fdd7","subnet":"172.16.40.0/22","updated_at":"2023-10-18T16:43:19.912799Z"},{"created_at":"2023-10-18T16:43:19.912799Z","id":"7ecbb54d-39e3-4c8a-b892-21165c91b24f","subnet":"fd63:256c:45f7:af6c::/64","updated_at":"2023-10-18T16:43:19.912799Z"}],"tags":[],"updated_at":"2023-10-18T16:43:19.912799Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "718"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:50:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f9a54dbc-4b67-4322-8ec1-ff658aec85a8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://422f3a0f-8672-47d0-ba43-e6f70fe573d3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:21.169294Z","created_at":"2023-10-18T16:43:21.169294Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.422f3a0f-8672-47d0-ba43-e6f70fe573d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"86352ce5-787c-449c-9998-79898166204d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:45:13.613947Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1497"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:50:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7208fc8c-5a45-419c-bf26-be61d1974682
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VGtSTmVVMXNiMWhFVkUxNlRWUkJlRTU2UlRKT1JFMTVUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRYZzRDbmhMZVU4NGFIaFdaVVJGYTA0eWRtOUxjRlJzZDBoSlNrUXJiMlY0WjJaQllVUkNiV3B2YTBoSFZTdGxjekp5WkhWWE5qbEdiR3RWYWpaRlVGQjBiUzhLUm5sQ1NrUjBlR1JxWjFnelRsTlNVelppYVRGM1QwUnpSMnRwVEU1bloxcG9kRlIwVjFNM1RsaHZkeTl6VGpncmNUVXlkVWg2VURCcmNrbHdUMkZyT0FwalpscG5ORVo2VVhsMFpXOXJTbGMxTUd4eVlsZHROVW8wYzFaVEwwdGxibFI1T1UxM1NsRlRORU0yZW5oMlIweGtlakZUTjJGaFNXaHRLMHhNT1U5bkNtaDBMMGRNV1RGS1RVNXFPVXd3UXpaRVFuVTJiV2hoT0dOSGFVMUNSbUU1VFdWTWFrcE5Namt4V1ROU1lYQk1OR3hVUkhBekt6ZEVNemREUjA4MlJVZ0tRblJ5UVdaMmQxVnFkbXhLTVRKM2QySlZZbVZTTWtaaWJEaFlhMU5VUzFWRVQwdHRSbWhoVFRnNFZtSnpNamxOTTBGck1VeHNhMnBxUldKNVdHNUllQXBaWTJOMllqSXdaazlzVDBKRVpsaG9ORUV3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpDTVVab2RYSTVUVGhaTTJwa2MzbFVlbUp1ZDNGSlZHSjJSakpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDTkVneFdFbDNNVkZ4VG1oWGNtb3dZbGxZTm10NmVuSkpjMEZTYVVJdlpFTkliSEZGYzBkRkwyRktVVlJ6Y25CUlZncFNSWHB5VFVzNFZuUm9Za3huUzNwblQwRmFObkJYV1hWRmFuTkZTbnBoU0ZsdE1EbDNhRFZNTUZGUWQwTnVUaXRUU25FNE1uUmxkRU0wT0RoM2JGbFJDbGwwYlVscU5VZExOVW8zYWxocFUzWjNSa016YlVwTFVHMTVhSFpIU2tGV1lWRlNSMWR2WVVORVJIcG5VMjVOUTBwbWVYTTBTSHBFY0VGSWNHbHFWRmdLTUhSclNFcENVMk0wYlVWWlNXbEZiRTlTUVhSNEswdFRhMGhFYkRWSmNFVkxZM1ptWVRnMmFXTlRPR1JDU1dKSVMyaEVVV2htTnpsUE9ERTRWVTVWUndveWFqUmFSbTlsU2xBcmRHcE9XRnBITkhobWMyRnNSVXBMWWtSb1VYZEtZa2xWWTBONk5VaFFUREpHWms1amQzZ3lOREZ3ZGk5b1dpdEthR3hDV2prNUNubGtPVGg1V2xweFlsaFNWWEJIUm1VdlNrcHNXa2hHVWxOTVJrbDBhVXA2U2taNE1Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly80MjJmM2EwZi04NjcyLTQ3ZDAtYmE0My1lNmY3MGZlNTczZDMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBIVU1YeENkOFd0MnJRSnRvWmdqN3pVcUxSa2UwdHp6Vm9aT0Rvb3JUdURFcjltT2Zxc0NlMXU0Uw==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2630"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:50:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4cc981a4-9b45-43f4-bbeb-36d9b2e7e70e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:50:25.595417Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "676"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:50:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 21f4c3ac-0219-427b-bcec-2c7692baf043
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3/nodes?order_by=created_at_asc&page=1&pool_id=e903ea26-fed8-4d2e-83ac-80da5478e6f6&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:45:22.864846Z","error_message":null,"id":"763cccf3-28bc-4a71-bf3f-50743fa64646","name":"scw-test-pool-minimal-test-pool-minimal-763ccc","pool_id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","provider_id":"scaleway://instance/fr-par-1/c6df0307-f00a-4a58-89b5-7d39cfeff63b","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:50:25.561389Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "659"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:50:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e62911ed-0d93-49e0-a6f2-2a305bfc49b7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/86352ce5-787c-449c-9998-79898166204d
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-18T16:43:19.912799Z","dhcp_enabled":true,"id":"86352ce5-787c-449c-9998-79898166204d","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:19.912799Z","id":"e8dae137-1a4b-466e-835a-826dcf62fdd7","subnet":"172.16.40.0/22","updated_at":"2023-10-18T16:43:19.912799Z"},{"created_at":"2023-10-18T16:43:19.912799Z","id":"7ecbb54d-39e3-4c8a-b892-21165c91b24f","subnet":"fd63:256c:45f7:af6c::/64","updated_at":"2023-10-18T16:43:19.912799Z"}],"tags":[],"updated_at":"2023-10-18T16:43:19.912799Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "718"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:50:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 047ad7f3-d85e-4029-8d70-d613b3e945d7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://422f3a0f-8672-47d0-ba43-e6f70fe573d3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:21.169294Z","created_at":"2023-10-18T16:43:21.169294Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.422f3a0f-8672-47d0-ba43-e6f70fe573d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"86352ce5-787c-449c-9998-79898166204d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:45:13.613947Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1497"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:50:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3c0d6a1e-1f59-412a-b49a-2ac679f97be9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VGtSTmVVMXNiMWhFVkUxNlRWUkJlRTU2UlRKT1JFMTVUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRYZzRDbmhMZVU4NGFIaFdaVVJGYTA0eWRtOUxjRlJzZDBoSlNrUXJiMlY0WjJaQllVUkNiV3B2YTBoSFZTdGxjekp5WkhWWE5qbEdiR3RWYWpaRlVGQjBiUzhLUm5sQ1NrUjBlR1JxWjFnelRsTlNVelppYVRGM1QwUnpSMnRwVEU1bloxcG9kRlIwVjFNM1RsaHZkeTl6VGpncmNUVXlkVWg2VURCcmNrbHdUMkZyT0FwalpscG5ORVo2VVhsMFpXOXJTbGMxTUd4eVlsZHROVW8wYzFaVEwwdGxibFI1T1UxM1NsRlRORU0yZW5oMlIweGtlakZUTjJGaFNXaHRLMHhNT1U5bkNtaDBMMGRNV1RGS1RVNXFPVXd3UXpaRVFuVTJiV2hoT0dOSGFVMUNSbUU1VFdWTWFrcE5Namt4V1ROU1lYQk1OR3hVUkhBekt6ZEVNemREUjA4MlJVZ0tRblJ5UVdaMmQxVnFkbXhLTVRKM2QySlZZbVZTTWtaaWJEaFlhMU5VUzFWRVQwdHRSbWhoVFRnNFZtSnpNamxOTTBGck1VeHNhMnBxUldKNVdHNUllQXBaWTJOMllqSXdaazlzVDBKRVpsaG9ORUV3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpDTVVab2RYSTVUVGhaTTJwa2MzbFVlbUp1ZDNGSlZHSjJSakpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDTkVneFdFbDNNVkZ4VG1oWGNtb3dZbGxZTm10NmVuSkpjMEZTYVVJdlpFTkliSEZGYzBkRkwyRktVVlJ6Y25CUlZncFNSWHB5VFVzNFZuUm9Za3huUzNwblQwRmFObkJYV1hWRmFuTkZTbnBoU0ZsdE1EbDNhRFZNTUZGUWQwTnVUaXRUU25FNE1uUmxkRU0wT0RoM2JGbFJDbGwwYlVscU5VZExOVW8zYWxocFUzWjNSa016YlVwTFVHMTVhSFpIU2tGV1lWRlNSMWR2WVVORVJIcG5VMjVOUTBwbWVYTTBTSHBFY0VGSWNHbHFWRmdLTUhSclNFcENVMk0wYlVWWlNXbEZiRTlTUVhSNEswdFRhMGhFYkRWSmNFVkxZM1ptWVRnMmFXTlRPR1JDU1dKSVMyaEVVV2htTnpsUE9ERTRWVTVWUndveWFqUmFSbTlsU2xBcmRHcE9XRnBITkhobWMyRnNSVXBMWWtSb1VYZEtZa2xWWTBONk5VaFFUREpHWms1amQzZ3lOREZ3ZGk5b1dpdEthR3hDV2prNUNubGtPVGg1V2xweFlsaFNWWEJIUm1VdlNrcHNXa2hHVWxOTVJrbDBhVXA2U2taNE1Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly80MjJmM2EwZi04NjcyLTQ3ZDAtYmE0My1lNmY3MGZlNTczZDMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBIVU1YeENkOFd0MnJRSnRvWmdqN3pVcUxSa2UwdHp6Vm9aT0Rvb3JUdURFcjltT2Zxc0NlMXU0Uw==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2630"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:50:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 585db4c7-15ee-4781-836a-daf44b0289b5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:50:25.595417Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "676"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:50:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 12548ec7-f330-41c4-ad05-43bae52fa870
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3/nodes?order_by=created_at_asc&page=1&pool_id=e903ea26-fed8-4d2e-83ac-80da5478e6f6&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:45:22.864846Z","error_message":null,"id":"763cccf3-28bc-4a71-bf3f-50743fa64646","name":"scw-test-pool-minimal-test-pool-minimal-763ccc","pool_id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","provider_id":"scaleway://instance/fr-par-1/c6df0307-f00a-4a58-89b5-7d39cfeff63b","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:50:25.561389Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "659"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:50:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 46e264b4-661b-49f7-a279-241caeb0fc10
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://422f3a0f-8672-47d0-ba43-e6f70fe573d3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:21.169294Z","created_at":"2023-10-18T16:43:21.169294Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.422f3a0f-8672-47d0-ba43-e6f70fe573d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"86352ce5-787c-449c-9998-79898166204d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:45:13.613947Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1497"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:50:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1c5bd1e2-95a1-44a0-a8fa-0f8a2275f146
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"kubelet_args":{},"upgrade_policy":null,"zone":"fr-par-1","root_volume_type":"default_volume_type","root_volume_size":null,"public_ip_disabled":false}'
+    body: '{"name":"test-pool-minimal-2","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","minimal"],"kubelet_args":{},"zone":"fr-par-1","root_volume_type":"default_volume_type","public_ip_disabled":false}'
     form: {}
     headers:
       Content-Type:
@@ -3650,19 +2627,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868291Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426475Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "683"
+      - "658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:50:28 GMT
+      - Tue, 07 Nov 2023 15:54:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3672,7 +2649,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f0d6de2-fd21-4438-b92e-748ddc5e7f09
+      - b900f4d7-dfa5-4e24-b8e0-099531cc39c5
     status: 200 OK
     code: 200
     duration: ""
@@ -3683,19 +2660,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:50:28 GMT
+      - Tue, 07 Nov 2023 15:54:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3705,7 +2682,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf0c0228-193f-4f27-a8a0-8e5fa5a253dd
+      - 6e8afc70-c782-492d-87e4-d00633d1b435
     status: 200 OK
     code: 200
     duration: ""
@@ -3716,19 +2693,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:50:33 GMT
+      - Tue, 07 Nov 2023 15:54:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3738,7 +2715,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e76cdf47-e8ee-4f38-a0ff-510383378ef9
+      - 0c6eb122-c9e3-49b7-97e9-ad3f20b6485e
     status: 200 OK
     code: 200
     duration: ""
@@ -3749,19 +2726,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:50:38 GMT
+      - Tue, 07 Nov 2023 15:54:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3771,7 +2748,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f36f2699-89bd-4e85-8dfd-f384a7d65495
+      - cbf394a7-eec8-4b1b-8677-53d926badfe5
     status: 200 OK
     code: 200
     duration: ""
@@ -3782,19 +2759,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:50:44 GMT
+      - Tue, 07 Nov 2023 15:54:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3804,7 +2781,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d43a904-bbaa-487b-9bed-33eeec0ca5f2
+      - 8d8240c2-b6b0-45d2-9884-80848ebbf545
     status: 200 OK
     code: 200
     duration: ""
@@ -3815,19 +2792,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:50:49 GMT
+      - Tue, 07 Nov 2023 15:54:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3837,7 +2814,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f56167ea-fe7a-46f3-a864-6cd08c80100b
+      - 94f95703-89d5-4a01-ba14-4843e3aa5ca8
     status: 200 OK
     code: 200
     duration: ""
@@ -3848,19 +2825,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:50:54 GMT
+      - Tue, 07 Nov 2023 15:54:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3870,7 +2847,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4ffe973-ef7a-4b86-9798-9304d216c63b
+      - 13a60d2d-c86d-40b6-a810-538a87f5693a
     status: 200 OK
     code: 200
     duration: ""
@@ -3881,19 +2858,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:50:59 GMT
+      - Tue, 07 Nov 2023 15:54:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3903,7 +2880,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55873c1c-c5ae-4736-be94-85ebaae6d476
+      - 1abff5b9-c841-4b41-b35d-5941dca01ae1
     status: 200 OK
     code: 200
     duration: ""
@@ -3914,19 +2891,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:04 GMT
+      - Tue, 07 Nov 2023 15:55:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3936,7 +2913,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ac8bc79-bff6-4196-9174-37d3e1dea52d
+      - 28df22f9-501a-4850-8a74-1093320a564d
     status: 200 OK
     code: 200
     duration: ""
@@ -3947,19 +2924,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:09 GMT
+      - Tue, 07 Nov 2023 15:55:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3969,7 +2946,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff43ec76-5f7f-4bef-9840-fdf0a82d7090
+      - 545e54f4-76cd-4e1f-a560-7940158d9e03
     status: 200 OK
     code: 200
     duration: ""
@@ -3980,19 +2957,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:14 GMT
+      - Tue, 07 Nov 2023 15:55:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4002,7 +2979,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45faf7a3-c627-4834-94a0-60e0c2285810
+      - 4fdd257d-ea67-418c-9d34-e49ca4bdd40b
     status: 200 OK
     code: 200
     duration: ""
@@ -4013,19 +2990,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:19 GMT
+      - Tue, 07 Nov 2023 15:55:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4035,7 +3012,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85d3da4b-3aa0-487b-a392-b194f25c2d44
+      - c6e8dd06-abff-4587-a405-b72e963823f4
     status: 200 OK
     code: 200
     duration: ""
@@ -4046,19 +3023,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:24 GMT
+      - Tue, 07 Nov 2023 15:55:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4068,7 +3045,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6389270-afe0-425d-afdb-cfe2f9b5f8b5
+      - 1b2375dd-84fb-47a0-979a-53e0c7439fdf
     status: 200 OK
     code: 200
     duration: ""
@@ -4079,19 +3056,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:29 GMT
+      - Tue, 07 Nov 2023 15:55:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4101,7 +3078,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3404d4da-9a7c-417b-a4b5-03ae372c0667
+      - 4ba9c1e2-4a7a-4058-b416-b4ae46a262ac
     status: 200 OK
     code: 200
     duration: ""
@@ -4112,19 +3089,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:34 GMT
+      - Tue, 07 Nov 2023 15:55:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4134,7 +3111,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82398f31-e687-469f-8281-c0f1f426382e
+      - fcbf2348-0c2e-42d5-ad57-c24e7459eb61
     status: 200 OK
     code: 200
     duration: ""
@@ -4145,19 +3122,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:40 GMT
+      - Tue, 07 Nov 2023 15:55:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4167,7 +3144,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c350bbea-3b87-4037-967d-b5b6855201b0
+      - 8a73755e-1d62-43bc-b632-bc0fb04bb259
     status: 200 OK
     code: 200
     duration: ""
@@ -4178,19 +3155,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:45 GMT
+      - Tue, 07 Nov 2023 15:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4200,7 +3177,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 326d7412-7588-4fbd-bfca-1ddfd17d69fc
+      - 076b8277-e88d-4b57-82a6-59e2222b43e2
     status: 200 OK
     code: 200
     duration: ""
@@ -4211,19 +3188,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:50 GMT
+      - Tue, 07 Nov 2023 15:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4233,7 +3210,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0206fcc1-8261-45d6-8079-55c6f71419f1
+      - 5bdda78d-ede0-4652-996d-ec723177004f
     status: 200 OK
     code: 200
     duration: ""
@@ -4244,19 +3221,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:55 GMT
+      - Tue, 07 Nov 2023 15:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4266,7 +3243,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef9b5500-ae39-429a-98ab-91101784d1a3
+      - 90a46396-784b-4064-b0ee-12b3ce946dc1
     status: 200 OK
     code: 200
     duration: ""
@@ -4277,19 +3254,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:00 GMT
+      - Tue, 07 Nov 2023 15:55:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4299,7 +3276,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4122b60d-0e11-4efa-b81b-1a6f6b9f68c0
+      - 1e0a9f82-44f9-4225-9e0c-2cd8f242c382
     status: 200 OK
     code: 200
     duration: ""
@@ -4310,19 +3287,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:05 GMT
+      - Tue, 07 Nov 2023 15:56:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4332,7 +3309,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53efc1e1-3517-41b8-af50-7f04aa90ec5f
+      - 5604c6de-3dab-49fb-abab-8aa1d6258856
     status: 200 OK
     code: 200
     duration: ""
@@ -4343,19 +3320,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:10 GMT
+      - Tue, 07 Nov 2023 15:56:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4365,7 +3342,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26c74f2c-d793-4e75-9768-7dc1f3fc3f36
+      - 0ee29ebf-c6be-4df5-b25b-b29595ec5423
     status: 200 OK
     code: 200
     duration: ""
@@ -4376,19 +3353,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:15 GMT
+      - Tue, 07 Nov 2023 15:56:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4398,7 +3375,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5b2f331-b700-49e0-875f-95597c66c789
+      - ff287062-dcef-4c20-8ff6-fa978480bee9
     status: 200 OK
     code: 200
     duration: ""
@@ -4409,19 +3386,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:20 GMT
+      - Tue, 07 Nov 2023 15:56:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4431,7 +3408,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dbfe6458-b0cd-4bc0-b0d7-865d98201387
+      - e6132f24-7f0d-4b67-8572-87cd62f52b8e
     status: 200 OK
     code: 200
     duration: ""
@@ -4442,19 +3419,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:25 GMT
+      - Tue, 07 Nov 2023 15:56:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4464,7 +3441,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 851c8dee-6a4f-4afa-ae5a-31f4a7349019
+      - 2006ce02-0d14-4db8-bbd7-a37f7d8c8b57
     status: 200 OK
     code: 200
     duration: ""
@@ -4475,19 +3452,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:30 GMT
+      - Tue, 07 Nov 2023 15:56:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4497,7 +3474,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22ec02a4-3b9f-44f7-b927-d0f9b3ea0fa5
+      - 4f67f659-4ec7-473e-8d4f-6a6c0899d9b4
     status: 200 OK
     code: 200
     duration: ""
@@ -4508,19 +3485,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:35 GMT
+      - Tue, 07 Nov 2023 15:56:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4530,7 +3507,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b9d362d-3920-40c3-80a1-5da0ec16d1e4
+      - 63945639-5b0e-4036-a7eb-0e86fe5c3cee
     status: 200 OK
     code: 200
     duration: ""
@@ -4541,19 +3518,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:40 GMT
+      - Tue, 07 Nov 2023 15:56:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4563,7 +3540,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc983714-d75c-4758-aabb-2c930db113f5
+      - 93bbdc43-4f61-47da-9ef1-712c6ec980aa
     status: 200 OK
     code: 200
     duration: ""
@@ -4574,19 +3551,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:45 GMT
+      - Tue, 07 Nov 2023 15:56:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4596,7 +3573,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 631faa9f-c657-49cf-9ed9-ef4c6588eb78
+      - 6911ebd9-61b8-48dc-a9b6-457d66429ac4
     status: 200 OK
     code: 200
     duration: ""
@@ -4607,19 +3584,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:50 GMT
+      - Tue, 07 Nov 2023 15:56:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4629,7 +3606,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee04a261-bc1b-4f7d-9587-b8e543bec4d7
+      - 7c129d64-16b8-46b0-9419-a7322d1f458a
     status: 200 OK
     code: 200
     duration: ""
@@ -4640,19 +3617,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:55 GMT
+      - Tue, 07 Nov 2023 15:56:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4662,7 +3639,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85f27181-b2c0-4e3f-907b-c907b5e799d9
+      - 5c5c30e5-3a3f-42a9-98e7-304ac8864d6d
     status: 200 OK
     code: 200
     duration: ""
@@ -4673,19 +3650,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:01 GMT
+      - Tue, 07 Nov 2023 15:56:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4695,7 +3672,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5716da12-c319-486e-9b5c-45eed37a44c6
+      - 2af045ce-5338-4a52-a7b5-e31e5d51395a
     status: 200 OK
     code: 200
     duration: ""
@@ -4706,19 +3683,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:06 GMT
+      - Tue, 07 Nov 2023 15:57:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4728,7 +3705,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1fc30526-c835-4501-b6ff-92628a7968c4
+      - e1a5d32c-3c5d-4fba-a51c-6deab9d135b4
     status: 200 OK
     code: 200
     duration: ""
@@ -4739,19 +3716,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:54:26.126426Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:11 GMT
+      - Tue, 07 Nov 2023 15:57:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4761,7 +3738,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51a10e90-f81c-474e-87a7-1bfbfb5f5a6b
+      - 06b0f13a-2207-48b3-bfde-aaea28371255
     status: 200 OK
     code: 200
     duration: ""
@@ -4772,19 +3749,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:57:08.233955Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:16 GMT
+      - Tue, 07 Nov 2023 15:57:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4794,7 +3771,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3df36196-70d4-41ae-83a4-6daf07c1cc39
+      - c989ba46-08fa-4e66-9d77-34b0c7b1be76
     status: 200 OK
     code: 200
     duration: ""
@@ -4805,19 +3782,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:57:08.233955Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:21 GMT
+      - Tue, 07 Nov 2023 15:57:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4827,7 +3804,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3fb1d1a8-caeb-4c8b-bfb4-5bab409e6d83
+      - f251dd03-48eb-4d1d-b8c9-1079fc36a49c
     status: 200 OK
     code: 200
     duration: ""
@@ -4838,19 +3815,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/nodes?order_by=created_at_asc&page=1&pool_id=d79da6df-2a18-4330-a7c5-37717e81e0b7&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:54:26.677382Z","error_message":null,"id":"65951e44-4d97-42e5-b399-d657766f253b","name":"scw-test-pool-minima-test-pool-minimal--65951e","pool_id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","provider_id":"scaleway://instance/fr-par-1/ead03329-0c55-4aae-8e51-2f8292dd36d2","public_ip_v4":"163.172.146.54","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:57:08.215914Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "680"
+      - "642"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:26 GMT
+      - Tue, 07 Nov 2023 15:57:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4860,7 +3837,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce8301f0-f184-4c13-862f-cc46af54e9bc
+      - 2ce13d67-7e7c-4aef-8157-8866c1ed6fc4
     status: 200 OK
     code: 200
     duration: ""
@@ -4871,19 +3848,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.749824Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "680"
+      - "1452"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:31 GMT
+      - Tue, 07 Nov 2023 15:57:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4893,7 +3870,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2cab4fe3-514f-4b7e-9dc6-3fb83709d9dd
+      - f04dd7b4-45bc-4d13-8a68-7d584e3948b7
     status: 200 OK
     code: 200
     duration: ""
@@ -4904,19 +3881,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:57:08.233955Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:36 GMT
+      - Tue, 07 Nov 2023 15:57:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4926,7 +3903,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b60389aa-7438-4c67-b508-4a4f93c390e1
+      - 2c096a3f-c410-43ab-a4ed-4d5688e7f971
     status: 200 OK
     code: 200
     duration: ""
@@ -4937,19 +3914,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c0076356-a746-4ffa-ba2e-8731fd24cf1f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-07T15:49:50.833519Z","dhcp_enabled":true,"id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","name":"test-pool-minimal","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.833519Z","id":"fb021b16-2494-457d-9d6c-2cf0028452b3","subnet":"172.16.20.0/22","updated_at":"2023-11-07T15:49:50.833519Z"},{"created_at":"2023-11-07T15:49:50.833519Z","id":"280feec4-d559-47b4-90f0-f9cf39fafe11","subnet":"fd5f:519c:6d46:1fd9::/64","updated_at":"2023-11-07T15:49:50.833519Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.833519Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "680"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:41 GMT
+      - Tue, 07 Nov 2023 15:57:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4959,7 +3936,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5eab4f2-5707-4261-9bb0-0fca03c049ae
+      - 82027579-8216-4a06-ad8f-976f690e4f0d
     status: 200 OK
     code: 200
     duration: ""
@@ -4970,19 +3947,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.749824Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "680"
+      - "1452"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:47 GMT
+      - Tue, 07 Nov 2023 15:57:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4992,7 +3969,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c882091a-a5c1-4b47-97c2-a00d3ede3cb3
+      - 2fc35cc8-77da-4802-a1bc-605c48d9328b
     status: 200 OK
     code: 200
     duration: ""
@@ -5003,19 +3980,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNVdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUbFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyWmlDa0ZwV0ZaV2JXNUpORVIyZDFsUlJHWlFUR1JIY25GbFVqRXZUV05NUVdkeFowRm5WVmt5U0VwcGMyaE9Ubmt6ZUVSd1VtbzFPRGhqTTFSaWVUaE1MM01LY0V4RWNHbHJNWG96TWpOc05GcHFhRnBPVm1KRVRscHRRekpOTTJsV2JXZHplbXBMVEc1VFVrb3habTFvVW04ck5XZ3llRmRPUzNJeWRVUkRSM0JSVHdwT1JFOXlSVFpMWTNBMU55dGFVelZYTVc5VVRVYzBTVlZWTWpkSlVYRnJkVzFwUkVkRGNYbzJZMHBKUm1ac1NXWnNTMjlTWVZNM1dteEVabWR3U25scUNsZGtOMWhpTVZSWlQzUkZaemg0YkV0WFpXOVBlamM0V1ZodVVtbGlNVnBRUXpFNGNrWnVla3d4UkZZMlJIcGljaXR5T0hSQllVRnBUbXBsWXpKSFdWUUtXakpoVUdwSldUWjRRMlpHUVc1MlUySm1kVzV0TmtvcmMzRnlVMWN5VkZkSmRGbFZUaTlhUkdsRWJFaERkbVJQTWxCdVJFdHBZVlp6ZW5ST09XWXdRd295YkdWYVJXZ3hXVWcyWkZoUkwxSmFjbWR6UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpEYTJ0NFYyRlFVM2RHZVVwb0wzWXljVU14U1ZSdVpXRnpjV05OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCY1c5b1dYaHJUalpITUdSWVNFVTRRbUpNYkRCcmEzaGlkRUZKTVZsRmNYUlJNM0JrWVhOWkwyeDJWR1JrZGpobVFRbzJLMUJRT1VSdU5tWk9jWEp6YVVVeVYweDFVbXR1WXpRelkwcEdaWGRxV2xoRVlXRjJZV05YVlhnelJFa3hja0U0Y1dSeGMwNTBWV1ExVmtWRlVFZERDbkZyVkM5b05sTkNkM1pWTkZWd05TdERia2hFUW1rMWRYZGxaSGdyV1RoRlVFZ3pZMUo2UlN0QlRXRjJTbFJDUWtWaE0xQlFjVXhQUlhCaWJtMURhbGdLZEdjNE9UZHVUMFJKTDFoalpURTRWazF2VFcxU1VIWkxTSGhqY1dWV1MzSkdkbmcxU1VaNmVEQlFhV1ZJVjJaV2VqVkZlSEJNVm1sSFMxZ3dTalp6T0FvMVVsaFhOakZoVWxOT1pVTjRUVWhoTVZVMlRubE9heTlFYkdoNkwydG1hVVJZVDNWaFZtVnFPVzQ0WW1SR1JsRmxVak5VVVVaRmIwZFVibTVGYWs4ekNqbENMMUZ3VUdSTlUyb3plVTAxYWxoaE0xVmFZelV3T0U1UVVtTktkelo2ZFVsTU53b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGZlZjNkMC0yMzAwLTQ5NTYtYjMzYi1jZjk3NGVlMzBhMDEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpNFBUb3RWVzJ1bExqQVZuUWNDdXNJRDJLNml1Tmt3aHM2V24xQlNEdVFhYjhBdnNkeXBCMmZmTg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "680"
+      - "2628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:52 GMT
+      - Tue, 07 Nov 2023 15:57:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5025,7 +4002,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48a48d5b-c2c6-498c-b382-8ce0b226d250
+      - 6c070dad-c6d0-4402-962c-2b1eb1a5bad5
     status: 200 OK
     code: 200
     duration: ""
@@ -5036,19 +4013,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:54:22.757519Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "651"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:57 GMT
+      - Tue, 07 Nov 2023 15:57:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5058,7 +4035,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afe5f0fe-5a4b-4d1f-9433-0b214299378e
+      - 32bc59d3-8a64-4309-9350-1750be90e593
     status: 200 OK
     code: 200
     duration: ""
@@ -5069,19 +4046,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:57:08.233955Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:54:02 GMT
+      - Tue, 07 Nov 2023 15:57:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5091,7 +4068,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0b0436ee-b71e-4311-bf3d-cf3504cece44
+      - 546fc4e3-6402-4dcd-b204-e94294e04ab6
     status: 200 OK
     code: 200
     duration: ""
@@ -5102,19 +4079,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/nodes?order_by=created_at_asc&page=1&pool_id=0149b1d8-63d9-4735-8fa6-3256b5a76ddc&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:47.022178Z","error_message":null,"id":"158fc3fe-d8bd-476d-8fc5-64d84224df41","name":"scw-test-pool-minimal-test-pool-minimal-158fc3","pool_id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","provider_id":"scaleway://instance/fr-par-1/44de6ba8-c06f-4dec-9cb3-da3090369984","public_ip_v4":"51.15.132.168","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:57:08.177957Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "680"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:54:07 GMT
+      - Tue, 07 Nov 2023 15:57:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5124,7 +4101,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5417cf4a-106a-4319-9edb-b3cd9332f611
+      - 0dfcabc5-7d34-452d-9a5b-9ff4b0abe756
     status: 200 OK
     code: 200
     duration: ""
@@ -5135,19 +4112,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/nodes?order_by=created_at_asc&page=1&pool_id=d79da6df-2a18-4330-a7c5-37717e81e0b7&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:54:26.677382Z","error_message":null,"id":"65951e44-4d97-42e5-b399-d657766f253b","name":"scw-test-pool-minima-test-pool-minimal--65951e","pool_id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","provider_id":"scaleway://instance/fr-par-1/ead03329-0c55-4aae-8e51-2f8292dd36d2","public_ip_v4":"163.172.146.54","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:57:08.215914Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "680"
+      - "642"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:54:12 GMT
+      - Tue, 07 Nov 2023 15:57:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5157,7 +4134,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7637bd82-5f09-4bb9-9379-ccbab069be1a
+      - 4a254698-3886-438d-889f-27de28f91538
     status: 200 OK
     code: 200
     duration: ""
@@ -5168,19 +4145,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c0076356-a746-4ffa-ba2e-8731fd24cf1f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-07T15:49:50.833519Z","dhcp_enabled":true,"id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","name":"test-pool-minimal","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.833519Z","id":"fb021b16-2494-457d-9d6c-2cf0028452b3","subnet":"172.16.20.0/22","updated_at":"2023-11-07T15:49:50.833519Z"},{"created_at":"2023-11-07T15:49:50.833519Z","id":"280feec4-d559-47b4-90f0-f9cf39fafe11","subnet":"fd5f:519c:6d46:1fd9::/64","updated_at":"2023-11-07T15:49:50.833519Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.833519Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "680"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:54:17 GMT
+      - Tue, 07 Nov 2023 15:57:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5190,7 +4167,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3103d735-e618-4685-9e3e-6f29bcc71517
+      - 2e487592-d162-4b41-b039-5572444c3475
     status: 200 OK
     code: 200
     duration: ""
@@ -5201,19 +4178,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:57:08.233955Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:54:22 GMT
+      - Tue, 07 Nov 2023 15:57:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5223,7 +4200,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ae6cdc1-ddef-4c6c-9e78-68f4d02b32f5
+      - acbec904-11d5-48c7-bb10-89d2167b5354
     status: 200 OK
     code: 200
     duration: ""
@@ -5234,19 +4211,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.749824Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "680"
+      - "1452"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:54:27 GMT
+      - Tue, 07 Nov 2023 15:57:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5256,7 +4233,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9b1707e-2cc2-4440-85cd-25a84037936d
+      - 4d16b119-c514-41ca-8d0d-458a03741479
     status: 200 OK
     code: 200
     duration: ""
@@ -5267,19 +4244,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/nodes?order_by=created_at_asc&page=1&pool_id=d79da6df-2a18-4330-a7c5-37717e81e0b7&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:54:26.677382Z","error_message":null,"id":"65951e44-4d97-42e5-b399-d657766f253b","name":"scw-test-pool-minima-test-pool-minimal--65951e","pool_id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","provider_id":"scaleway://instance/fr-par-1/ead03329-0c55-4aae-8e51-2f8292dd36d2","public_ip_v4":"163.172.146.54","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:57:08.215914Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "680"
+      - "642"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:54:32 GMT
+      - Tue, 07 Nov 2023 15:57:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5289,7 +4266,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a164be21-db59-45d2-b52c-81472f8c4eed
+      - ada6a6e1-0673-446e-8488-7aeeb899b35e
     status: 200 OK
     code: 200
     duration: ""
@@ -5300,19 +4277,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNVdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUbFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyWmlDa0ZwV0ZaV2JXNUpORVIyZDFsUlJHWlFUR1JIY25GbFVqRXZUV05NUVdkeFowRm5WVmt5U0VwcGMyaE9Ubmt6ZUVSd1VtbzFPRGhqTTFSaWVUaE1MM01LY0V4RWNHbHJNWG96TWpOc05GcHFhRnBPVm1KRVRscHRRekpOTTJsV2JXZHplbXBMVEc1VFVrb3habTFvVW04ck5XZ3llRmRPUzNJeWRVUkRSM0JSVHdwT1JFOXlSVFpMWTNBMU55dGFVelZYTVc5VVRVYzBTVlZWTWpkSlVYRnJkVzFwUkVkRGNYbzJZMHBKUm1ac1NXWnNTMjlTWVZNM1dteEVabWR3U25scUNsZGtOMWhpTVZSWlQzUkZaemg0YkV0WFpXOVBlamM0V1ZodVVtbGlNVnBRUXpFNGNrWnVla3d4UkZZMlJIcGljaXR5T0hSQllVRnBUbXBsWXpKSFdWUUtXakpoVUdwSldUWjRRMlpHUVc1MlUySm1kVzV0TmtvcmMzRnlVMWN5VkZkSmRGbFZUaTlhUkdsRWJFaERkbVJQTWxCdVJFdHBZVlp6ZW5ST09XWXdRd295YkdWYVJXZ3hXVWcyWkZoUkwxSmFjbWR6UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpEYTJ0NFYyRlFVM2RHZVVwb0wzWXljVU14U1ZSdVpXRnpjV05OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCY1c5b1dYaHJUalpITUdSWVNFVTRRbUpNYkRCcmEzaGlkRUZKTVZsRmNYUlJNM0JrWVhOWkwyeDJWR1JrZGpobVFRbzJLMUJRT1VSdU5tWk9jWEp6YVVVeVYweDFVbXR1WXpRelkwcEdaWGRxV2xoRVlXRjJZV05YVlhnelJFa3hja0U0Y1dSeGMwNTBWV1ExVmtWRlVFZERDbkZyVkM5b05sTkNkM1pWTkZWd05TdERia2hFUW1rMWRYZGxaSGdyV1RoRlVFZ3pZMUo2UlN0QlRXRjJTbFJDUWtWaE0xQlFjVXhQUlhCaWJtMURhbGdLZEdjNE9UZHVUMFJKTDFoalpURTRWazF2VFcxU1VIWkxTSGhqY1dWV1MzSkdkbmcxU1VaNmVEQlFhV1ZJVjJaV2VqVkZlSEJNVm1sSFMxZ3dTalp6T0FvMVVsaFhOakZoVWxOT1pVTjRUVWhoTVZVMlRubE9heTlFYkdoNkwydG1hVVJZVDNWaFZtVnFPVzQ0WW1SR1JsRmxVak5VVVVaRmIwZFVibTVGYWs4ekNqbENMMUZ3VUdSTlUyb3plVTAxYWxoaE0xVmFZelV3T0U1UVVtTktkelo2ZFVsTU53b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGZlZjNkMC0yMzAwLTQ5NTYtYjMzYi1jZjk3NGVlMzBhMDEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpNFBUb3RWVzJ1bExqQVZuUWNDdXNJRDJLNml1Tmt3aHM2V24xQlNEdVFhYjhBdnNkeXBCMmZmTg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "680"
+      - "2628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:54:37 GMT
+      - Tue, 07 Nov 2023 15:57:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5322,7 +4299,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9eef88ca-d19c-435f-94fe-7d10955046d3
+      - a72d4218-5d3d-4b54-93c1-cadd2c061899
     status: 200 OK
     code: 200
     duration: ""
@@ -5333,19 +4310,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:54:22.757519Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "680"
+      - "651"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:54:42 GMT
+      - Tue, 07 Nov 2023 15:57:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5355,7 +4332,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f52c449-c41a-4501-ac83-a859f72f7d69
+      - 149c2f1c-6d6e-4062-96f6-07e929aa3af6
     status: 200 OK
     code: 200
     duration: ""
@@ -5366,19 +4343,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/nodes?order_by=created_at_asc&page=1&pool_id=0149b1d8-63d9-4735-8fa6-3256b5a76ddc&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:47.022178Z","error_message":null,"id":"158fc3fe-d8bd-476d-8fc5-64d84224df41","name":"scw-test-pool-minimal-test-pool-minimal-158fc3","pool_id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","provider_id":"scaleway://instance/fr-par-1/44de6ba8-c06f-4dec-9cb3-da3090369984","public_ip_v4":"51.15.132.168","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:57:08.177957Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "680"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:54:47 GMT
+      - Tue, 07 Nov 2023 15:57:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5388,7 +4365,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0fe0727f-4fc6-4b7c-893e-524e58a8abbd
+      - 85a7a12a-229e-46c3-a089-7c4be9d9b365
     status: 200 OK
     code: 200
     duration: ""
@@ -5399,877 +4376,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "680"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:54:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e67a29f9-7cc5-42cd-ae9e-0433bdfb063b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "680"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:54:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e094375e-7802-4628-8979-5992d9a58b30
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "680"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f185a863-263e-4e10-a094-12a3e2708b2e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "680"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a2aa4065-cdef-4e9e-9202-a7b2e64d54d7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "680"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 76a67360-c369-4452-bfee-65efbef43574
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "680"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cd0bae41-0deb-4ee9-af2e-97bf615ff7c2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:50:28.592868Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "680"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e02253df-7e10-4394-9ff6-d4db59a2d4ea
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:55:25.642729Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "678"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3c30226b-6e9b-4da6-adaa-b2a07c13b6d7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:55:25.642729Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "678"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1eefbc1a-fd4f-4b74-ba28-9570bd47165b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3/nodes?order_by=created_at_asc&page=1&pool_id=9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:50:29.077607Z","error_message":null,"id":"4bf49a53-286a-47b9-9073-75aac8717ac0","name":"scw-test-pool-minima-test-pool-minimal--4bf49a","pool_id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","provider_id":"scaleway://instance/fr-par-1/bd30346a-89e9-4e47-b9bb-734491a2aaa0","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:55:25.627946Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "657"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7b61c864-b748-4cb1-9b5c-861d860bf6ef
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://422f3a0f-8672-47d0-ba43-e6f70fe573d3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:21.169294Z","created_at":"2023-10-18T16:43:21.169294Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.422f3a0f-8672-47d0-ba43-e6f70fe573d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"86352ce5-787c-449c-9998-79898166204d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:45:13.613947Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1497"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b8eb6515-1504-456e-ae64-50f39b62c669
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:55:25.642729Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "678"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ad2800b8-f256-419f-bc27-c0a9f85e87e6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/86352ce5-787c-449c-9998-79898166204d
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-18T16:43:19.912799Z","dhcp_enabled":true,"id":"86352ce5-787c-449c-9998-79898166204d","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:19.912799Z","id":"e8dae137-1a4b-466e-835a-826dcf62fdd7","subnet":"172.16.40.0/22","updated_at":"2023-10-18T16:43:19.912799Z"},{"created_at":"2023-10-18T16:43:19.912799Z","id":"7ecbb54d-39e3-4c8a-b892-21165c91b24f","subnet":"fd63:256c:45f7:af6c::/64","updated_at":"2023-10-18T16:43:19.912799Z"}],"tags":[],"updated_at":"2023-10-18T16:43:19.912799Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "718"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0500a866-45da-46ca-ba28-3db4e5f22db6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://422f3a0f-8672-47d0-ba43-e6f70fe573d3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:21.169294Z","created_at":"2023-10-18T16:43:21.169294Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.422f3a0f-8672-47d0-ba43-e6f70fe573d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"86352ce5-787c-449c-9998-79898166204d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:45:13.613947Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1497"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6e0f4c21-bbbf-417c-b662-b13d04cd28f7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VGtSTmVVMXNiMWhFVkUxNlRWUkJlRTU2UlRKT1JFMTVUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRYZzRDbmhMZVU4NGFIaFdaVVJGYTA0eWRtOUxjRlJzZDBoSlNrUXJiMlY0WjJaQllVUkNiV3B2YTBoSFZTdGxjekp5WkhWWE5qbEdiR3RWYWpaRlVGQjBiUzhLUm5sQ1NrUjBlR1JxWjFnelRsTlNVelppYVRGM1QwUnpSMnRwVEU1bloxcG9kRlIwVjFNM1RsaHZkeTl6VGpncmNUVXlkVWg2VURCcmNrbHdUMkZyT0FwalpscG5ORVo2VVhsMFpXOXJTbGMxTUd4eVlsZHROVW8wYzFaVEwwdGxibFI1T1UxM1NsRlRORU0yZW5oMlIweGtlakZUTjJGaFNXaHRLMHhNT1U5bkNtaDBMMGRNV1RGS1RVNXFPVXd3UXpaRVFuVTJiV2hoT0dOSGFVMUNSbUU1VFdWTWFrcE5Namt4V1ROU1lYQk1OR3hVUkhBekt6ZEVNemREUjA4MlJVZ0tRblJ5UVdaMmQxVnFkbXhLTVRKM2QySlZZbVZTTWtaaWJEaFlhMU5VUzFWRVQwdHRSbWhoVFRnNFZtSnpNamxOTTBGck1VeHNhMnBxUldKNVdHNUllQXBaWTJOMllqSXdaazlzVDBKRVpsaG9ORUV3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpDTVVab2RYSTVUVGhaTTJwa2MzbFVlbUp1ZDNGSlZHSjJSakpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDTkVneFdFbDNNVkZ4VG1oWGNtb3dZbGxZTm10NmVuSkpjMEZTYVVJdlpFTkliSEZGYzBkRkwyRktVVlJ6Y25CUlZncFNSWHB5VFVzNFZuUm9Za3huUzNwblQwRmFObkJYV1hWRmFuTkZTbnBoU0ZsdE1EbDNhRFZNTUZGUWQwTnVUaXRUU25FNE1uUmxkRU0wT0RoM2JGbFJDbGwwYlVscU5VZExOVW8zYWxocFUzWjNSa016YlVwTFVHMTVhSFpIU2tGV1lWRlNSMWR2WVVORVJIcG5VMjVOUTBwbWVYTTBTSHBFY0VGSWNHbHFWRmdLTUhSclNFcENVMk0wYlVWWlNXbEZiRTlTUVhSNEswdFRhMGhFYkRWSmNFVkxZM1ptWVRnMmFXTlRPR1JDU1dKSVMyaEVVV2htTnpsUE9ERTRWVTVWUndveWFqUmFSbTlsU2xBcmRHcE9XRnBITkhobWMyRnNSVXBMWWtSb1VYZEtZa2xWWTBONk5VaFFUREpHWms1amQzZ3lOREZ3ZGk5b1dpdEthR3hDV2prNUNubGtPVGg1V2xweFlsaFNWWEJIUm1VdlNrcHNXa2hHVWxOTVJrbDBhVXA2U2taNE1Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly80MjJmM2EwZi04NjcyLTQ3ZDAtYmE0My1lNmY3MGZlNTczZDMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBIVU1YeENkOFd0MnJRSnRvWmdqN3pVcUxSa2UwdHp6Vm9aT0Rvb3JUdURFcjltT2Zxc0NlMXU0Uw==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2630"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 43e27c20-41f3-495f-ba5c-a7e9ef24c7fe
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:55:25.642729Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "678"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8c79b925-30c3-4f3e-bc70-6b0e156567ab
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:50:25.595417Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "676"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - abc1bb53-c7ea-4426-8f76-4af3e538afcf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3/nodes?order_by=created_at_asc&page=1&pool_id=e903ea26-fed8-4d2e-83ac-80da5478e6f6&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:45:22.864846Z","error_message":null,"id":"763cccf3-28bc-4a71-bf3f-50743fa64646","name":"scw-test-pool-minimal-test-pool-minimal-763ccc","pool_id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","provider_id":"scaleway://instance/fr-par-1/c6df0307-f00a-4a58-89b5-7d39cfeff63b","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:55:25.665461Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "689"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5dcc94a7-507d-4b15-ab54-5ab9dfd9256d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3/nodes?order_by=created_at_asc&page=1&pool_id=9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:50:29.077607Z","error_message":null,"id":"4bf49a53-286a-47b9-9073-75aac8717ac0","name":"scw-test-pool-minima-test-pool-minimal--4bf49a","pool_id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","provider_id":"scaleway://instance/fr-par-1/bd30346a-89e9-4e47-b9bb-734491a2aaa0","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:55:25.627946Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "657"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e719a7e1-fb5b-469a-827b-eba8717bd216
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/86352ce5-787c-449c-9998-79898166204d
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-18T16:43:19.912799Z","dhcp_enabled":true,"id":"86352ce5-787c-449c-9998-79898166204d","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:19.912799Z","id":"e8dae137-1a4b-466e-835a-826dcf62fdd7","subnet":"172.16.40.0/22","updated_at":"2023-10-18T16:43:19.912799Z"},{"created_at":"2023-10-18T16:43:19.912799Z","id":"7ecbb54d-39e3-4c8a-b892-21165c91b24f","subnet":"fd63:256c:45f7:af6c::/64","updated_at":"2023-10-18T16:43:19.912799Z"}],"tags":[],"updated_at":"2023-10-18T16:43:19.912799Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "718"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c8eec1bd-0bd7-4eb2-8e5b-1f41f675801b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:55:25.642729Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "678"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 185cfb81-332c-4bfd-9229-9aaba642b2b1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://422f3a0f-8672-47d0-ba43-e6f70fe573d3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:21.169294Z","created_at":"2023-10-18T16:43:21.169294Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.422f3a0f-8672-47d0-ba43-e6f70fe573d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"86352ce5-787c-449c-9998-79898166204d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:45:13.613947Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1497"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0b27cdbc-884e-45fa-ad08-b76215443d5b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3/nodes?order_by=created_at_asc&page=1&pool_id=9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:50:29.077607Z","error_message":null,"id":"4bf49a53-286a-47b9-9073-75aac8717ac0","name":"scw-test-pool-minima-test-pool-minimal--4bf49a","pool_id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","provider_id":"scaleway://instance/fr-par-1/bd30346a-89e9-4e47-b9bb-734491a2aaa0","public_ip_v4":"51.15.216.28","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:55:25.627946Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "657"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 88995ea3-fbd2-42e5-ab7e-8afccf3b9598
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VGtSTmVVMXNiMWhFVkUxNlRWUkJlRTU2UlRKT1JFMTVUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRYZzRDbmhMZVU4NGFIaFdaVVJGYTA0eWRtOUxjRlJzZDBoSlNrUXJiMlY0WjJaQllVUkNiV3B2YTBoSFZTdGxjekp5WkhWWE5qbEdiR3RWYWpaRlVGQjBiUzhLUm5sQ1NrUjBlR1JxWjFnelRsTlNVelppYVRGM1QwUnpSMnRwVEU1bloxcG9kRlIwVjFNM1RsaHZkeTl6VGpncmNUVXlkVWg2VURCcmNrbHdUMkZyT0FwalpscG5ORVo2VVhsMFpXOXJTbGMxTUd4eVlsZHROVW8wYzFaVEwwdGxibFI1T1UxM1NsRlRORU0yZW5oMlIweGtlakZUTjJGaFNXaHRLMHhNT1U5bkNtaDBMMGRNV1RGS1RVNXFPVXd3UXpaRVFuVTJiV2hoT0dOSGFVMUNSbUU1VFdWTWFrcE5Namt4V1ROU1lYQk1OR3hVUkhBekt6ZEVNemREUjA4MlJVZ0tRblJ5UVdaMmQxVnFkbXhLTVRKM2QySlZZbVZTTWtaaWJEaFlhMU5VUzFWRVQwdHRSbWhoVFRnNFZtSnpNamxOTTBGck1VeHNhMnBxUldKNVdHNUllQXBaWTJOMllqSXdaazlzVDBKRVpsaG9ORUV3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpDTVVab2RYSTVUVGhaTTJwa2MzbFVlbUp1ZDNGSlZHSjJSakpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDTkVneFdFbDNNVkZ4VG1oWGNtb3dZbGxZTm10NmVuSkpjMEZTYVVJdlpFTkliSEZGYzBkRkwyRktVVlJ6Y25CUlZncFNSWHB5VFVzNFZuUm9Za3huUzNwblQwRmFObkJYV1hWRmFuTkZTbnBoU0ZsdE1EbDNhRFZNTUZGUWQwTnVUaXRUU25FNE1uUmxkRU0wT0RoM2JGbFJDbGwwYlVscU5VZExOVW8zYWxocFUzWjNSa016YlVwTFVHMTVhSFpIU2tGV1lWRlNSMWR2WVVORVJIcG5VMjVOUTBwbWVYTTBTSHBFY0VGSWNHbHFWRmdLTUhSclNFcENVMk0wYlVWWlNXbEZiRTlTUVhSNEswdFRhMGhFYkRWSmNFVkxZM1ptWVRnMmFXTlRPR1JDU1dKSVMyaEVVV2htTnpsUE9ERTRWVTVWUndveWFqUmFSbTlsU2xBcmRHcE9XRnBITkhobWMyRnNSVXBMWWtSb1VYZEtZa2xWWTBONk5VaFFUREpHWms1amQzZ3lOREZ3ZGk5b1dpdEthR3hDV2prNUNubGtPVGg1V2xweFlsaFNWWEJIUm1VdlNrcHNXa2hHVWxOTVJrbDBhVXA2U2taNE1Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly80MjJmM2EwZi04NjcyLTQ3ZDAtYmE0My1lNmY3MGZlNTczZDMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBIVU1YeENkOFd0MnJRSnRvWmdqN3pVcUxSa2UwdHp6Vm9aT0Rvb3JUdURFcjltT2Zxc0NlMXU0Uw==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2630"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - eb2c7b1b-b3b1-430e-81aa-882b15ee60b9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:50:25.595417Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "676"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8ab81116-78c3-4c7a-9916-128a0806d20d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3/nodes?order_by=created_at_asc&page=1&pool_id=e903ea26-fed8-4d2e-83ac-80da5478e6f6&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:45:22.864846Z","error_message":null,"id":"763cccf3-28bc-4a71-bf3f-50743fa64646","name":"scw-test-pool-minimal-test-pool-minimal-763ccc","pool_id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","provider_id":"scaleway://instance/fr-par-1/c6df0307-f00a-4a58-89b5-7d39cfeff63b","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:55:25.665461Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "689"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 66f04e77-3940-43ae-b4d8-2e4c144550e9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:50:28.582542Z","id":"9fb309dc-4484-4c7d-b4cd-c6d8f0ac0200","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-10-18T16:55:30.527431751Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:57:15.744774237Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "684"
+      - "659"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:55:30 GMT
+      - Tue, 07 Nov 2023 15:57:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6279,7 +4398,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2e92d85-d1e3-4a61-ad38-9c662f06c208
+      - d72227ee-7109-45a7-a114-d5638f1a5f23
     status: 200 OK
     code: 200
     duration: ""
@@ -6290,19 +4409,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://422f3a0f-8672-47d0-ba43-e6f70fe573d3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:21.169294Z","created_at":"2023-10-18T16:43:21.169294Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.422f3a0f-8672-47d0-ba43-e6f70fe573d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"86352ce5-787c-449c-9998-79898166204d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:45:13.613947Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:57:15.744774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1497"
+      - "656"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:55:30 GMT
+      - Tue, 07 Nov 2023 15:57:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6312,7 +4431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4265ebf3-1ddd-4ca1-af64-eeb345999942
+      - 464a4004-c970-4e9b-baf6-815c1d778db2
     status: 200 OK
     code: 200
     duration: ""
@@ -6323,19 +4442,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/86352ce5-787c-449c-9998-79898166204d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:43:19.912799Z","dhcp_enabled":true,"id":"86352ce5-787c-449c-9998-79898166204d","name":"test-pool-minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:19.912799Z","id":"e8dae137-1a4b-466e-835a-826dcf62fdd7","subnet":"172.16.40.0/22","updated_at":"2023-10-18T16:43:19.912799Z"},{"created_at":"2023-10-18T16:43:19.912799Z","id":"7ecbb54d-39e3-4c8a-b892-21165c91b24f","subnet":"fd63:256c:45f7:af6c::/64","updated_at":"2023-10-18T16:43:19.912799Z"}],"tags":[],"updated_at":"2023-10-18T16:43:19.912799Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:57:15.744774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "718"
+      - "656"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:55:31 GMT
+      - Tue, 07 Nov 2023 15:57:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6345,7 +4464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8a5a7da-4221-4a9a-9654-7d570b3e618a
+      - 6bdfbc63-6033-47a5-99d0-f3d1fcab9ead
     status: 200 OK
     code: 200
     duration: ""
@@ -6356,19 +4475,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://422f3a0f-8672-47d0-ba43-e6f70fe573d3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:21.169294Z","created_at":"2023-10-18T16:43:21.169294Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.422f3a0f-8672-47d0-ba43-e6f70fe573d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"86352ce5-787c-449c-9998-79898166204d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:45:13.613947Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:57:15.744774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1497"
+      - "656"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:55:31 GMT
+      - Tue, 07 Nov 2023 15:57:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6378,7 +4497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42d68eef-cd3f-4bef-bd13-a3de11d8bb86
+      - 8c3eb8e2-eac1-4333-927c-2f7dd73066a2
     status: 200 OK
     code: 200
     duration: ""
@@ -6389,19 +4508,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VGtSTmVVMXNiMWhFVkUxNlRWUkJlRTU2UlRKT1JFMTVUV3h2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRYZzRDbmhMZVU4NGFIaFdaVVJGYTA0eWRtOUxjRlJzZDBoSlNrUXJiMlY0WjJaQllVUkNiV3B2YTBoSFZTdGxjekp5WkhWWE5qbEdiR3RWYWpaRlVGQjBiUzhLUm5sQ1NrUjBlR1JxWjFnelRsTlNVelppYVRGM1QwUnpSMnRwVEU1bloxcG9kRlIwVjFNM1RsaHZkeTl6VGpncmNUVXlkVWg2VURCcmNrbHdUMkZyT0FwalpscG5ORVo2VVhsMFpXOXJTbGMxTUd4eVlsZHROVW8wYzFaVEwwdGxibFI1T1UxM1NsRlRORU0yZW5oMlIweGtlakZUTjJGaFNXaHRLMHhNT1U5bkNtaDBMMGRNV1RGS1RVNXFPVXd3UXpaRVFuVTJiV2hoT0dOSGFVMUNSbUU1VFdWTWFrcE5Namt4V1ROU1lYQk1OR3hVUkhBekt6ZEVNemREUjA4MlJVZ0tRblJ5UVdaMmQxVnFkbXhLTVRKM2QySlZZbVZTTWtaaWJEaFlhMU5VUzFWRVQwdHRSbWhoVFRnNFZtSnpNamxOTTBGck1VeHNhMnBxUldKNVdHNUllQXBaWTJOMllqSXdaazlzVDBKRVpsaG9ORUV3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpDTVVab2RYSTVUVGhaTTJwa2MzbFVlbUp1ZDNGSlZHSjJSakpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDTkVneFdFbDNNVkZ4VG1oWGNtb3dZbGxZTm10NmVuSkpjMEZTYVVJdlpFTkliSEZGYzBkRkwyRktVVlJ6Y25CUlZncFNSWHB5VFVzNFZuUm9Za3huUzNwblQwRmFObkJYV1hWRmFuTkZTbnBoU0ZsdE1EbDNhRFZNTUZGUWQwTnVUaXRUU25FNE1uUmxkRU0wT0RoM2JGbFJDbGwwYlVscU5VZExOVW8zYWxocFUzWjNSa016YlVwTFVHMTVhSFpIU2tGV1lWRlNSMWR2WVVORVJIcG5VMjVOUTBwbWVYTTBTSHBFY0VGSWNHbHFWRmdLTUhSclNFcENVMk0wYlVWWlNXbEZiRTlTUVhSNEswdFRhMGhFYkRWSmNFVkxZM1ptWVRnMmFXTlRPR1JDU1dKSVMyaEVVV2htTnpsUE9ERTRWVTVWUndveWFqUmFSbTlsU2xBcmRHcE9XRnBITkhobWMyRnNSVXBMWWtSb1VYZEtZa2xWWTBONk5VaFFUREpHWms1amQzZ3lOREZ3ZGk5b1dpdEthR3hDV2prNUNubGtPVGg1V2xweFlsaFNWWEJIUm1VdlNrcHNXa2hHVWxOTVJrbDBhVXA2U2taNE1Bb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly80MjJmM2EwZi04NjcyLTQ3ZDAtYmE0My1lNmY3MGZlNTczZDMuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBIVU1YeENkOFd0MnJRSnRvWmdqN3pVcUxSa2UwdHp6Vm9aT0Rvb3JUdURFcjltT2Zxc0NlMXU0Uw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:57:15.744774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "2630"
+      - "656"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:55:31 GMT
+      - Tue, 07 Nov 2023 15:57:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6411,7 +4530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3c9de36-8e32-48e3-8a99-edc2fb16ac47
+      - ed2e7010-613c-4610-8bc7-ad1fbedec8ee
     status: 200 OK
     code: 200
     duration: ""
@@ -6422,19 +4541,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:50:25.595417Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:54:26.116121Z","id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"updated_at":"2023-11-07T15:57:15.744774Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "676"
+      - "656"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:55:31 GMT
+      - Tue, 07 Nov 2023 15:57:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6444,7 +4563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3aeee7e-a1a4-4e88-b0fe-f6a783894aaf
+      - 4842e24a-1eb9-4589-b94d-65fd755cd039
     status: 200 OK
     code: 200
     duration: ""
@@ -6455,19 +4574,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3/nodes?order_by=created_at_asc&page=1&pool_id=e903ea26-fed8-4d2e-83ac-80da5478e6f6&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d79da6df-2a18-4330-a7c5-37717e81e0b7
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:45:22.864846Z","error_message":null,"id":"763cccf3-28bc-4a71-bf3f-50743fa64646","name":"scw-test-pool-minimal-test-pool-minimal-763ccc","pool_id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","provider_id":"scaleway://instance/fr-par-1/c6df0307-f00a-4a58-89b5-7d39cfeff63b","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:55:31.102553Z"}],"total_count":1}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"d79da6df-2a18-4330-a7c5-37717e81e0b7","type":"not_found"}'
     headers:
       Content-Length:
-      - "689"
+      - "125"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:55:31 GMT
+      - Tue, 07 Nov 2023 15:57:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6477,271 +4596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e857004-85ba-49a0-86a9-d49287fd27bf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/e903ea26-fed8-4d2e-83ac-80da5478e6f6
-    method: DELETE
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","container_runtime":"containerd","created_at":"2023-10-18T16:43:26.636841Z","id":"e903ea26-fed8-4d2e-83ac-80da5478e6f6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-10-18T16:55:31.997813105Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "682"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ad5b6a67-710a-4eeb-a32a-6cdd287cca17
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3?with_additional_resources=true
-    method: DELETE
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://422f3a0f-8672-47d0-ba43-e6f70fe573d3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:21.169294Z","created_at":"2023-10-18T16:43:21.169294Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.422f3a0f-8672-47d0-ba43-e6f70fe573d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"86352ce5-787c-449c-9998-79898166204d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:55:32.215792849Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1503"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5eb3df26-dbda-46d2-8545-af1e5065f874
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://422f3a0f-8672-47d0-ba43-e6f70fe573d3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:21.169294Z","created_at":"2023-10-18T16:43:21.169294Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.422f3a0f-8672-47d0-ba43-e6f70fe573d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"86352ce5-787c-449c-9998-79898166204d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:55:32.215793Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1500"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9b70b564-b00b-49da-a381-ed3606cd47ec
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://422f3a0f-8672-47d0-ba43-e6f70fe573d3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:21.169294Z","created_at":"2023-10-18T16:43:21.169294Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.422f3a0f-8672-47d0-ba43-e6f70fe573d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"86352ce5-787c-449c-9998-79898166204d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:55:32.215793Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1500"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1e01d7a2-1c7b-44f1-a483-8f38252ab298
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://422f3a0f-8672-47d0-ba43-e6f70fe573d3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:21.169294Z","created_at":"2023-10-18T16:43:21.169294Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.422f3a0f-8672-47d0-ba43-e6f70fe573d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"86352ce5-787c-449c-9998-79898166204d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:55:32.215793Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1500"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2ef39f12-4c3b-4a6e-a6f6-0111826dc514
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://422f3a0f-8672-47d0-ba43-e6f70fe573d3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:21.169294Z","created_at":"2023-10-18T16:43:21.169294Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.422f3a0f-8672-47d0-ba43-e6f70fe573d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"86352ce5-787c-449c-9998-79898166204d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:55:32.215793Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1500"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bab043a6-388d-48ad-a747-ca3e8b28994e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://422f3a0f-8672-47d0-ba43-e6f70fe573d3.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T16:43:21.169294Z","created_at":"2023-10-18T16:43:21.169294Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.422f3a0f-8672-47d0-ba43-e6f70fe573d3.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"86352ce5-787c-449c-9998-79898166204d","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-18T16:55:32.215793Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1500"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - dc0c9c96-abaa-489f-95d3-05e62058a7c8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "128"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:55:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 19f6af63-3225-4a70-a716-607656cd2c4b
+      - a28c7a03-6181-4fe6-ad03-fc06988d2b3e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -6752,10 +4607,637 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/86352ce5-787c-449c-9998-79898166204d
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.749824Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1452"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:57:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6b72f77f-e4a1-4f7a-8436-a1f7f4b79069
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c0076356-a746-4ffa-ba2e-8731fd24cf1f
+    method: GET
+  response:
+    body: '{"created_at":"2023-11-07T15:49:50.833519Z","dhcp_enabled":true,"id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","name":"test-pool-minimal","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.833519Z","id":"fb021b16-2494-457d-9d6c-2cf0028452b3","subnet":"172.16.20.0/22","updated_at":"2023-11-07T15:49:50.833519Z"},{"created_at":"2023-11-07T15:49:50.833519Z","id":"280feec4-d559-47b4-90f0-f9cf39fafe11","subnet":"fd5f:519c:6d46:1fd9::/64","updated_at":"2023-11-07T15:49:50.833519Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.833519Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "701"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:57:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 591bf0dd-55c7-4498-9fc0-0c7ab2a48092
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.749824Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1452"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:57:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 18d91cef-8c21-49c1-b6a8-8a5e1fc5feba
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1taW5pbWFsIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNVdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUbFp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyWmlDa0ZwV0ZaV2JXNUpORVIyZDFsUlJHWlFUR1JIY25GbFVqRXZUV05NUVdkeFowRm5WVmt5U0VwcGMyaE9Ubmt6ZUVSd1VtbzFPRGhqTTFSaWVUaE1MM01LY0V4RWNHbHJNWG96TWpOc05GcHFhRnBPVm1KRVRscHRRekpOTTJsV2JXZHplbXBMVEc1VFVrb3habTFvVW04ck5XZ3llRmRPUzNJeWRVUkRSM0JSVHdwT1JFOXlSVFpMWTNBMU55dGFVelZYTVc5VVRVYzBTVlZWTWpkSlVYRnJkVzFwUkVkRGNYbzJZMHBKUm1ac1NXWnNTMjlTWVZNM1dteEVabWR3U25scUNsZGtOMWhpTVZSWlQzUkZaemg0YkV0WFpXOVBlamM0V1ZodVVtbGlNVnBRUXpFNGNrWnVla3d4UkZZMlJIcGljaXR5T0hSQllVRnBUbXBsWXpKSFdWUUtXakpoVUdwSldUWjRRMlpHUVc1MlUySm1kVzV0TmtvcmMzRnlVMWN5VkZkSmRGbFZUaTlhUkdsRWJFaERkbVJQTWxCdVJFdHBZVlp6ZW5ST09XWXdRd295YkdWYVJXZ3hXVWcyWkZoUkwxSmFjbWR6UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpEYTJ0NFYyRlFVM2RHZVVwb0wzWXljVU14U1ZSdVpXRnpjV05OUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCY1c5b1dYaHJUalpITUdSWVNFVTRRbUpNYkRCcmEzaGlkRUZKTVZsRmNYUlJNM0JrWVhOWkwyeDJWR1JrZGpobVFRbzJLMUJRT1VSdU5tWk9jWEp6YVVVeVYweDFVbXR1WXpRelkwcEdaWGRxV2xoRVlXRjJZV05YVlhnelJFa3hja0U0Y1dSeGMwNTBWV1ExVmtWRlVFZERDbkZyVkM5b05sTkNkM1pWTkZWd05TdERia2hFUW1rMWRYZGxaSGdyV1RoRlVFZ3pZMUo2UlN0QlRXRjJTbFJDUWtWaE0xQlFjVXhQUlhCaWJtMURhbGdLZEdjNE9UZHVUMFJKTDFoalpURTRWazF2VFcxU1VIWkxTSGhqY1dWV1MzSkdkbmcxU1VaNmVEQlFhV1ZJVjJaV2VqVkZlSEJNVm1sSFMxZ3dTalp6T0FvMVVsaFhOakZoVWxOT1pVTjRUVWhoTVZVMlRubE9heTlFYkdoNkwydG1hVVJZVDNWaFZtVnFPVzQ0WW1SR1JsRmxVak5VVVVaRmIwZFVibTVGYWs4ekNqbENMMUZ3VUdSTlUyb3plVTAxYWxoaE0xVmFZelV3T0U1UVVtTktkelo2ZFVsTU53b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9hNGZlZjNkMC0yMzAwLTQ5NTYtYjMzYi1jZjk3NGVlMzBhMDEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLW1pbmltYWwKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1taW5pbWFsIgogICAgdXNlcjogdGVzdC1wb29sLW1pbmltYWwtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtbWluaW1hbApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1taW5pbWFsLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpNFBUb3RWVzJ1bExqQVZuUWNDdXNJRDJLNml1Tmt3aHM2V24xQlNEdVFhYjhBdnNkeXBCMmZmTg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:57:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 645e1764-f56b-4d53-8908-e5e11026be6b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:54:22.757519Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "651"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:57:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b7ce912c-8202-4665-9202-2a9650a587ad
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01/nodes?order_by=created_at_asc&page=1&pool_id=0149b1d8-63d9-4735-8fa6-3256b5a76ddc&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:47.022178Z","error_message":null,"id":"158fc3fe-d8bd-476d-8fc5-64d84224df41","name":"scw-test-pool-minimal-test-pool-minimal-158fc3","pool_id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","provider_id":"scaleway://instance/fr-par-1/44de6ba8-c06f-4dec-9cb3-da3090369984","public_ip_v4":"51.15.132.168","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:57:16.235597Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "670"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:57:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d1d40f4c-5d50-45bc-8daf-5269d97656cc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"86352ce5-787c-449c-9998-79898166204d","type":"not_found"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:57:42.620403142Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "657"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:57:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 40cb3ee1-120b-4f0a-90cd-446dc25e3517
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:57:42.620403Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "654"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:57:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 663819c2-1ed4-4fa5-9b85-9db2561887ae
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:57:42.620403Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "654"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:57:47 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ba847540-0314-413e-a265-3077c5bd6c30
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:57:42.620403Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "654"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:57:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ca7cd166-fbd3-4162-b649-b0087a320b2c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:57:42.620403Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "654"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:57:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 72f4d6b6-9489-4a77-9cd3-f29c616dd461
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:57:42.620403Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "654"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:58:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 59728c21-473e-4238-b0cf-8ea80f29535d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:57:42.620403Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "654"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:58:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6f3d1902-5981-4bc2-9661-fe2afdc2ec32
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.858083Z","id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-minimal","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","default"],"updated_at":"2023-11-07T15:57:42.620403Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "654"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:58:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a567e464-4eca-4a55-9293-8667103e6c35
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/0149b1d8-63d9-4735-8fa6-3256b5a76ddc
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"0149b1d8-63d9-4735-8fa6-3256b5a76ddc","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "125"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:58:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 35c33335-1d64-41d4-9545-bd1d5b2a5c6d
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01?with_additional_resources=true
+    method: DELETE
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:58:18.176852293Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1458"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:58:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dc52d136-46bb-4f26-8dfe-402bde386973
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:58:18.176852Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1455"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:58:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a355dc3d-164a-462b-b674-d6d409a36ea3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://a4fef3d0-2300-4956-b33b-cf974ee30a01.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.386503Z","created_at":"2023-11-07T15:49:53.386503Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.a4fef3d0-2300-4956-b33b-cf974ee30a01.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","ingress":"none","name":"test-pool-minimal","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:58:18.176852Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1455"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:58:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d758f41a-91b2-498f-900c-70d3e1998386
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:58:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c706a60b-de7d-4a9d-8b0c-598f732908ef
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c0076356-a746-4ffa-ba2e-8731fd24cf1f
+    method: DELETE
+  response:
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"c0076356-a746-4ffa-ba2e-8731fd24cf1f","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -6764,7 +5246,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:55:57 GMT
+      - Tue, 07 Nov 2023 15:58:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6774,7 +5256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7468a16c-7976-459b-9370-40139e9864b2
+      - c16e783d-d81d-4642-ba6f-60d9248ce220
     status: 404 Not Found
     code: 404
     duration: ""
@@ -6785,10 +5267,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/422f3a0f-8672-47d0-ba43-e6f70fe573d3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/a4fef3d0-2300-4956-b33b-cf974ee30a01
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"422f3a0f-8672-47d0-ba43-e6f70fe573d3","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"a4fef3d0-2300-4956-b33b-cf974ee30a01","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -6797,7 +5279,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:55:57 GMT
+      - Tue, 07 Nov 2023 15:58:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6807,7 +5289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a62ee659-5789-4785-af1f-1ebe0e8beed4
+      - fd22f596-39ad-4853-af2d-0c68cad0d9ae
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-kubelet-args.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-kubelet-args.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:41 GMT
+      - Tue, 07 Nov 2023 15:49:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,12 +34,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e301e20e-dd66-453a-b65f-abd6eb8be628
+      - 3ec67b84-c7d8-4ce9-8ca4-075f204ebcbf
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-kubelet-args","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"test-pool-kubelet-args","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-18T16:35:44.326008Z","dhcp_enabled":true,"id":"5af82341-c048-4f53-853a-3df5421d10f9","name":"test-pool-kubelet-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:35:44.326008Z","id":"c16fa43b-e195-41c1-a918-26bfcb8118ed","subnet":"172.16.0.0/22","updated_at":"2023-10-18T16:35:44.326008Z"},{"created_at":"2023-10-18T16:35:44.326008Z","id":"1ba012b4-d607-4b55-96f6-9e4f65dd9b4d","subnet":"fd63:256c:45f7:8be8::/64","updated_at":"2023-10-18T16:35:44.326008Z"}],"tags":[],"updated_at":"2023-10-18T16:35:44.326008Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T15:49:55.417041Z","dhcp_enabled":true,"id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","name":"test-pool-kubelet-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:55.417041Z","id":"90143903-6b61-42cb-98b4-948eba8300fb","subnet":"172.16.72.0/22","updated_at":"2023-11-07T15:49:55.417041Z"},{"created_at":"2023-11-07T15:49:55.417041Z","id":"58142691-df80-49ff-ac64-409f0e429805","subnet":"fd5f:519c:6d46:cde2::/64","updated_at":"2023-11-07T15:49:55.417041Z"}],"tags":[],"updated_at":"2023-11-07T15:49:55.417041Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "722"
+      - "706"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:45 GMT
+      - Tue, 07 Nov 2023 15:49:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba9d7dae-79aa-49bc-8224-d7791fda0f3b
+      - 2e2a3072-7cf0-4cae-8d38-b62f7b7db6cf
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5af82341-c048-4f53-853a-3df5421d10f9
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/05fe8b90-1a7d-46b3-92cd-67d49cd1cd54
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:35:44.326008Z","dhcp_enabled":true,"id":"5af82341-c048-4f53-853a-3df5421d10f9","name":"test-pool-kubelet-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:35:44.326008Z","id":"c16fa43b-e195-41c1-a918-26bfcb8118ed","subnet":"172.16.0.0/22","updated_at":"2023-10-18T16:35:44.326008Z"},{"created_at":"2023-10-18T16:35:44.326008Z","id":"1ba012b4-d607-4b55-96f6-9e4f65dd9b4d","subnet":"fd63:256c:45f7:8be8::/64","updated_at":"2023-10-18T16:35:44.326008Z"}],"tags":[],"updated_at":"2023-10-18T16:35:44.326008Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T15:49:55.417041Z","dhcp_enabled":true,"id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","name":"test-pool-kubelet-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:55.417041Z","id":"90143903-6b61-42cb-98b4-948eba8300fb","subnet":"172.16.72.0/22","updated_at":"2023-11-07T15:49:55.417041Z"},{"created_at":"2023-11-07T15:49:55.417041Z","id":"58142691-df80-49ff-ac64-409f0e429805","subnet":"fd5f:519c:6d46:cde2::/64","updated_at":"2023-11-07T15:49:55.417041Z"}],"tags":[],"updated_at":"2023-11-07T15:49:55.417041Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "722"
+      - "706"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:45 GMT
+      - Tue, 07 Nov 2023 15:49:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - abb61fe4-021d-44f1-899d-cccfaef5e654
+      - 220cea02-1d14-4ded-9bf2-a01ff41cc53f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-kubelet-args","description":"","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":"5af82341-c048-4f53-853a-3df5421d10f9"}'
+    body: '{"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","type":"","name":"test-pool-kubelet-args","description":"","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54"}'
     form: {}
     headers:
       Content-Type:
@@ -118,16 +118,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.387747837Z","created_at":"2023-10-18T16:35:45.387747837Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5af82341-c048-4f53-853a-3df5421d10f9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-10-18T16:35:45.400146997Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588333967Z","created_at":"2023-11-07T15:49:56.588333967Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:49:56.604722327Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1519"
+      - "1474"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:45 GMT
+      - Tue, 07 Nov 2023 15:49:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16e80935-014b-478c-9239-36f93756fc07
+      - 7ef43c44-432e-4641-80a3-003169853f5a
     status: 200 OK
     code: 200
     duration: ""
@@ -148,19 +148,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.387748Z","created_at":"2023-10-18T16:35:45.387748Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5af82341-c048-4f53-853a-3df5421d10f9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-10-18T16:35:45.400147Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:49:56.604722Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1510"
+      - "1465"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:45 GMT
+      - Tue, 07 Nov 2023 15:49:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f743f005-c272-4a2a-9bba-e43e8de4fd08
+      - 7e80b604-bd71-4ffc-ae6c-2e5cb3611fc8
     status: 200 OK
     code: 200
     duration: ""
@@ -181,19 +181,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.387748Z","created_at":"2023-10-18T16:35:45.387748Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5af82341-c048-4f53-853a-3df5421d10f9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-10-18T16:35:47.031220Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:49:58.184594Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:50 GMT
+      - Tue, 07 Nov 2023 15:50:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18d17aa1-c714-473c-b106-6af60b133cf8
+      - c79007ba-3212-43f8-8551-c44c50022be9
     status: 200 OK
     code: 200
     duration: ""
@@ -214,19 +214,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.387748Z","created_at":"2023-10-18T16:35:45.387748Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5af82341-c048-4f53-853a-3df5421d10f9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-10-18T16:35:47.031220Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:49:58.184594Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:50 GMT
+      - Tue, 07 Nov 2023 15:50:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9aa5a817-6e60-4b90-bd9f-4601ba933224
+      - 73d440f1-1a56-4b0e-94cb-9b69a73a01c6
     status: 200 OK
     code: 200
     duration: ""
@@ -247,19 +247,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUWHBWTUU1c2IxaEVWRTE2VFZSQmVFNTZSVEpOZWxVd1RteHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEZsRUNpdEtiblpZTDBKeWVrbE9OVU5JT1ZGRWFqTmpNQ3RETlZveFFXVnVXbEo1VWpsR1JrSldja1FyY2xKeFFVTm1kVXR0WlhBNGNUSlpaamRCU2pJeFlpc0tTbTlHY0N0VllYaE5NbVF3YzJoNE0xRnVRazRyVUVKYU9HOWhXVmRhT0VKSGRHOTZWU3RNZFZkbGNVOXhLMHgxT0ZKaWNIbzBSRFJ3Tm5kTFoySkpjUW8wYzBSVVVYUktUR2czVUVsRE1tZEJWMnh0VW5Obk9FeHhlbXhSVWpkTE1ubEtWelpHVUM5emFHSnRiSHBVYUZOSWExRlJPSFZFWkRCVGFqTm5ZeloyQ21GSldtcDNhMDVhZUZSS1QzRjFNRFIxVVV4a05HeEpiME5UTUhOamJuQnhUWEZHTURFNU4xUktPREJOZEdnMlNGVnBObEJVV1dkWmNtazBabXd2T1dRS1NUQTBjV3BJZEVFNGFXZE9iM014VmsxWVdIbzVWbnBIYVRCdlVIcEtNbWh0YUdSVlZVaEtZMlpFVDBVclZDdFlhRzVyY2toNVRFSjBXbGxEUVRabFNRcHhVWEowTlRKdVFUUlhjblZpY2tsTFFVaHJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWklWR3hwTWtSVVVYa3hTQzlwTjJkaU5uQmxlVEIxTlZCS1kweE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJjMVZZU0ZseVExRTBjRkZCYzNFek5DdGhURUpNV2tVcmNVTnlkSFl5YjJ0NVZWTktNMHhJVEhOV1pURmFNbkJJYlFwck1qaExiR3hYZG05MkswWlZNV3RJVHpKQ05tUnBLM293VWtvMGVuQXJiV2M1WkZGblNXcHVZVEZuSzJsSU1td3JiRnBMZEdWQ1dYZEpLMmxyVTJwQkNrOXZjRTl1ZGtacVUxWTNWVmtyV0RGRFpuTXdiRzlyVTBoQ1RDdFFjWG80YTJ3NE1HUjRNR1JXVTJGWlIzUXphV1ozTkVkTGIwTkhVVWx5YzJOU1RrMEtiRWRwVXk5b01HaE5URkIzYUc1bWQyVmlOV2MxV0M5d05ERkNVeloyYUROVlZHUm5aMjR2ZFU5RFUzbE5ka1E0VERNd2RYWkVTRFZtVDI1TGVrSlFiQXA2YlROdWVIUjFZME5SZFVKcVlWaGlWMmxVU0hWUFNGbFBNU3M0UjJoa1EzSmtNVlpGUzBWM1R5c3ZWVXR2UzJvNGFEVlFTRFYzZHpadFdYaGxOVEJyQ2tGcWRFNXFabW8xU2s5S2IwbERUVzFDZVVGa1N5c3pXa1ZSZFdOTVQwWm1Sa2xzV1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzRjNmZmNmM4LTViNDctNDY4MS05ZmM2LWRmZjdiMWI3NDIyNi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wta3ViZWxldC1hcmdzCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wta3ViZWxldC1hcmdzIgogICAgdXNlcjogdGVzdC1wb29sLWt1YmVsZXQtYXJncy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wta3ViZWxldC1hcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiByV1F1MmNaNWFrVkhSVTFJN3VZYlJvUjFOT0xSMTNZeWt1UnhzcFpZdW5lM0lMeDNVcHNyQ0IxQw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXhUa1JyTVU0eGIxaEVWRTE2VFZSRmQwNXFSVEZPUkdzeFRqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFVwWkNtZHlUR1ZWY25abGVXSnZUVUpEVGpKRlNVcEJXVXRRUmxoc2JuWlNTVkJUY3pFeUwxRlZiREl3TVcxUVVtNUxaSGRzTUd4R1JGSkVhRVJHVlZCMGNtRUtTRk5JWlc1clRXdGtUMjVQWXk4d2VWRjRhVkV6VW5Jd1oyVlhTbFJSVGpoMFJWSTBkR0Y2YUdvMFFYWnJXWEUyUzB4NVEzbzNRMG8zTmtaaFkxZEVTUXBwVkZSNFJ5OUNWMGswTldScmJ6aFFVMVF5YVd4T1UyUndLMnBNUlV4U1R6QkVaWGhIUnpaMlkwUjBhemxxY0RrME5GZE9ZWEZOTVdkR1RWa3lZakZLQ2pGWVZVbGlTa053VW5KdldWWTRieXN5VkdWYVVEQnNNRkJ5Y25Wd1drSkZjRVpCYm14SFdFazVVMXBIVEhobGJrVklSRzFqVDBKMU9XUnROa05UVkdVS2NHcFpXV1E0TDBNMldHUndaR2RaWTJ4SU5USm9TVWxaTVhoa2R6SjVTVWhPTVRVMU9XbFlNWFowYUVkS2FtOU9SelJKVURoMloyMTFZWFZFZWxsT1JBcHhSVXRIY21odVlscGpSRmRUV0RjNEswWnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWk9ha1pDZDFsSU1uWjFPRzFuYkVoS01ESXdWRkUyU2swelRrcE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNPVGxSVGtjeGJGTlJkWEpHY0ZneFZGRjVTa2d5TWs1dGVHdzJTQzh4T0U1TWEyRnVTblZPTUhabUwzbHRXR2RzZUFvM1FWQnVRbGszUkVKVmFWcEhZVXMwYnpkaVJXNXJlRll2TDBadlVHRmlSVzlKZUd4WlUycEpVVXhYZVV0aldFcFBNSEZYYmpWSVdIaFVkbWsyVUZZd0NrdEhVbWxZY1VSQ2QxZERibkpGYTBSV05taE5ha1JXT1ZscE9IWnNSQzgzY2xBdlpWSm1WMk5CWmxZek4xTm5kM0Z4T0hWRlZESlRNVkpDZWxJcmRqSUtTSGRVSzNSME4xRjZaa0ZGVWxVNFptTlVPVnBhWlN0TWFUY3ZiakJWVVU5dU5VaFNhbmxDVGtKaGNYVnFNbmQyZG1SdlFWWm5TM0ZDVlZCSWVUVklkQW8wVFU1emVXdzVaRVpSUldjd2FqTlpWalJSTmt0blptNWFMMDA0Y3pJMlFsaENTRXRuUjI1QlRVWnFhQzl3ZERoNFQzSjNiRWRyZGxscU1VZDRZbWRTQ201dFNVVTViRU00Vm1oR1JFZHpSMkpOTVRsS09HSmtVbXRYTkROVVRHcFhlamxXTVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzQ0ZmVjZGIyLWZjNjQtNDJkNy1hN2UyLTk2NDY5MTliZWY3OS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wta3ViZWxldC1hcmdzCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wta3ViZWxldC1hcmdzIgogICAgdXNlcjogdGVzdC1wb29sLWt1YmVsZXQtYXJncy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wta3ViZWxldC1hcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBianNMYzVwZ090UXlLMkprbjRhNUpnSlNnVVBySGY0YzBHRWQwVWFUTmpwRzRNMGVBcWs5bnQ5Wg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2670"
+      - "2668"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:50 GMT
+      - Tue, 07 Nov 2023 15:50:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05a1ef32-ec3f-4c0b-a878-ccf31ae7a921
+      - 0a021b4d-56aa-44c9-93c3-d44de2b3d90b
     status: 200 OK
     code: 200
     duration: ""
@@ -280,19 +280,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.387748Z","created_at":"2023-10-18T16:35:45.387748Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5af82341-c048-4f53-853a-3df5421d10f9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-10-18T16:35:47.031220Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:49:58.184594Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:50 GMT
+      - Tue, 07 Nov 2023 15:50:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,12 +302,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d461fa4b-f5a0-4384-b424-81ac22715f94
+      - 90b2f86a-0f1e-495a-9807-e5301f907aa7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"kubelet_args":{"maxPods":"1337"},"upgrade_policy":null,"zone":"fr-par-1","root_volume_type":"default_volume_type","root_volume_size":null,"public_ip_disabled":false}'
+    body: '{"name":"test-pool-kubelet-args","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"kubelet_args":{"maxPods":"1337"},"zone":"fr-par-1","root_volume_type":"default_volume_type","public_ip_disabled":false}'
     form: {}
     headers:
       Content-Type:
@@ -315,19 +315,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695427Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "707"
+      - "682"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 15:50:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -337,7 +337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a415342-4b66-49ab-b299-76e6f1aeff37
+      - 67d2cb30-827c-442b-8894-5af29c375700
     status: 200 OK
     code: 200
     duration: ""
@@ -348,19 +348,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 15:50:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -370,7 +370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0873104-f8a2-4151-919d-beca1890ad55
+      - 913d664d-6060-43d0-9ade-1279ea3468b2
     status: 200 OK
     code: 200
     duration: ""
@@ -381,19 +381,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:56 GMT
+      - Tue, 07 Nov 2023 15:50:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -403,7 +403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 707a00c4-e141-469a-8854-0d69deb31505
+      - b6621310-17bb-4619-a49f-43eff2d199a1
     status: 200 OK
     code: 200
     duration: ""
@@ -414,19 +414,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:02 GMT
+      - Tue, 07 Nov 2023 15:50:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -436,7 +436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1264cf5-f2b2-4462-a372-07a3984279fd
+      - 88905ce1-7815-47d0-bd2e-f11bd9e3e218
     status: 200 OK
     code: 200
     duration: ""
@@ -447,19 +447,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:07 GMT
+      - Tue, 07 Nov 2023 15:50:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -469,7 +469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19024334-b66d-458e-8b9d-266a84286698
+      - a89c89e7-d2ba-4836-9179-4a3ba965951c
     status: 200 OK
     code: 200
     duration: ""
@@ -480,19 +480,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:12 GMT
+      - Tue, 07 Nov 2023 15:50:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee7fac32-a52d-4570-b6d7-6a2ea39ef452
+      - e4a37098-2389-4c4c-bdff-a22c0a8dff88
     status: 200 OK
     code: 200
     duration: ""
@@ -513,19 +513,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:17 GMT
+      - Tue, 07 Nov 2023 15:50:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9017cc2b-8312-41da-b04b-38bb4634bd4b
+      - 24af6657-0022-4b8a-850f-0055eed9c753
     status: 200 OK
     code: 200
     duration: ""
@@ -546,19 +546,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:22 GMT
+      - Tue, 07 Nov 2023 15:50:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7bd2f34d-7775-4ece-9268-8a02e9b83370
+      - 704e4a9a-b52f-4780-a075-3df59fec13e8
     status: 200 OK
     code: 200
     duration: ""
@@ -579,19 +579,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:28 GMT
+      - Tue, 07 Nov 2023 15:50:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72428e92-83fa-4a53-aa9f-99be4c8875af
+      - b5281c84-64c9-4413-a5f1-81175882bf84
     status: 200 OK
     code: 200
     duration: ""
@@ -612,19 +612,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:33 GMT
+      - Tue, 07 Nov 2023 15:50:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b02440fe-b144-4e31-a478-62bc6a9f53c6
+      - 8ea7e7dd-56e4-4ce7-8b32-6e798bdfdb6a
     status: 200 OK
     code: 200
     duration: ""
@@ -645,19 +645,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:38 GMT
+      - Tue, 07 Nov 2023 15:50:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7dcfe0df-d126-4e2d-a4fe-1c97f1436ca0
+      - db3bbf99-76a3-489a-a038-838b51cf8594
     status: 200 OK
     code: 200
     duration: ""
@@ -678,19 +678,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:43 GMT
+      - Tue, 07 Nov 2023 15:50:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06cac110-a046-4a34-bef9-b7903119618f
+      - 37e8d218-7db6-4471-8388-9b8978fedd4f
     status: 200 OK
     code: 200
     duration: ""
@@ -711,19 +711,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:48 GMT
+      - Tue, 07 Nov 2023 15:51:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49eda6a7-5904-4521-9edd-4a778508bf85
+      - 06ddd1c2-c8da-45cf-9fb2-653bb2074e8a
     status: 200 OK
     code: 200
     duration: ""
@@ -744,19 +744,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:53 GMT
+      - Tue, 07 Nov 2023 15:51:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bbf18e7d-daf8-4f2e-a1a4-6e6b8a2ad538
+      - 5b765ee0-d3a1-430a-8531-a27304daffd8
     status: 200 OK
     code: 200
     duration: ""
@@ -777,19 +777,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:58 GMT
+      - Tue, 07 Nov 2023 15:51:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a09711f-d82f-47a1-806a-075f7cbf37c8
+      - b575fb56-4fe6-46bb-bfab-85ba4b1fdae7
     status: 200 OK
     code: 200
     duration: ""
@@ -810,19 +810,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:03 GMT
+      - Tue, 07 Nov 2023 15:51:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f436c08-e589-4e99-b68b-5185007bed55
+      - 4a59e9b2-0867-42ef-b486-0574755425fa
     status: 200 OK
     code: 200
     duration: ""
@@ -843,19 +843,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:08 GMT
+      - Tue, 07 Nov 2023 15:51:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50def725-adee-48f2-8e74-d21b86d78981
+      - d4640c60-41f0-43a2-8d65-1faa1030558d
     status: 200 OK
     code: 200
     duration: ""
@@ -876,19 +876,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:13 GMT
+      - Tue, 07 Nov 2023 15:51:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c527af9b-ed62-418b-ac69-6c51cae3c851
+      - 448379af-82a0-4416-ad85-47a23727733a
     status: 200 OK
     code: 200
     duration: ""
@@ -909,19 +909,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:18 GMT
+      - Tue, 07 Nov 2023 15:51:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 873bde1a-12b6-4748-b1e1-bc5d5f6a45ce
+      - 52843c6d-ec44-4f15-8755-7ccdfc5fc35a
     status: 200 OK
     code: 200
     duration: ""
@@ -942,19 +942,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:23 GMT
+      - Tue, 07 Nov 2023 15:51:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 384cfc34-bc27-4ae1-b6e3-224d883b0cb7
+      - fe84fecb-7870-4c62-a38a-c45933c732d4
     status: 200 OK
     code: 200
     duration: ""
@@ -975,19 +975,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:28 GMT
+      - Tue, 07 Nov 2023 15:51:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab975a24-6728-4b64-b3af-836246ea26af
+      - a329c866-55d2-47a1-aeed-02b7ff89f3d4
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,19 +1008,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:33 GMT
+      - Tue, 07 Nov 2023 15:51:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74ab4fce-7710-400e-8e87-8fa965f974b2
+      - 4765d512-d9b2-496d-8b0f-f390acfb7c5f
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,19 +1041,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:38 GMT
+      - Tue, 07 Nov 2023 15:51:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01c5fab4-c0ac-4d5e-9adf-441128a0f7c7
+      - d7f3fe36-d408-4a20-b056-3278b24c7804
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,19 +1074,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:43 GMT
+      - Tue, 07 Nov 2023 15:51:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dcd8d16b-f600-48f8-8ee8-b5ceb9c48753
+      - 92608d9b-3255-423d-8b3e-fc87afa18a85
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,19 +1107,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:48 GMT
+      - Tue, 07 Nov 2023 15:52:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1129,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0fa0f02-1391-4ea8-bb59-43f1497d838b
+      - 925c4099-c907-4c90-ac03-878054bc883a
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,19 +1140,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:53 GMT
+      - Tue, 07 Nov 2023 15:52:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a623e27-5b1f-4970-9882-15cdba1eee61
+      - 0caff4d1-32af-4e73-a570-2b2961324488
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,19 +1173,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:58 GMT
+      - Tue, 07 Nov 2023 15:52:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f10c38a3-d272-4381-ae19-cfd40cbb2132
+      - a13cab13-3d12-44f9-8ec9-50d355618a6d
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,19 +1206,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:04 GMT
+      - Tue, 07 Nov 2023 15:52:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0f63862-29fc-4621-901a-e48fe5deb5cf
+      - 7105c49a-fd6a-4238-985f-060eeb4bd701
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,19 +1239,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:09 GMT
+      - Tue, 07 Nov 2023 15:52:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7bd38984-4707-48dc-99e1-aa491c31e8c5
+      - dcebca94-9985-442d-961d-442e4bafbb09
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,19 +1272,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:14 GMT
+      - Tue, 07 Nov 2023 15:52:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c16ef5f-e995-46c4-b21f-697e5a261a15
+      - 33a992b3-0b15-449a-b72c-c7469b3a44b5
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,19 +1305,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:19 GMT
+      - Tue, 07 Nov 2023 15:52:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 706fb776-05b6-4e14-ad2d-251932a7167f
+      - 8a062c63-930e-4983-b60d-ccc5ff2d6b5e
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,19 +1338,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:24 GMT
+      - Tue, 07 Nov 2023 15:52:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1360,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76bcc239-b339-4d61-a3a4-6bbc62ea6643
+      - 9025bbc9-afcf-412e-bbae-4320005418e2
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,19 +1371,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:29 GMT
+      - Tue, 07 Nov 2023 15:52:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1393,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9243eef-b62f-4066-9b15-60ff4021bdad
+      - e6eee115-1770-4972-add7-58fd8c330c9b
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,19 +1404,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:34 GMT
+      - Tue, 07 Nov 2023 15:52:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1426,7 +1426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f529ebc-7b64-4c95-ae8d-383299bb439c
+      - 0654cc68-f2fe-405b-86cb-ebee010c8b99
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,19 +1437,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:39 GMT
+      - Tue, 07 Nov 2023 15:52:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1459,7 +1459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 527730d3-78f7-4ddb-a8ed-b57670edb93e
+      - 6d0a4449-991f-4c3d-adfe-4e0dddf34a95
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,19 +1470,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:44 GMT
+      - Tue, 07 Nov 2023 15:52:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1492,7 +1492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7605fec-d55c-4dcc-93aa-c7e8215066fc
+      - 95680048-fbc6-47b0-802d-e89f7f242ab3
     status: 200 OK
     code: 200
     duration: ""
@@ -1503,19 +1503,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:49 GMT
+      - Tue, 07 Nov 2023 15:53:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0db76d12-ef97-42cd-ba9f-4a0b10291e93
+      - da89c9bf-d421-4a3e-85b0-22705511f0e3
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,19 +1536,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:54 GMT
+      - Tue, 07 Nov 2023 15:53:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1558,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc5c0085-29f5-4fcf-94d3-5447b5f933a5
+      - 9456fc05-343b-4d13-9db0-c05934dd0f64
     status: 200 OK
     code: 200
     duration: ""
@@ -1569,19 +1569,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:59 GMT
+      - Tue, 07 Nov 2023 15:53:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1591,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd2d097d-3f28-4aec-9bca-2f852e7b6189
+      - f370d16c-e007-4a8f-bb5d-abc5bcadc76e
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,19 +1602,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:04 GMT
+      - Tue, 07 Nov 2023 15:53:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6b2cfe5-9e55-4396-acff-e72fe1ef0155
+      - 74adadd0-604e-4fb1-8d38-bebcd79d8130
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,19 +1635,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:09 GMT
+      - Tue, 07 Nov 2023 15:53:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1657,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 702e5135-2014-4210-b598-dcb4f4548fb9
+      - 8fcb416a-66ec-437d-95af-2df2c816b855
     status: 200 OK
     code: 200
     duration: ""
@@ -1668,19 +1668,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:14 GMT
+      - Tue, 07 Nov 2023 15:53:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1690,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5212cf12-66e8-4344-b7c9-ad47cddd16ba
+      - 36f7911c-a793-42fd-98c1-60649c13678c
     status: 200 OK
     code: 200
     duration: ""
@@ -1701,19 +1701,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:19 GMT
+      - Tue, 07 Nov 2023 15:53:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1723,7 +1723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7281e01-fd5a-48b2-9b15-67fbd354b3ce
+      - bdbd0397-1e3b-4472-ae3f-811bfe2b7dc9
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,19 +1734,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:24 GMT
+      - Tue, 07 Nov 2023 15:53:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1756,7 +1756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2bc35cd8-3e76-44b3-b72a-c17bc0a5a98c
+      - 2102d2e7-99a0-4c94-b4ef-4a9951be0793
     status: 200 OK
     code: 200
     duration: ""
@@ -1767,19 +1767,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:29 GMT
+      - Tue, 07 Nov 2023 15:53:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1789,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1dc323f-974c-4ee2-ae8d-2fffa078ebfc
+      - 8d20507a-4549-498c-8147-89c078dceb6b
     status: 200 OK
     code: 200
     duration: ""
@@ -1800,19 +1800,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:34 GMT
+      - Tue, 07 Nov 2023 15:53:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1822,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e7edfad-ba71-4f9e-b9bc-8c0a62ea2800
+      - 3278fc00-849d-4a41-b76b-a385de4f21b1
     status: 200 OK
     code: 200
     duration: ""
@@ -1833,19 +1833,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:40 GMT
+      - Tue, 07 Nov 2023 15:53:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1855,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2bea3b9-edba-4e0d-958c-d90f42f25dc0
+      - d0900199-1f82-47ac-a0e9-5fcffe0d8ea8
     status: 200 OK
     code: 200
     duration: ""
@@ -1866,19 +1866,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:45 GMT
+      - Tue, 07 Nov 2023 15:53:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1888,7 +1888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c603c20b-1f3d-462d-bae1-22930b4fb6c6
+      - db446e4d-7571-4462-8600-6f4c0cc1cb57
     status: 200 OK
     code: 200
     duration: ""
@@ -1899,19 +1899,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:50 GMT
+      - Tue, 07 Nov 2023 15:54:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1921,7 +1921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5d6c737-29ce-468f-be71-08e22a39d3d0
+      - 568c13e3-5ec4-4e0b-8aa8-f72c0c17e755
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,19 +1932,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:55 GMT
+      - Tue, 07 Nov 2023 15:54:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1954,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df39f702-5aa5-40d1-9434-d119d0270ab5
+      - 20756832-41c6-4866-b97f-8c0a954d92f5
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,19 +1965,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:00 GMT
+      - Tue, 07 Nov 2023 15:54:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1987,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3158d86d-b6ca-4a19-ae55-f8ba52ee595e
+      - 5a256169-2c6b-4b9d-92da-93c285a63dea
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,19 +1998,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:05 GMT
+      - Tue, 07 Nov 2023 15:54:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2020,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - addc9323-16a1-436f-9e4c-c50169812916
+      - 40017f0c-685c-486f-bdc4-b3363da60de3
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,19 +2031,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:10 GMT
+      - Tue, 07 Nov 2023 15:54:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2053,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a44719d0-6eb4-40c9-9a9c-a60c6bb6d3d6
+      - 6e1cc0e7-7a92-4837-8fc0-41a83ded40a8
     status: 200 OK
     code: 200
     duration: ""
@@ -2064,19 +2064,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:15 GMT
+      - Tue, 07 Nov 2023 15:54:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2086,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24e4bb29-5e21-43f9-8fff-2ae775ef3ee9
+      - f5c16cef-724f-46c3-9323-c0e8e3416859
     status: 200 OK
     code: 200
     duration: ""
@@ -2097,19 +2097,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:20 GMT
+      - Tue, 07 Nov 2023 15:54:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2119,7 +2119,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 652c4180-4a72-4263-9420-07133d4f4a0d
+      - c017cbfb-b5ef-4857-abbf-880b9127163e
     status: 200 OK
     code: 200
     duration: ""
@@ -2130,19 +2130,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:25 GMT
+      - Tue, 07 Nov 2023 15:54:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2152,7 +2152,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4394c860-99ec-4d91-97ce-cf12dec15e29
+      - 34bcd051-35e9-4f82-8c88-c44e3a9d7c09
     status: 200 OK
     code: 200
     duration: ""
@@ -2163,19 +2163,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:30 GMT
+      - Tue, 07 Nov 2023 15:54:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2185,7 +2185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be5e8e2e-7916-47ee-8640-b5dc1a172eb7
+      - 9c8196f9-d169-4389-bead-94d8d03e19c0
     status: 200 OK
     code: 200
     duration: ""
@@ -2196,19 +2196,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:35 GMT
+      - Tue, 07 Nov 2023 15:54:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2218,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b78920a9-a3b8-498e-b1b9-b2854323ee7c
+      - 7ee5a95a-777e-4f58-aafd-e5e18ad02a63
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,19 +2229,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:50:02.818695Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:40 GMT
+      - Tue, 07 Nov 2023 15:54:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2251,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a968029e-6c3c-489d-883d-a9b72c81221b
+      - 7cf275e7-f5b0-4289-809b-3ab87eaa1eeb
     status: 200 OK
     code: 200
     duration: ""
@@ -2262,19 +2262,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:54:55.639882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "677"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:45 GMT
+      - Tue, 07 Nov 2023 15:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2284,7 +2284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2cda6028-6fce-4040-a50f-c91c44657345
+      - 4ffd69b6-69ba-433b-b349-d607c48b351a
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,19 +2295,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:51:04.519958Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "704"
+      - "1462"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:50 GMT
+      - Tue, 07 Nov 2023 15:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2317,7 +2317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a47297ac-5670-407d-93b2-ba8ce97cbdbe
+      - d5c569c1-f9ef-4e74-883b-cfd1caa3f9f2
     status: 200 OK
     code: 200
     duration: ""
@@ -2328,19 +2328,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:54:55.639882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "677"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:55 GMT
+      - Tue, 07 Nov 2023 15:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2350,7 +2350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dde7b966-7a07-4953-ba3a-74fa1da2ed38
+      - 7836606f-975d-4cd0-99b7-aa2dc8fd577c
     status: 200 OK
     code: 200
     duration: ""
@@ -2361,19 +2361,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79/nodes?order_by=created_at_asc&page=1&pool_id=d2df0d2c-c86b-461f-a9f9-e4a197ce22f2&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:20.188708Z","error_message":null,"id":"d2f0e877-833c-4400-a3ae-413e3b6eef96","name":"scw-test-pool-kubelet-test-pool-kubelet-d2f0e8","pool_id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","provider_id":"scaleway://instance/fr-par-1/407e7ae9-a178-47dc-8435-81df980a7ed7","public_ip_v4":"51.158.116.58","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:55.620609Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "704"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:00 GMT
+      - Tue, 07 Nov 2023 15:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2383,7 +2383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6c2b6fd-9af0-40fe-9c8b-dbb4ff75292a
+      - eb6b3e10-66cf-4bea-8567-aae60ad565ed
     status: 200 OK
     code: 200
     duration: ""
@@ -2394,19 +2394,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:51:04.519958Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "704"
+      - "1462"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:05 GMT
+      - Tue, 07 Nov 2023 15:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2416,7 +2416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9bc1a6fb-e58f-4ba8-a43f-1715e69faac5
+      - 8c2f41e0-1258-46a1-97a7-6980b5ebc50e
     status: 200 OK
     code: 200
     duration: ""
@@ -2427,19 +2427,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:54:55.639882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "704"
+      - "677"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:11 GMT
+      - Tue, 07 Nov 2023 15:54:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2449,7 +2449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a86de990-0d9e-4bb3-bdfd-bf1e3fe877e6
+      - e7afadba-8e2f-48ae-9b8f-74320c221abb
     status: 200 OK
     code: 200
     duration: ""
@@ -2460,1860 +2460,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/05fe8b90-1a7d-46b3-92cd-67d49cd1cd54
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f6c23206-5526-4499-a50f-6032970b9746
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 65d61b40-3c23-4442-ae75-b4ffd530c9c1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 803986ce-4c5b-4da2-8150-c79539dd2eaa
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 49e6b84d-2d0d-419f-899e-4048ada79e83
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 55ee30fa-99ed-4a11-aeda-c389299104c2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 47e8bc2a-0705-46e0-a424-ec090235ce7a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2bc154c9-4727-4dc9-b5ae-0d9e13c45275
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ac33b76d-08f1-4ea8-b2c0-92f7adc9cc6a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a8925ec6-b8a0-4f4c-9fe0-310223d09f77
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a4cfbd76-0fdd-4d4f-8b05-a05434895296
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 624bd7a1-6e52-4e14-b63b-daaf1231b6bd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ae807936-989e-4843-b8a5-3e1f95019c75
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fd3e6291-386a-4de7-8385-31a3adcd4994
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 40f79b1f-1ffb-49bf-b34f-943a2fc8af0a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fd9571f9-a291-4e24-b8ce-db9809a5e088
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 77c15440-c3bf-4068-a7eb-140c6564c35e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 12340ca4-0df8-45cb-8dbb-d9e6046258b3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d398b290-5948-45bd-a54c-cf29945b68f5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e342428d-2746-42c9-afc2-6edfdfd49726
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f8a8e231-2cfb-42be-bc87-5c74c411e619
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b76215bf-ff76-4a71-b09f-0a5b11747ac5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 55360466-0cca-49c1-8c9e-cc4bdaef4497
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 825a4c79-81f9-4338-9727-d4a56e05ebf2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - edc1a225-dd86-46bb-8e4e-cdd3961fc0c1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 875f52b3-47ca-412f-95e9-40a645e956ad
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1a60a6a4-fbb5-42fd-a282-be7a6e360ee1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 78f7661c-aaba-447a-b0e9-063c64451cb3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e17dca40-9dfc-4ac4-975c-2a340a7fe5a6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:35:50.809901Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "704"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c5370daf-1e3f-49d2-8a3f-37be59dc2e2d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:43:38.328270Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "702"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4b212166-5ee6-4df9-b3e9-9cfdf302a89c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.387748Z","created_at":"2023-10-18T16:35:45.387748Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5af82341-c048-4f53-853a-3df5421d10f9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-10-18T16:37:11.350616Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1507"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - df197996-5efd-48a7-aef8-5c1ff00ebf43
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:43:38.328270Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "702"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a95e606e-66b0-4d73-895a-5849425f482d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226/nodes?order_by=created_at_asc&page=1&pool_id=146e381b-b865-42f1-8d77-72fe68993ee1&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:38:41.119851Z","error_message":null,"id":"34d13a4f-a42a-4e74-af47-218d67034f76","name":"scw-test-pool-kubelet-test-pool-kubelet-34d13a","pool_id":"146e381b-b865-42f1-8d77-72fe68993ee1","provider_id":"scaleway://instance/fr-par-1/11a29d81-9d44-4626-ad74-61fd9fe0fe6f","public_ip_v4":"163.172.141.90","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:43:38.313909Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "659"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bb513a9f-5426-41e0-9f94-f56c6b4f28ae
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.387748Z","created_at":"2023-10-18T16:35:45.387748Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5af82341-c048-4f53-853a-3df5421d10f9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-10-18T16:37:11.350616Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1507"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 329da46b-ed7c-491c-8453-ac0c5a1b788a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:43:38.328270Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "702"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9242a0ba-23b1-49ee-b843-8943eddbadab
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5af82341-c048-4f53-853a-3df5421d10f9
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-18T16:35:44.326008Z","dhcp_enabled":true,"id":"5af82341-c048-4f53-853a-3df5421d10f9","name":"test-pool-kubelet-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:35:44.326008Z","id":"c16fa43b-e195-41c1-a918-26bfcb8118ed","subnet":"172.16.0.0/22","updated_at":"2023-10-18T16:35:44.326008Z"},{"created_at":"2023-10-18T16:35:44.326008Z","id":"1ba012b4-d607-4b55-96f6-9e4f65dd9b4d","subnet":"fd63:256c:45f7:8be8::/64","updated_at":"2023-10-18T16:35:44.326008Z"}],"tags":[],"updated_at":"2023-10-18T16:35:44.326008Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "722"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bbaa2abb-ee63-4506-90c3-5819e2d68bae
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.387748Z","created_at":"2023-10-18T16:35:45.387748Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5af82341-c048-4f53-853a-3df5421d10f9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-10-18T16:37:11.350616Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1507"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d5925d1b-bbaa-435f-beae-6e45021b6f98
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUWHBWTUU1c2IxaEVWRTE2VFZSQmVFNTZSVEpOZWxVd1RteHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEZsRUNpdEtiblpZTDBKeWVrbE9OVU5JT1ZGRWFqTmpNQ3RETlZveFFXVnVXbEo1VWpsR1JrSldja1FyY2xKeFFVTm1kVXR0WlhBNGNUSlpaamRCU2pJeFlpc0tTbTlHY0N0VllYaE5NbVF3YzJoNE0xRnVRazRyVUVKYU9HOWhXVmRhT0VKSGRHOTZWU3RNZFZkbGNVOXhLMHgxT0ZKaWNIbzBSRFJ3Tm5kTFoySkpjUW8wYzBSVVVYUktUR2czVUVsRE1tZEJWMnh0VW5Obk9FeHhlbXhSVWpkTE1ubEtWelpHVUM5emFHSnRiSHBVYUZOSWExRlJPSFZFWkRCVGFqTm5ZeloyQ21GSldtcDNhMDVhZUZSS1QzRjFNRFIxVVV4a05HeEpiME5UTUhOamJuQnhUWEZHTURFNU4xUktPREJOZEdnMlNGVnBObEJVV1dkWmNtazBabXd2T1dRS1NUQTBjV3BJZEVFNGFXZE9iM014VmsxWVdIbzVWbnBIYVRCdlVIcEtNbWh0YUdSVlZVaEtZMlpFVDBVclZDdFlhRzVyY2toNVRFSjBXbGxEUVRabFNRcHhVWEowTlRKdVFUUlhjblZpY2tsTFFVaHJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWklWR3hwTWtSVVVYa3hTQzlwTjJkaU5uQmxlVEIxTlZCS1kweE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJjMVZZU0ZseVExRTBjRkZCYzNFek5DdGhURUpNV2tVcmNVTnlkSFl5YjJ0NVZWTktNMHhJVEhOV1pURmFNbkJJYlFwck1qaExiR3hYZG05MkswWlZNV3RJVHpKQ05tUnBLM293VWtvMGVuQXJiV2M1WkZGblNXcHVZVEZuSzJsSU1td3JiRnBMZEdWQ1dYZEpLMmxyVTJwQkNrOXZjRTl1ZGtacVUxWTNWVmtyV0RGRFpuTXdiRzlyVTBoQ1RDdFFjWG80YTJ3NE1HUjRNR1JXVTJGWlIzUXphV1ozTkVkTGIwTkhVVWx5YzJOU1RrMEtiRWRwVXk5b01HaE5URkIzYUc1bWQyVmlOV2MxV0M5d05ERkNVeloyYUROVlZHUm5aMjR2ZFU5RFUzbE5ka1E0VERNd2RYWkVTRFZtVDI1TGVrSlFiQXA2YlROdWVIUjFZME5SZFVKcVlWaGlWMmxVU0hWUFNGbFBNU3M0UjJoa1EzSmtNVlpGUzBWM1R5c3ZWVXR2UzJvNGFEVlFTRFYzZHpadFdYaGxOVEJyQ2tGcWRFNXFabW8xU2s5S2IwbERUVzFDZVVGa1N5c3pXa1ZSZFdOTVQwWm1Sa2xzV1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzRjNmZmNmM4LTViNDctNDY4MS05ZmM2LWRmZjdiMWI3NDIyNi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wta3ViZWxldC1hcmdzCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wta3ViZWxldC1hcmdzIgogICAgdXNlcjogdGVzdC1wb29sLWt1YmVsZXQtYXJncy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wta3ViZWxldC1hcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiByV1F1MmNaNWFrVkhSVTFJN3VZYlJvUjFOT0xSMTNZeWt1UnhzcFpZdW5lM0lMeDNVcHNyQ0IxQw==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2670"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9e39d5cd-e95e-4d44-a3d5-16ae5701c895
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:43:38.328270Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "702"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - da022b1a-8669-4681-a6de-c5d2b54f0263
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226/nodes?order_by=created_at_asc&page=1&pool_id=146e381b-b865-42f1-8d77-72fe68993ee1&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:38:41.119851Z","error_message":null,"id":"34d13a4f-a42a-4e74-af47-218d67034f76","name":"scw-test-pool-kubelet-test-pool-kubelet-34d13a","pool_id":"146e381b-b865-42f1-8d77-72fe68993ee1","provider_id":"scaleway://instance/fr-par-1/11a29d81-9d44-4626-ad74-61fd9fe0fe6f","public_ip_v4":"163.172.141.90","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:43:38.313909Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "659"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8829f1fd-5370-45db-8493-144e1cd1fb4e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5af82341-c048-4f53-853a-3df5421d10f9
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-18T16:35:44.326008Z","dhcp_enabled":true,"id":"5af82341-c048-4f53-853a-3df5421d10f9","name":"test-pool-kubelet-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:35:44.326008Z","id":"c16fa43b-e195-41c1-a918-26bfcb8118ed","subnet":"172.16.0.0/22","updated_at":"2023-10-18T16:35:44.326008Z"},{"created_at":"2023-10-18T16:35:44.326008Z","id":"1ba012b4-d607-4b55-96f6-9e4f65dd9b4d","subnet":"fd63:256c:45f7:8be8::/64","updated_at":"2023-10-18T16:35:44.326008Z"}],"tags":[],"updated_at":"2023-10-18T16:35:44.326008Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "722"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d67df46f-1afc-4b0a-a647-a20cabd1e1d2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.387748Z","created_at":"2023-10-18T16:35:45.387748Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5af82341-c048-4f53-853a-3df5421d10f9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-10-18T16:37:11.350616Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1507"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5008f2a1-1ed6-4ab0-a41e-5a037bc5af4b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUWHBWTUU1c2IxaEVWRTE2VFZSQmVFNTZSVEpOZWxVd1RteHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEZsRUNpdEtiblpZTDBKeWVrbE9OVU5JT1ZGRWFqTmpNQ3RETlZveFFXVnVXbEo1VWpsR1JrSldja1FyY2xKeFFVTm1kVXR0WlhBNGNUSlpaamRCU2pJeFlpc0tTbTlHY0N0VllYaE5NbVF3YzJoNE0xRnVRazRyVUVKYU9HOWhXVmRhT0VKSGRHOTZWU3RNZFZkbGNVOXhLMHgxT0ZKaWNIbzBSRFJ3Tm5kTFoySkpjUW8wYzBSVVVYUktUR2czVUVsRE1tZEJWMnh0VW5Obk9FeHhlbXhSVWpkTE1ubEtWelpHVUM5emFHSnRiSHBVYUZOSWExRlJPSFZFWkRCVGFqTm5ZeloyQ21GSldtcDNhMDVhZUZSS1QzRjFNRFIxVVV4a05HeEpiME5UTUhOamJuQnhUWEZHTURFNU4xUktPREJOZEdnMlNGVnBObEJVV1dkWmNtazBabXd2T1dRS1NUQTBjV3BJZEVFNGFXZE9iM014VmsxWVdIbzVWbnBIYVRCdlVIcEtNbWh0YUdSVlZVaEtZMlpFVDBVclZDdFlhRzVyY2toNVRFSjBXbGxEUVRabFNRcHhVWEowTlRKdVFUUlhjblZpY2tsTFFVaHJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWklWR3hwTWtSVVVYa3hTQzlwTjJkaU5uQmxlVEIxTlZCS1kweE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJjMVZZU0ZseVExRTBjRkZCYzNFek5DdGhURUpNV2tVcmNVTnlkSFl5YjJ0NVZWTktNMHhJVEhOV1pURmFNbkJJYlFwck1qaExiR3hYZG05MkswWlZNV3RJVHpKQ05tUnBLM293VWtvMGVuQXJiV2M1WkZGblNXcHVZVEZuSzJsSU1td3JiRnBMZEdWQ1dYZEpLMmxyVTJwQkNrOXZjRTl1ZGtacVUxWTNWVmtyV0RGRFpuTXdiRzlyVTBoQ1RDdFFjWG80YTJ3NE1HUjRNR1JXVTJGWlIzUXphV1ozTkVkTGIwTkhVVWx5YzJOU1RrMEtiRWRwVXk5b01HaE5URkIzYUc1bWQyVmlOV2MxV0M5d05ERkNVeloyYUROVlZHUm5aMjR2ZFU5RFUzbE5ka1E0VERNd2RYWkVTRFZtVDI1TGVrSlFiQXA2YlROdWVIUjFZME5SZFVKcVlWaGlWMmxVU0hWUFNGbFBNU3M0UjJoa1EzSmtNVlpGUzBWM1R5c3ZWVXR2UzJvNGFEVlFTRFYzZHpadFdYaGxOVEJyQ2tGcWRFNXFabW8xU2s5S2IwbERUVzFDZVVGa1N5c3pXa1ZSZFdOTVQwWm1Sa2xzV1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzRjNmZmNmM4LTViNDctNDY4MS05ZmM2LWRmZjdiMWI3NDIyNi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wta3ViZWxldC1hcmdzCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wta3ViZWxldC1hcmdzIgogICAgdXNlcjogdGVzdC1wb29sLWt1YmVsZXQtYXJncy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wta3ViZWxldC1hcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiByV1F1MmNaNWFrVkhSVTFJN3VZYlJvUjFOT0xSMTNZeWt1UnhzcFpZdW5lM0lMeDNVcHNyQ0IxQw==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2670"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9b172985-d143-411d-bc7e-09ab42ee8575
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:43:38.328270Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "702"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 12fba21d-218d-48cf-b71a-d191d72c0013
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226/nodes?order_by=created_at_asc&page=1&pool_id=146e381b-b865-42f1-8d77-72fe68993ee1&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:38:41.119851Z","error_message":null,"id":"34d13a4f-a42a-4e74-af47-218d67034f76","name":"scw-test-pool-kubelet-test-pool-kubelet-34d13a","pool_id":"146e381b-b865-42f1-8d77-72fe68993ee1","provider_id":"scaleway://instance/fr-par-1/11a29d81-9d44-4626-ad74-61fd9fe0fe6f","public_ip_v4":"163.172.141.90","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:43:38.313909Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "659"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d4d3cdb0-1c36-4ca4-9135-94b7e9b2b624
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"autoscaling":null,"size":null,"min_size":null,"max_size":null,"autohealing":null,"tags":null,"kubelet_args":{"maxPods":"50"},"upgrade_policy":{"max_unavailable":null,"max_surge":null}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: PATCH
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:43:44.996062436Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "703"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e3f96761-70ec-4a2f-844b-fada94082d90
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:43:44.996062Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "700"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8e6f27a2-450e-4134-929e-e1f0389823cc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:43:44.996062Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "700"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f44cfbd1-0453-4c28-b5c6-1b752811dfce
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226/nodes?order_by=created_at_asc&page=1&pool_id=146e381b-b865-42f1-8d77-72fe68993ee1&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:38:41.119851Z","error_message":null,"id":"34d13a4f-a42a-4e74-af47-218d67034f76","name":"scw-test-pool-kubelet-test-pool-kubelet-34d13a","pool_id":"146e381b-b865-42f1-8d77-72fe68993ee1","provider_id":"scaleway://instance/fr-par-1/11a29d81-9d44-4626-ad74-61fd9fe0fe6f","public_ip_v4":"163.172.141.90","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:43:38.313909Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "659"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cbe5e2db-3d86-4f1a-992a-7d7aa13e74f3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.387748Z","created_at":"2023-10-18T16:35:45.387748Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5af82341-c048-4f53-853a-3df5421d10f9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-10-18T16:37:11.350616Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1507"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 20ba7acd-24cf-4a9d-976e-71d4f368ed04
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:43:44.996062Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "700"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2e0f41d4-bbca-4374-9066-32971f33cb60
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5af82341-c048-4f53-853a-3df5421d10f9
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-18T16:35:44.326008Z","dhcp_enabled":true,"id":"5af82341-c048-4f53-853a-3df5421d10f9","name":"test-pool-kubelet-args","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:35:44.326008Z","id":"c16fa43b-e195-41c1-a918-26bfcb8118ed","subnet":"172.16.0.0/22","updated_at":"2023-10-18T16:35:44.326008Z"},{"created_at":"2023-10-18T16:35:44.326008Z","id":"1ba012b4-d607-4b55-96f6-9e4f65dd9b4d","subnet":"fd63:256c:45f7:8be8::/64","updated_at":"2023-10-18T16:35:44.326008Z"}],"tags":[],"updated_at":"2023-10-18T16:35:44.326008Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "722"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 06ef70a6-ee0d-4e54-9b61-c48540ec6a7b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.387748Z","created_at":"2023-10-18T16:35:45.387748Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5af82341-c048-4f53-853a-3df5421d10f9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-10-18T16:37:11.350616Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1507"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6130815d-8430-4afb-88d6-ce98a162532a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUWHBWTUU1c2IxaEVWRTE2VFZSQmVFNTZSVEpOZWxVd1RteHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEZsRUNpdEtiblpZTDBKeWVrbE9OVU5JT1ZGRWFqTmpNQ3RETlZveFFXVnVXbEo1VWpsR1JrSldja1FyY2xKeFFVTm1kVXR0WlhBNGNUSlpaamRCU2pJeFlpc0tTbTlHY0N0VllYaE5NbVF3YzJoNE0xRnVRazRyVUVKYU9HOWhXVmRhT0VKSGRHOTZWU3RNZFZkbGNVOXhLMHgxT0ZKaWNIbzBSRFJ3Tm5kTFoySkpjUW8wYzBSVVVYUktUR2czVUVsRE1tZEJWMnh0VW5Obk9FeHhlbXhSVWpkTE1ubEtWelpHVUM5emFHSnRiSHBVYUZOSWExRlJPSFZFWkRCVGFqTm5ZeloyQ21GSldtcDNhMDVhZUZSS1QzRjFNRFIxVVV4a05HeEpiME5UTUhOamJuQnhUWEZHTURFNU4xUktPREJOZEdnMlNGVnBObEJVV1dkWmNtazBabXd2T1dRS1NUQTBjV3BJZEVFNGFXZE9iM014VmsxWVdIbzVWbnBIYVRCdlVIcEtNbWh0YUdSVlZVaEtZMlpFVDBVclZDdFlhRzVyY2toNVRFSjBXbGxEUVRabFNRcHhVWEowTlRKdVFUUlhjblZpY2tsTFFVaHJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWklWR3hwTWtSVVVYa3hTQzlwTjJkaU5uQmxlVEIxTlZCS1kweE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJjMVZZU0ZseVExRTBjRkZCYzNFek5DdGhURUpNV2tVcmNVTnlkSFl5YjJ0NVZWTktNMHhJVEhOV1pURmFNbkJJYlFwck1qaExiR3hYZG05MkswWlZNV3RJVHpKQ05tUnBLM293VWtvMGVuQXJiV2M1WkZGblNXcHVZVEZuSzJsSU1td3JiRnBMZEdWQ1dYZEpLMmxyVTJwQkNrOXZjRTl1ZGtacVUxWTNWVmtyV0RGRFpuTXdiRzlyVTBoQ1RDdFFjWG80YTJ3NE1HUjRNR1JXVTJGWlIzUXphV1ozTkVkTGIwTkhVVWx5YzJOU1RrMEtiRWRwVXk5b01HaE5URkIzYUc1bWQyVmlOV2MxV0M5d05ERkNVeloyYUROVlZHUm5aMjR2ZFU5RFUzbE5ka1E0VERNd2RYWkVTRFZtVDI1TGVrSlFiQXA2YlROdWVIUjFZME5SZFVKcVlWaGlWMmxVU0hWUFNGbFBNU3M0UjJoa1EzSmtNVlpGUzBWM1R5c3ZWVXR2UzJvNGFEVlFTRFYzZHpadFdYaGxOVEJyQ2tGcWRFNXFabW8xU2s5S2IwbERUVzFDZVVGa1N5c3pXa1ZSZFdOTVQwWm1Sa2xzV1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzRjNmZmNmM4LTViNDctNDY4MS05ZmM2LWRmZjdiMWI3NDIyNi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wta3ViZWxldC1hcmdzCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wta3ViZWxldC1hcmdzIgogICAgdXNlcjogdGVzdC1wb29sLWt1YmVsZXQtYXJncy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wta3ViZWxldC1hcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiByV1F1MmNaNWFrVkhSVTFJN3VZYlJvUjFOT0xSMTNZeWt1UnhzcFpZdW5lM0lMeDNVcHNyQ0IxQw==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2670"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0a7befe2-370c-4cde-b789-4c264376b344
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:43:44.996062Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "700"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1bfc22c5-2494-4bbd-8a70-7d87553383e7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226/nodes?order_by=created_at_asc&page=1&pool_id=146e381b-b865-42f1-8d77-72fe68993ee1&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:38:41.119851Z","error_message":null,"id":"34d13a4f-a42a-4e74-af47-218d67034f76","name":"scw-test-pool-kubelet-test-pool-kubelet-34d13a","pool_id":"146e381b-b865-42f1-8d77-72fe68993ee1","provider_id":"scaleway://instance/fr-par-1/11a29d81-9d44-4626-ad74-61fd9fe0fe6f","public_ip_v4":"163.172.141.90","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:43:45.710493Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "689"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d32751e6-e7e5-419a-86dd-d3786406cae6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/146e381b-b865-42f1-8d77-72fe68993ee1
-    method: DELETE
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","container_runtime":"containerd","created_at":"2023-10-18T16:35:50.800572Z","id":"146e381b-b865-42f1-8d77-72fe68993ee1","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-10-18T16:43:47.033897327Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-07T15:49:55.417041Z","dhcp_enabled":true,"id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","name":"test-pool-kubelet-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:55.417041Z","id":"90143903-6b61-42cb-98b4-948eba8300fb","subnet":"172.16.72.0/22","updated_at":"2023-11-07T15:49:55.417041Z"},{"created_at":"2023-11-07T15:49:55.417041Z","id":"58142691-df80-49ff-ac64-409f0e429805","subnet":"fd5f:519c:6d46:cde2::/64","updated_at":"2023-11-07T15:49:55.417041Z"}],"tags":[],"updated_at":"2023-11-07T15:49:55.417041Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "706"
@@ -4322,7 +2472,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:47 GMT
+      - Tue, 07 Nov 2023 15:54:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4332,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eeb44f7f-b3fd-4bbd-acd5-88ba2c4be90f
+      - 74d7a251-30fe-4782-b809-543b49a24e7f
     status: 200 OK
     code: 200
     duration: ""
@@ -4343,19 +2493,681 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:51:04.519958Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1462"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:54:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 818d4d71-6cb6-4487-a67e-c18d47e76346
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXhUa1JyTVU0eGIxaEVWRTE2VFZSRmQwNXFSVEZPUkdzeFRqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFVwWkNtZHlUR1ZWY25abGVXSnZUVUpEVGpKRlNVcEJXVXRRUmxoc2JuWlNTVkJUY3pFeUwxRlZiREl3TVcxUVVtNUxaSGRzTUd4R1JGSkVhRVJHVlZCMGNtRUtTRk5JWlc1clRXdGtUMjVQWXk4d2VWRjRhVkV6VW5Jd1oyVlhTbFJSVGpoMFJWSTBkR0Y2YUdvMFFYWnJXWEUyUzB4NVEzbzNRMG8zTmtaaFkxZEVTUXBwVkZSNFJ5OUNWMGswTldScmJ6aFFVMVF5YVd4T1UyUndLMnBNUlV4U1R6QkVaWGhIUnpaMlkwUjBhemxxY0RrME5GZE9ZWEZOTVdkR1RWa3lZakZLQ2pGWVZVbGlTa053VW5KdldWWTRieXN5VkdWYVVEQnNNRkJ5Y25Wd1drSkZjRVpCYm14SFdFazVVMXBIVEhobGJrVklSRzFqVDBKMU9XUnROa05UVkdVS2NHcFpXV1E0TDBNMldHUndaR2RaWTJ4SU5USm9TVWxaTVhoa2R6SjVTVWhPTVRVMU9XbFlNWFowYUVkS2FtOU9SelJKVURoMloyMTFZWFZFZWxsT1JBcHhSVXRIY21odVlscGpSRmRUV0RjNEswWnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWk9ha1pDZDFsSU1uWjFPRzFuYkVoS01ESXdWRkUyU2swelRrcE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNPVGxSVGtjeGJGTlJkWEpHY0ZneFZGRjVTa2d5TWs1dGVHdzJTQzh4T0U1TWEyRnVTblZPTUhabUwzbHRXR2RzZUFvM1FWQnVRbGszUkVKVmFWcEhZVXMwYnpkaVJXNXJlRll2TDBadlVHRmlSVzlKZUd4WlUycEpVVXhYZVV0aldFcFBNSEZYYmpWSVdIaFVkbWsyVUZZd0NrdEhVbWxZY1VSQ2QxZERibkpGYTBSV05taE5ha1JXT1ZscE9IWnNSQzgzY2xBdlpWSm1WMk5CWmxZek4xTm5kM0Z4T0hWRlZESlRNVkpDZWxJcmRqSUtTSGRVSzNSME4xRjZaa0ZGVWxVNFptTlVPVnBhWlN0TWFUY3ZiakJWVVU5dU5VaFNhbmxDVGtKaGNYVnFNbmQyZG1SdlFWWm5TM0ZDVlZCSWVUVklkQW8wVFU1emVXdzVaRVpSUldjd2FqTlpWalJSTmt0blptNWFMMDA0Y3pJMlFsaENTRXRuUjI1QlRVWnFhQzl3ZERoNFQzSjNiRWRyZGxscU1VZDRZbWRTQ201dFNVVTViRU00Vm1oR1JFZHpSMkpOTVRsS09HSmtVbXRYTkROVVRHcFhlamxXTVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzQ0ZmVjZGIyLWZjNjQtNDJkNy1hN2UyLTk2NDY5MTliZWY3OS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wta3ViZWxldC1hcmdzCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wta3ViZWxldC1hcmdzIgogICAgdXNlcjogdGVzdC1wb29sLWt1YmVsZXQtYXJncy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wta3ViZWxldC1hcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBianNMYzVwZ090UXlLMkprbjRhNUpnSlNnVVBySGY0YzBHRWQwVWFUTmpwRzRNMGVBcWs5bnQ5Wg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2668"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:54:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b75f9104-d20f-4a94-ae1c-6abd1f84b518
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:54:55.639882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "677"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:54:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ca9affd9-9f57-4421-9091-9fda3ab8c79e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79/nodes?order_by=created_at_asc&page=1&pool_id=d2df0d2c-c86b-461f-a9f9-e4a197ce22f2&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:20.188708Z","error_message":null,"id":"d2f0e877-833c-4400-a3ae-413e3b6eef96","name":"scw-test-pool-kubelet-test-pool-kubelet-d2f0e8","pool_id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","provider_id":"scaleway://instance/fr-par-1/407e7ae9-a178-47dc-8435-81df980a7ed7","public_ip_v4":"51.158.116.58","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:55.620609Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "641"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:54:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4c8f8fc9-1c72-48be-81d4-5d01326e9676
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/05fe8b90-1a7d-46b3-92cd-67d49cd1cd54
+    method: GET
+  response:
+    body: '{"created_at":"2023-11-07T15:49:55.417041Z","dhcp_enabled":true,"id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","name":"test-pool-kubelet-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:55.417041Z","id":"90143903-6b61-42cb-98b4-948eba8300fb","subnet":"172.16.72.0/22","updated_at":"2023-11-07T15:49:55.417041Z"},{"created_at":"2023-11-07T15:49:55.417041Z","id":"58142691-df80-49ff-ac64-409f0e429805","subnet":"fd5f:519c:6d46:cde2::/64","updated_at":"2023-11-07T15:49:55.417041Z"}],"tags":[],"updated_at":"2023-11-07T15:49:55.417041Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "706"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 94c3a282-3c62-4ad4-bccb-bc9b1cafde7c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:51:04.519958Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1462"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 78f602d8-0829-4e01-b8bf-d04ae7c6913b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXhUa1JyTVU0eGIxaEVWRTE2VFZSRmQwNXFSVEZPUkdzeFRqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFVwWkNtZHlUR1ZWY25abGVXSnZUVUpEVGpKRlNVcEJXVXRRUmxoc2JuWlNTVkJUY3pFeUwxRlZiREl3TVcxUVVtNUxaSGRzTUd4R1JGSkVhRVJHVlZCMGNtRUtTRk5JWlc1clRXdGtUMjVQWXk4d2VWRjRhVkV6VW5Jd1oyVlhTbFJSVGpoMFJWSTBkR0Y2YUdvMFFYWnJXWEUyUzB4NVEzbzNRMG8zTmtaaFkxZEVTUXBwVkZSNFJ5OUNWMGswTldScmJ6aFFVMVF5YVd4T1UyUndLMnBNUlV4U1R6QkVaWGhIUnpaMlkwUjBhemxxY0RrME5GZE9ZWEZOTVdkR1RWa3lZakZLQ2pGWVZVbGlTa053VW5KdldWWTRieXN5VkdWYVVEQnNNRkJ5Y25Wd1drSkZjRVpCYm14SFdFazVVMXBIVEhobGJrVklSRzFqVDBKMU9XUnROa05UVkdVS2NHcFpXV1E0TDBNMldHUndaR2RaWTJ4SU5USm9TVWxaTVhoa2R6SjVTVWhPTVRVMU9XbFlNWFowYUVkS2FtOU9SelJKVURoMloyMTFZWFZFZWxsT1JBcHhSVXRIY21odVlscGpSRmRUV0RjNEswWnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWk9ha1pDZDFsSU1uWjFPRzFuYkVoS01ESXdWRkUyU2swelRrcE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNPVGxSVGtjeGJGTlJkWEpHY0ZneFZGRjVTa2d5TWs1dGVHdzJTQzh4T0U1TWEyRnVTblZPTUhabUwzbHRXR2RzZUFvM1FWQnVRbGszUkVKVmFWcEhZVXMwYnpkaVJXNXJlRll2TDBadlVHRmlSVzlKZUd4WlUycEpVVXhYZVV0aldFcFBNSEZYYmpWSVdIaFVkbWsyVUZZd0NrdEhVbWxZY1VSQ2QxZERibkpGYTBSV05taE5ha1JXT1ZscE9IWnNSQzgzY2xBdlpWSm1WMk5CWmxZek4xTm5kM0Z4T0hWRlZESlRNVkpDZWxJcmRqSUtTSGRVSzNSME4xRjZaa0ZGVWxVNFptTlVPVnBhWlN0TWFUY3ZiakJWVVU5dU5VaFNhbmxDVGtKaGNYVnFNbmQyZG1SdlFWWm5TM0ZDVlZCSWVUVklkQW8wVFU1emVXdzVaRVpSUldjd2FqTlpWalJSTmt0blptNWFMMDA0Y3pJMlFsaENTRXRuUjI1QlRVWnFhQzl3ZERoNFQzSjNiRWRyZGxscU1VZDRZbWRTQ201dFNVVTViRU00Vm1oR1JFZHpSMkpOTVRsS09HSmtVbXRYTkROVVRHcFhlamxXTVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzQ0ZmVjZGIyLWZjNjQtNDJkNy1hN2UyLTk2NDY5MTliZWY3OS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wta3ViZWxldC1hcmdzCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wta3ViZWxldC1hcmdzIgogICAgdXNlcjogdGVzdC1wb29sLWt1YmVsZXQtYXJncy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wta3ViZWxldC1hcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBianNMYzVwZ090UXlLMkprbjRhNUpnSlNnVVBySGY0YzBHRWQwVWFUTmpwRzRNMGVBcWs5bnQ5Wg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2668"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 71f0c535-dab9-4274-ac6c-36189e8e56d5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"1337"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:54:55.639882Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "677"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ddcac4db-ea11-4b98-902d-a44b33eeb958
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79/nodes?order_by=created_at_asc&page=1&pool_id=d2df0d2c-c86b-461f-a9f9-e4a197ce22f2&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:20.188708Z","error_message":null,"id":"d2f0e877-833c-4400-a3ae-413e3b6eef96","name":"scw-test-pool-kubelet-test-pool-kubelet-d2f0e8","pool_id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","provider_id":"scaleway://instance/fr-par-1/407e7ae9-a178-47dc-8435-81df980a7ed7","public_ip_v4":"51.158.116.58","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:55.620609Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "641"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0a4fe0ab-cbac-48cb-9e35-1611a7fd2f6a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"kubelet_args":{"maxPods":"50"},"upgrade_policy":{"max_unavailable":null,"max_surge":null}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    method: PATCH
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:55:01.090524988Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "678"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e6ec95c4-463c-411a-bd3a-3b40a788ec1a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:55:01.090525Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "675"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7ee88b40-b57d-4de5-ac0c-6a52ae3eeb12
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:55:01.090525Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "675"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5c34efe4-939d-4b82-acbe-05742b70bd24
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79/nodes?order_by=created_at_asc&page=1&pool_id=d2df0d2c-c86b-461f-a9f9-e4a197ce22f2&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:20.188708Z","error_message":null,"id":"d2f0e877-833c-4400-a3ae-413e3b6eef96","name":"scw-test-pool-kubelet-test-pool-kubelet-d2f0e8","pool_id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","provider_id":"scaleway://instance/fr-par-1/407e7ae9-a178-47dc-8435-81df980a7ed7","public_ip_v4":"51.158.116.58","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:55.620609Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "641"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8eb2017c-fa5b-477f-b878-d5f3706526b6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:51:04.519958Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1462"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c3953873-92ae-47df-b015-ef4bbd13bb67
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:55:01.090525Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "675"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9602d453-b372-4660-ac87-2924f4527cea
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/05fe8b90-1a7d-46b3-92cd-67d49cd1cd54
+    method: GET
+  response:
+    body: '{"created_at":"2023-11-07T15:49:55.417041Z","dhcp_enabled":true,"id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","name":"test-pool-kubelet-args","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:55.417041Z","id":"90143903-6b61-42cb-98b4-948eba8300fb","subnet":"172.16.72.0/22","updated_at":"2023-11-07T15:49:55.417041Z"},{"created_at":"2023-11-07T15:49:55.417041Z","id":"58142691-df80-49ff-ac64-409f0e429805","subnet":"fd5f:519c:6d46:cde2::/64","updated_at":"2023-11-07T15:49:55.417041Z"}],"tags":[],"updated_at":"2023-11-07T15:49:55.417041Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "706"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4533a2b7-4a9b-43c7-a308-f2e78f8bd475
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:51:04.519958Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1462"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d297c0fa-d341-4913-aedb-785bdb5734a2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXhUa1JyTVU0eGIxaEVWRTE2VFZSRmQwNXFSVEZPUkdzeFRqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFVwWkNtZHlUR1ZWY25abGVXSnZUVUpEVGpKRlNVcEJXVXRRUmxoc2JuWlNTVkJUY3pFeUwxRlZiREl3TVcxUVVtNUxaSGRzTUd4R1JGSkVhRVJHVlZCMGNtRUtTRk5JWlc1clRXdGtUMjVQWXk4d2VWRjRhVkV6VW5Jd1oyVlhTbFJSVGpoMFJWSTBkR0Y2YUdvMFFYWnJXWEUyUzB4NVEzbzNRMG8zTmtaaFkxZEVTUXBwVkZSNFJ5OUNWMGswTldScmJ6aFFVMVF5YVd4T1UyUndLMnBNUlV4U1R6QkVaWGhIUnpaMlkwUjBhemxxY0RrME5GZE9ZWEZOTVdkR1RWa3lZakZLQ2pGWVZVbGlTa053VW5KdldWWTRieXN5VkdWYVVEQnNNRkJ5Y25Wd1drSkZjRVpCYm14SFdFazVVMXBIVEhobGJrVklSRzFqVDBKMU9XUnROa05UVkdVS2NHcFpXV1E0TDBNMldHUndaR2RaWTJ4SU5USm9TVWxaTVhoa2R6SjVTVWhPTVRVMU9XbFlNWFowYUVkS2FtOU9SelJKVURoMloyMTFZWFZFZWxsT1JBcHhSVXRIY21odVlscGpSRmRUV0RjNEswWnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWk9ha1pDZDFsSU1uWjFPRzFuYkVoS01ESXdWRkUyU2swelRrcE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNPVGxSVGtjeGJGTlJkWEpHY0ZneFZGRjVTa2d5TWs1dGVHdzJTQzh4T0U1TWEyRnVTblZPTUhabUwzbHRXR2RzZUFvM1FWQnVRbGszUkVKVmFWcEhZVXMwYnpkaVJXNXJlRll2TDBadlVHRmlSVzlKZUd4WlUycEpVVXhYZVV0aldFcFBNSEZYYmpWSVdIaFVkbWsyVUZZd0NrdEhVbWxZY1VSQ2QxZERibkpGYTBSV05taE5ha1JXT1ZscE9IWnNSQzgzY2xBdlpWSm1WMk5CWmxZek4xTm5kM0Z4T0hWRlZESlRNVkpDZWxJcmRqSUtTSGRVSzNSME4xRjZaa0ZGVWxVNFptTlVPVnBhWlN0TWFUY3ZiakJWVVU5dU5VaFNhbmxDVGtKaGNYVnFNbmQyZG1SdlFWWm5TM0ZDVlZCSWVUVklkQW8wVFU1emVXdzVaRVpSUldjd2FqTlpWalJSTmt0blptNWFMMDA0Y3pJMlFsaENTRXRuUjI1QlRVWnFhQzl3ZERoNFQzSjNiRWRyZGxscU1VZDRZbWRTQ201dFNVVTViRU00Vm1oR1JFZHpSMkpOTVRsS09HSmtVbXRYTkROVVRHcFhlamxXTVFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzQ0ZmVjZGIyLWZjNjQtNDJkNy1hN2UyLTk2NDY5MTliZWY3OS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wta3ViZWxldC1hcmdzCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wta3ViZWxldC1hcmdzIgogICAgdXNlcjogdGVzdC1wb29sLWt1YmVsZXQtYXJncy1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1rdWJlbGV0LWFyZ3MKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wta3ViZWxldC1hcmdzLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBianNMYzVwZ090UXlLMkprbjRhNUpnSlNnVVBySGY0YzBHRWQwVWFUTmpwRzRNMGVBcWs5bnQ5Wg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2668"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 281418ce-98ae-4055-9698-dc0b1dd81d9d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:55:01.090525Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "675"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 55597dae-afb1-43e5-a310-9496756e122b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79/nodes?order_by=created_at_asc&page=1&pool_id=d2df0d2c-c86b-461f-a9f9-e4a197ce22f2&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:20.188708Z","error_message":null,"id":"d2f0e877-833c-4400-a3ae-413e3b6eef96","name":"scw-test-pool-kubelet-test-pool-kubelet-d2f0e8","pool_id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","provider_id":"scaleway://instance/fr-par-1/407e7ae9-a178-47dc-8435-81df980a7ed7","public_ip_v4":"51.158.116.58","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:55:01.710400Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "641"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a157643c-aa1b-453d-ab40-83f483d8b6a2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.387748Z","created_at":"2023-10-18T16:35:45.387748Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5af82341-c048-4f53-853a-3df5421d10f9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-10-18T16:43:47.114846477Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:55:03.019751288Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1513"
+      - "681"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:47 GMT
+      - Tue, 07 Nov 2023 15:55:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4365,7 +3177,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e99d210-5b24-452e-906b-e3fd89a98dd5
+      - b47f4848-fbd9-40ea-b969-dfde1fd68825
     status: 200 OK
     code: 200
     duration: ""
@@ -4376,19 +3188,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.387748Z","created_at":"2023-10-18T16:35:45.387748Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5af82341-c048-4f53-853a-3df5421d10f9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-10-18T16:43:47.114846Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:55:03.019751Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1510"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:47 GMT
+      - Tue, 07 Nov 2023 15:55:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4398,7 +3210,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7297f17d-f9cc-40de-b111-e07d1f3f25d9
+      - de577971-33de-4362-9ce0-51f67cb681ef
     status: 200 OK
     code: 200
     duration: ""
@@ -4409,19 +3221,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.387748Z","created_at":"2023-10-18T16:35:45.387748Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5af82341-c048-4f53-853a-3df5421d10f9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-10-18T16:43:47.114846Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:55:03.019751Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1510"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:52 GMT
+      - Tue, 07 Nov 2023 15:55:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4431,7 +3243,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 350c0d58-1f4d-4ee6-8ecd-c5635dcd32c4
+      - 17ec9805-6a61-452b-8ba3-1d7655c05154
     status: 200 OK
     code: 200
     duration: ""
@@ -4442,19 +3254,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.387748Z","created_at":"2023-10-18T16:35:45.387748Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5af82341-c048-4f53-853a-3df5421d10f9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-10-18T16:43:47.114846Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:55:03.019751Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1510"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:57 GMT
+      - Tue, 07 Nov 2023 15:55:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4464,7 +3276,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a22237a-313a-4966-9a3d-4009bc812928
+      - ae6e7406-ef6c-4bb2-9984-db8d4e13b3bd
     status: 200 OK
     code: 200
     duration: ""
@@ -4475,19 +3287,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.387748Z","created_at":"2023-10-18T16:35:45.387748Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5af82341-c048-4f53-853a-3df5421d10f9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-10-18T16:43:47.114846Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","container_runtime":"containerd","created_at":"2023-11-07T15:50:02.715984Z","id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","kubelet_args":{"maxPods":"50"},"max_size":1,"min_size":1,"name":"test-pool-kubelet-args","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"updated_at":"2023-11-07T15:55:03.019751Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1510"
+      - "678"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:02 GMT
+      - Tue, 07 Nov 2023 15:55:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4497,7 +3309,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21e03e80-595e-43f4-bf8e-dd7984ba8e7e
+      - c634c1b8-0710-4a9d-be34-e102535a46ed
     status: 200 OK
     code: 200
     duration: ""
@@ -4508,19 +3320,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d2df0d2c-c86b-461f-a9f9-e4a197ce22f2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.387748Z","created_at":"2023-10-18T16:35:45.387748Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4c6ff6c8-5b47-4681-9fc6-dff7b1b74226.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"5af82341-c048-4f53-853a-3df5421d10f9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-10-18T16:43:47.114846Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"d2df0d2c-c86b-461f-a9f9-e4a197ce22f2","type":"not_found"}'
     headers:
       Content-Length:
-      - "1510"
+      - "125"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:07 GMT
+      - Tue, 07 Nov 2023 15:55:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4530,40 +3342,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c1bf000-34dd-4988-8795-39f6e8809970
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "128"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:44:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8e6986ba-b8ab-4421-a681-673219f3057d
+      - b1f7790e-3a52-4278-972c-d860a739752d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4574,10 +3353,142 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/5af82341-c048-4f53-853a-3df5421d10f9
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"5af82341-c048-4f53-853a-3df5421d10f9","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:55:23.450892805Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1468"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f5452c7a-52d1-48c6-b72b-aaef241158d3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:55:23.450893Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1465"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 383157e7-d3f5-4f65-9a7a-c70687563434
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://44fecdb2-fc64-42d7-a7e2-9646919bef79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:56.588334Z","created_at":"2023-11-07T15:49:56.588334Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.44fecdb2-fc64-42d7-a7e2-9646919bef79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","ingress":"none","name":"test-pool-kubelet-args","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","kubelet_args"],"type":"kapsule","updated_at":"2023-11-07T15:55:23.450893Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1465"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c06fd81a-0b64-4442-8cea-a3e1c6fb26d1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4ee10323-e872-45cd-bc99-e98d6ef90cb5
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/05fe8b90-1a7d-46b3-92cd-67d49cd1cd54
+    method: DELETE
+  response:
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"05fe8b90-1a7d-46b3-92cd-67d49cd1cd54","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -4586,7 +3497,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:12 GMT
+      - Tue, 07 Nov 2023 15:55:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4596,7 +3507,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9aacd63-6129-45f9-9cb0-e6b5870e35f6
+      - eaba96d0-1a87-4773-a298-b63e5136c4e7
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4607,10 +3518,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4c6ff6c8-5b47-4681-9fc6-dff7b1b74226
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/44fecdb2-fc64-42d7-a7e2-9646919bef79
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"4c6ff6c8-5b47-4681-9fc6-dff7b1b74226","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"44fecdb2-fc64-42d7-a7e2-9646919bef79","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -4619,7 +3530,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:12 GMT
+      - Tue, 07 Nov 2023 15:55:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4629,7 +3540,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d14bb519-ea65-4fa5-b26e-b7b24c5d9544
+      - ec348626-1f76-4f4d-857f-598f5e6c8df7
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-placement-group.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-placement-group.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:27 GMT
+      - Tue, 07 Nov 2023 15:49:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,12 +34,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a837a7d5-be57-4460-9984-9dda98e2d573
+      - 0d29583a-90f3-463f-9b94-40532cfbc663
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-placement-group","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_type":"max_availability"}'
+    body: '{"name":"test-pool-placement-group","project":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_type":"max_availability"}'
     form: {}
     headers:
       Content-Type:
@@ -50,7 +50,7 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups
     method: POST
   response:
-    body: '{"placement_group":{"id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"fr-par-1"}}'
+    body: '{"placement_group":{"id":"c94a9260-bb00-4afa-ac71-37ddc8138240","name":"test-pool-placement-group","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "331"
@@ -59,9 +59,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:28 GMT
+      - Tue, 07 Nov 2023 15:49:50 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/c94a9260-bb00-4afa-ac71-37ddc8138240
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -71,7 +71,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 700a5a6c-569f-466d-be37-8c91ec1593a7
+      - 909dbbac-2890-4368-81f3-375c3e46c4dd
     status: 201 Created
     code: 201
     duration: ""
@@ -82,10 +82,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/c94a9260-bb00-4afa-ac71-37ddc8138240
     method: GET
   response:
-    body: '{"placement_group":{"id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"fr-par-1"}}'
+    body: '{"placement_group":{"id":"c94a9260-bb00-4afa-ac71-37ddc8138240","name":"test-pool-placement-group","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "331"
@@ -94,7 +94,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:28 GMT
+      - Tue, 07 Nov 2023 15:49:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -104,12 +104,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b83437ec-1d28-4f58-8000-6d6f603b5449
+      - 22d43c97-6e76-4f4d-bc8b-f0a5e3714598
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-placement-group","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"test-pool-placement-group","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -120,16 +120,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-19T16:36:28.273413Z","dhcp_enabled":true,"id":"9589709f-af0f-49cb-923c-013c1e52a7e9","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-19T16:36:28.273413Z","id":"f1cb0c41-9384-4d62-9cd7-6ef07d1830af","subnet":"172.16.12.0/22","updated_at":"2023-10-19T16:36:28.273413Z"},{"created_at":"2023-10-19T16:36:28.273413Z","id":"e465714b-f596-4260-8e5a-1a8bee719b49","subnet":"fd63:256c:45f7:dc6::/64","updated_at":"2023-10-19T16:36:28.273413Z"}],"tags":[],"updated_at":"2023-10-19T16:36:28.273413Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T15:49:51.166777Z","dhcp_enabled":true,"id":"d539826f-786f-4091-98fd-69d345ea1be0","name":"test-pool-placement-group","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.166777Z","id":"631a5559-4f8b-4d32-a176-969d1efa2a9d","subnet":"172.16.92.0/22","updated_at":"2023-11-07T15:49:51.166777Z"},{"created_at":"2023-11-07T15:49:51.166777Z","id":"3555dbc9-4a3a-42d1-9465-b7bf08ccea4c","subnet":"fd5f:519c:6d46:bde4::/64","updated_at":"2023-11-07T15:49:51.166777Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.166777Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "725"
+      - "709"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:29 GMT
+      - Tue, 07 Nov 2023 15:49:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -139,7 +139,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33f5e4b1-b5c9-496f-9045-586a5a2d7d24
+      - d3bb4b9c-a654-4d1f-9af0-08102cf5dd19
     status: 200 OK
     code: 200
     duration: ""
@@ -150,19 +150,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9589709f-af0f-49cb-923c-013c1e52a7e9
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d539826f-786f-4091-98fd-69d345ea1be0
     method: GET
   response:
-    body: '{"created_at":"2023-10-19T16:36:28.273413Z","dhcp_enabled":true,"id":"9589709f-af0f-49cb-923c-013c1e52a7e9","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-19T16:36:28.273413Z","id":"f1cb0c41-9384-4d62-9cd7-6ef07d1830af","subnet":"172.16.12.0/22","updated_at":"2023-10-19T16:36:28.273413Z"},{"created_at":"2023-10-19T16:36:28.273413Z","id":"e465714b-f596-4260-8e5a-1a8bee719b49","subnet":"fd63:256c:45f7:dc6::/64","updated_at":"2023-10-19T16:36:28.273413Z"}],"tags":[],"updated_at":"2023-10-19T16:36:28.273413Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T15:49:51.166777Z","dhcp_enabled":true,"id":"d539826f-786f-4091-98fd-69d345ea1be0","name":"test-pool-placement-group","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.166777Z","id":"631a5559-4f8b-4d32-a176-969d1efa2a9d","subnet":"172.16.92.0/22","updated_at":"2023-11-07T15:49:51.166777Z"},{"created_at":"2023-11-07T15:49:51.166777Z","id":"3555dbc9-4a3a-42d1-9465-b7bf08ccea4c","subnet":"fd5f:519c:6d46:bde4::/64","updated_at":"2023-11-07T15:49:51.166777Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.166777Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "725"
+      - "709"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:29 GMT
+      - Tue, 07 Nov 2023 15:49:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -172,12 +172,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7fdc1ddc-476d-4e2d-8f5b-1224cc210ce5
+      - 0fd1e803-f382-4bf1-b3f8-a9072baa5bbf
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-placement-group","description":"","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":"9589709f-af0f-49cb-923c-013c1e52a7e9"}'
+    body: '{"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","type":"","name":"test-pool-placement-group","description":"","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0"}'
     form: {}
     headers:
       Content-Type:
@@ -188,16 +188,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f7540fdb-410d-4d7d-8137-bb6dba36f1c7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:36:29.542789215Z","created_at":"2023-10-19T16:36:29.542789215Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f7540fdb-410d-4d7d-8137-bb6dba36f1c7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9589709f-af0f-49cb-923c-013c1e52a7e9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:36:29.599481327Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:49:53.233834907Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1525"
+      - "1474"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:29 GMT
+      - Tue, 07 Nov 2023 15:49:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -207,7 +207,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 865fb160-23bc-45ea-8b0b-9f8f86ad2d49
+      - 1e276830-2704-44ea-8e27-c37fa6938170
     status: 200 OK
     code: 200
     duration: ""
@@ -218,19 +218,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f7540fdb-410d-4d7d-8137-bb6dba36f1c7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f7540fdb-410d-4d7d-8137-bb6dba36f1c7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:36:29.542789Z","created_at":"2023-10-19T16:36:29.542789Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f7540fdb-410d-4d7d-8137-bb6dba36f1c7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9589709f-af0f-49cb-923c-013c1e52a7e9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:36:29.599481Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:49:53.233835Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:29 GMT
+      - Tue, 07 Nov 2023 15:49:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -240,7 +240,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76cf7827-42ac-4f5f-b1ad-5a233e921d38
+      - 68877933-17a9-45e8-91a1-39d3bdc281ac
     status: 200 OK
     code: 200
     duration: ""
@@ -251,19 +251,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f7540fdb-410d-4d7d-8137-bb6dba36f1c7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f7540fdb-410d-4d7d-8137-bb6dba36f1c7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:36:29.542789Z","created_at":"2023-10-19T16:36:29.542789Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f7540fdb-410d-4d7d-8137-bb6dba36f1c7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9589709f-af0f-49cb-923c-013c1e52a7e9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:36:31.468700Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:49:55.008245Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1521"
+      - "1476"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:34 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -273,7 +273,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ad6e648-1175-4877-8e53-b357edeefae9
+      - fd1fd105-eb1a-4100-8070-b3c0b4716649
     status: 200 OK
     code: 200
     duration: ""
@@ -284,19 +284,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f7540fdb-410d-4d7d-8137-bb6dba36f1c7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f7540fdb-410d-4d7d-8137-bb6dba36f1c7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:36:29.542789Z","created_at":"2023-10-19T16:36:29.542789Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f7540fdb-410d-4d7d-8137-bb6dba36f1c7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9589709f-af0f-49cb-923c-013c1e52a7e9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:36:31.468700Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:49:55.008245Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1521"
+      - "1476"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:34 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -306,7 +306,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2bb02554-7d22-43c2-badb-9ec5e745d9a4
+      - d782183f-ac1c-43f2-ac12-cf5985e35053
     status: 200 OK
     code: 200
     duration: ""
@@ -317,19 +317,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f7540fdb-410d-4d7d-8137-bb6dba36f1c7/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoUFJFVXlUWHBaZWsxV2IxaEVWRTE2VFZSQmVFOUVSVEpOZWxsNlRWWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFhvNENtYzNObTVrY1ZBdlVDOUNaVVJPWTFZNGF6Tk5ORko0Ym5CSE1HVjRkVkpuZEZoRFpGaDBSblZNWkV4a09VdzBNM05IVVVWWE1URTNSVFExYzI5alFrZ0taREZaVVhZeU5UQkJTVlpOYzNJMVRsQXZSMVYzWWtaNmN6Y3hMekV2WTIxWVNuQm1NMnN4U0dKT1MzRnNWMEp6UzNweFZFcGxWRFJGSzNKR1puaFVOQXBVZDJFNWFsUTVkbEp5U1dwRWRFTkVjV3hUTDNZeWFWRjBOMFp2VVhsR2VuTnlNSE5TVjJGSGJXSnJjSEY0WWxJd1EzRkNNV3NyYTFGME4ybFhNVFJsQ25VNFkzQlhTVUpFTlRsa1NXaERORVZDVERoSFFrNWlXbmhLVEVkMEwxVlZkMmhSYld4eU5qWnBTMUo2WW5SMFZYVjRXbVYyYkdOdGFIQjNSVkp2WmpRS2FWWlJNbUphS3pReFpYZEdLMkZoZVZsSFoyUXdiR0UzT1ZGRmNUaDRSazk2ZDNVMFlVZDVWVU5wU2xacmREZzBVRzVrZVhNcmJrbHZMMEZpUTFreFl3cDVkaTkyTlZRNFZVWldkM1J1UTFVelQxcGpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkRUelJDZW5oall6aE5WRFJoY1VoMWVXWlhTRTlaVmpSYVdFNU5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJhV0poVkcxdlQyWjFhME5EWjBGdFNtZFhlR1F3Y1dzcmQyMHpaMDVqZFRSaFExaElTMEZNWVZWbGNGRlhOVGhDV0FwQ1pEaFJhbEU0TjBsblZIcFdaRVo1UnpOUFVXZFdNWGxsZDIxbmJrbEVXbG9yUW1aQlNYbDZMMms0TWpkWVVXMW1SSG95WjJVNGJtWk5TMW8xUmxWSENtVTJiMFJITWxsUEszbEhVVVZGUzFoTE1HTllURXB1TmpWU2FVdERPSHBMYVhrd1ZFVjZhM1JxVjJwTWIzcFdaRFJGYkZsWlQyRmtaVXRPWW1GWGVtZ0tkRXN5TjFseWRsZHRjbVJsU2tSalJ5OUJZMVp0VjJWbFYzQkNUM1pLTjAxQ1MzcGlNMGcxVkc4clUzRnVRbkEyWVRVNFlTOWtiMGd2T0VodlVuVlFWZ3BpV0U1bU1VUTBiRUpDV0dadlUwVkNNVUpwTVdSbVJ6QnBNRVlyYnpOb2FXRkNSVkJCYVd0SlRqWTBMM1l4TkVzdmFVMHlWbGxIZWk5aWFURk5jVGRoQ2k4eE1rZFJaMVZWWkRGblZVcDRjMnhIZHpCTmIxSm5SbTFJWlZseEwxZDZhMHd3Y2dvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2Y3NTQwZmRiLTQxMGQtNGQ3ZC04MTM3LWJiNmRiYTM2ZjFjNy5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBBMkIycjdDNm1kZFp4cEdUcXRPSFA5R0d5dE55WVJBYW9UdENXYTBNeVY4YTdhTU5MQmZocFcwQw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXhUa1JyTVU1R2IxaEVWRTE2VFZSRmQwNXFSVEZPUkdzeFRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVERoRUNtMVdjMEp4TkVzMmNWaDRabXRGZW01aGNUWlFVVkk1T1d4bVRuWTFTemhLVERReFEwZExTelpWYVVKWGRtRnBWME5wZGxGdGNTOVlheTgwYUc1Q1ZqWUtjbWg1VXl0NlJ5c3ZRVmRVZDBaNU9VRldiMmhpZVZwT2ExUnpOMEZ3U0hGeU9XNXhabkZ0UW1rMWVHaExPVzVFU1RoT1NFbEVORVpNSzNvNGRFdExTZ3BoVDFZNWN6STFiSFpJU25CSlRtSkNkRWhOT0M5QlEwaFRjMjk0WWtKbFVXbGlVbmxETlZaSk5EbGpieXRCZG5wYUwyZDFURTlNVm1jM0wyUkJRbUkyQ21ZMWFqWkRiRWN5VG5kQ2VqaEtRVE5JUW1rNU5HcHNZWE5pTjBWSldtbFphWFIxYjBaR2NuaFBVamx6TW1Od1lVVk9NRUV6UTNKT1ZXbEhNM1pQVUcwS09WTTNWbkIwVFZWVWNWZGhTM0JwZUV0UlUwWkJhak5MVFc4eWJreFBNbmhZYkRNNFdHdFhVMUUxU3k5SVVIQlVUbGhxVG1oT1dscFFOV2czTTNCV2JBcFZXVGRzU1dkd2FrWlVlWEpJTUhwa01YVnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkdVVmRNYTNObVpFOWhkV3d5U2t3eE1XTlVSbXg0WlVFeFNtUk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJWbFY2YUdSYVZsVnJhVXAyUTFsV09YTnlkR2hzWW5FMk1GQnVWVFJWYVU1M05sVk5OR1p1TVU4MFpqTm9UbmhCYWdwV0swWkJkbEZuYm1wbFlVZHVlVk5yZVZsUGVUZG1WRU1yYm10R2IzVmtORmgxUzBkWWFGVkpiVmhrUlRaMFpsTnBhSEZHU21zNVNsVk9NM0Y1Yld0VENrUnlZVTlIUzA5SGIwRm5XbEZ3YVVOd1dXcFRlQ3RKVHpCcFJsSnNjMjVGTURoSllUTlZha2h5VmxjMlJtSlJibU5zTkVodmFXZDNOSFZDV1ZoMmNIUUtkV1JqVTBoa1MxZDViM0U1YW04eldtSnlObXRuVWtwbGVDdE5VR2Q1WWt0TU9VcGxkV0poTVM5WU1taHBSbVpuTTFZNU5USlhOekJ3WVVRNWNFNUdSZ3BxTUVkSFlXdHpla2hIYTNkQ05YTkRXbVJ5V25SdGIxWllXWGhTWTBNdmIwc3lWV3hwTWxGWVVYZE1UR3BGTW0wME9VY3phMU00ZDNSNmNtTTRlSGRsQ21wTk1YaGpWSHBQTUZONlRuVTRla1Y1U3pWT00yOWFVazVrWjNSbmVWRXdTRFJhYlFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2UxNTk3NjYwLWY5OTQtNDM4Zi1hYTk5LWE0MmM2NWYwMTBhNS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBsNnJJdnFZZTFvdjd2MEw5TUNTWHdxVmYyVDh2azdtNjFuWWpDS3lQVTFoZ2hkSUljMk5GeEYySA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2694"
+      - "2692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:35 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -339,7 +339,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - daae1845-5a0f-477b-8dbd-4f2c576d94f8
+      - fa1ee2f4-ae71-4f36-b6fc-d8f453a6c04d
     status: 200 OK
     code: 200
     duration: ""
@@ -350,19 +350,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f7540fdb-410d-4d7d-8137-bb6dba36f1c7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f7540fdb-410d-4d7d-8137-bb6dba36f1c7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:36:29.542789Z","created_at":"2023-10-19T16:36:29.542789Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f7540fdb-410d-4d7d-8137-bb6dba36f1c7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9589709f-af0f-49cb-923c-013c1e52a7e9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:36:31.468700Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:49:55.008245Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1521"
+      - "1476"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:35 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -372,12 +372,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b3b844e-7a6a-4d57-b644-52df471593bf
+      - 783fb2eb-a579-48b6-9e2e-bdd35eb511eb
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"upgrade_policy":null,"zone":"fr-par-1","root_volume_type":"default_volume_type","root_volume_size":null,"public_ip_disabled":false}'
+    body: '{"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"zone":"fr-par-1","root_volume_type":"default_volume_type","public_ip_disabled":false}'
     form: {}
     headers:
       Content-Type:
@@ -385,19 +385,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f7540fdb-410d-4d7d-8137-bb6dba36f1c7/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5/pools
     method: POST
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769298890Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "674"
+      - "651"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:35 GMT
+      - Tue, 07 Nov 2023 15:49:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -407,7 +407,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1ed3131-8c96-4815-84e6-efc9f142e8c4
+      - d64ed5bc-93c0-416c-93de-026c56f92d5d
     status: 200 OK
     code: 200
     duration: ""
@@ -418,19 +418,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:35 GMT
+      - Tue, 07 Nov 2023 15:49:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -440,7 +440,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6525be89-a4c1-4be0-88f8-a56717f9f3c3
+      - b68e1b77-035d-4138-a406-f34b8056a412
     status: 200 OK
     code: 200
     duration: ""
@@ -451,19 +451,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:40 GMT
+      - Tue, 07 Nov 2023 15:50:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -473,7 +473,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5eb6e457-70dd-4473-aec0-308562b2e322
+      - 32c08c5c-5e9b-4d5a-8840-a9ce7ea5cbf8
     status: 200 OK
     code: 200
     duration: ""
@@ -484,19 +484,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:45 GMT
+      - Tue, 07 Nov 2023 15:50:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -506,7 +506,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d7d0bf5-23d3-46c2-a1d0-c4abb630292d
+      - af7dde9b-0f8b-4277-850a-8a6ab3570ad3
     status: 200 OK
     code: 200
     duration: ""
@@ -517,19 +517,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:50 GMT
+      - Tue, 07 Nov 2023 15:50:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -539,7 +539,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 356d578e-de9e-48b2-8e78-70631b60e0d2
+      - ccfb2582-90b8-4ea3-b877-de759fb5072e
     status: 200 OK
     code: 200
     duration: ""
@@ -550,19 +550,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:55 GMT
+      - Tue, 07 Nov 2023 15:50:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -572,7 +572,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e677cf2-c009-4e5f-a837-c3656833de2a
+      - 4624bdab-4ff2-4bba-add3-0433f8d91a1b
     status: 200 OK
     code: 200
     duration: ""
@@ -583,19 +583,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:37:00 GMT
+      - Tue, 07 Nov 2023 15:50:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -605,7 +605,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74478b1f-5fb6-441f-b36a-bd2937759ea2
+      - 7aec4354-309a-4fca-9437-06c1055be908
     status: 200 OK
     code: 200
     duration: ""
@@ -616,19 +616,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:37:05 GMT
+      - Tue, 07 Nov 2023 15:50:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -638,7 +638,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cea2f601-2c21-4d12-a8eb-be536dcb5615
+      - 9b5dd339-843e-4b98-9726-2d1c691c7fc2
     status: 200 OK
     code: 200
     duration: ""
@@ -649,19 +649,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:37:11 GMT
+      - Tue, 07 Nov 2023 15:50:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -671,7 +671,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7fe9fbb7-704b-4929-8829-7434c9251d02
+      - e5142c54-24b1-44bc-b49f-f9aa378497c3
     status: 200 OK
     code: 200
     duration: ""
@@ -682,19 +682,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:37:16 GMT
+      - Tue, 07 Nov 2023 15:50:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -704,7 +704,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2ef7f81-34ed-4383-90a1-990884fa0283
+      - 7081c053-96d4-4eea-876a-98f723fe29f4
     status: 200 OK
     code: 200
     duration: ""
@@ -715,19 +715,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:37:21 GMT
+      - Tue, 07 Nov 2023 15:50:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -737,7 +737,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa67daa8-ec4d-4272-a521-b6b94bea5f8b
+      - 4b97145d-478e-44fe-87e9-2e949ddc6224
     status: 200 OK
     code: 200
     duration: ""
@@ -748,19 +748,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:37:26 GMT
+      - Tue, 07 Nov 2023 15:50:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -770,7 +770,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a9fd33a-994b-4cae-916c-6982e4d29ce8
+      - 347fc871-8fe9-4cf3-a3ed-e2d911f022ed
     status: 200 OK
     code: 200
     duration: ""
@@ -781,19 +781,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:37:31 GMT
+      - Tue, 07 Nov 2023 15:50:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -803,7 +803,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8060dc8d-558d-4483-9039-28fa98c91772
+      - 2686d1f1-a55c-4c8f-b616-76ab054d2d3c
     status: 200 OK
     code: 200
     duration: ""
@@ -814,19 +814,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:37:36 GMT
+      - Tue, 07 Nov 2023 15:51:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -836,7 +836,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f24aaac6-9f64-43ca-b88c-0a0828df9162
+      - 135f9e56-a251-421b-80e9-f5639407282f
     status: 200 OK
     code: 200
     duration: ""
@@ -847,19 +847,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:37:41 GMT
+      - Tue, 07 Nov 2023 15:51:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -869,7 +869,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f1e8982-5789-4e23-b72b-e4d924897a0d
+      - d2b5675e-8528-4af7-b583-cc294a2a7644
     status: 200 OK
     code: 200
     duration: ""
@@ -880,19 +880,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:37:46 GMT
+      - Tue, 07 Nov 2023 15:51:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -902,7 +902,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 568e3bab-142f-44c0-b3ba-19fbb570e298
+      - 0b3ad3ee-b549-4ed9-a167-6642ddd66b55
     status: 200 OK
     code: 200
     duration: ""
@@ -913,19 +913,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:37:51 GMT
+      - Tue, 07 Nov 2023 15:51:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -935,7 +935,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 003d7ccf-8644-4dfd-98ce-57000b8cb122
+      - 975ba53c-32da-42ca-b9bb-288998068b35
     status: 200 OK
     code: 200
     duration: ""
@@ -946,19 +946,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:37:56 GMT
+      - Tue, 07 Nov 2023 15:51:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -968,7 +968,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7d8ea78-bb87-4b9f-917b-e02993f344a8
+      - 93c21a9d-a6f1-4371-ba81-ded9d62a38ed
     status: 200 OK
     code: 200
     duration: ""
@@ -979,19 +979,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:38:01 GMT
+      - Tue, 07 Nov 2023 15:51:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1001,7 +1001,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d58762e-5f2e-4b85-a115-bb22521cd404
+      - 400c113d-4bee-4132-87e4-779daeb082aa
     status: 200 OK
     code: 200
     duration: ""
@@ -1012,19 +1012,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:38:06 GMT
+      - Tue, 07 Nov 2023 15:51:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1034,7 +1034,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 969ceee3-bfb5-47a9-a2d8-80806e9f656e
+      - 8499e719-88a4-4cd5-8416-4f6822d4044b
     status: 200 OK
     code: 200
     duration: ""
@@ -1045,19 +1045,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:38:11 GMT
+      - Tue, 07 Nov 2023 15:51:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1067,7 +1067,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d1d29e2-5837-40b1-ad9c-4b5485c67927
+      - 9f8dc54f-519d-4566-8d42-4ce5cf78e103
     status: 200 OK
     code: 200
     duration: ""
@@ -1078,19 +1078,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:38:16 GMT
+      - Tue, 07 Nov 2023 15:51:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1100,7 +1100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d19ed4b2-7131-4ec2-8c8f-d0facd0c8342
+      - cec82eef-b66c-4145-bd75-03eae9483f22
     status: 200 OK
     code: 200
     duration: ""
@@ -1111,19 +1111,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:38:21 GMT
+      - Tue, 07 Nov 2023 15:51:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1133,7 +1133,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f076106-c052-4144-a288-92fe879f576d
+      - 9d535e71-5363-4761-8514-2f2db9863d3e
     status: 200 OK
     code: 200
     duration: ""
@@ -1144,19 +1144,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:38:26 GMT
+      - Tue, 07 Nov 2023 15:51:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1166,7 +1166,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3c5360e-e5f0-496e-bdcd-0cffa16caab9
+      - 4e068854-9036-4303-8cea-cb0b315360b3
     status: 200 OK
     code: 200
     duration: ""
@@ -1177,19 +1177,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:38:31 GMT
+      - Tue, 07 Nov 2023 15:51:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1199,7 +1199,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c403618a-e22d-483d-82dc-01892e2ce1f1
+      - 3ad41008-2941-4115-9701-a198c2327c4e
     status: 200 OK
     code: 200
     duration: ""
@@ -1210,19 +1210,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:38:36 GMT
+      - Tue, 07 Nov 2023 15:52:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1232,7 +1232,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07469740-ccc3-41ec-9fe1-b826bd1dd104
+      - ac3518bc-666e-4308-8118-df9651a0a783
     status: 200 OK
     code: 200
     duration: ""
@@ -1243,19 +1243,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:38:41 GMT
+      - Tue, 07 Nov 2023 15:52:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1265,7 +1265,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3f551eb-aef7-4e91-8d58-4dc6499c5e10
+      - 8af724ec-e611-42fa-b5be-d83d9735d3ac
     status: 200 OK
     code: 200
     duration: ""
@@ -1276,19 +1276,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:38:46 GMT
+      - Tue, 07 Nov 2023 15:52:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1298,7 +1298,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8ec7fbf-428b-4d90-8563-d215eb9581c7
+      - a2585dd3-0a55-464c-a4bb-776c0ef6fe1a
     status: 200 OK
     code: 200
     duration: ""
@@ -1309,19 +1309,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:38:52 GMT
+      - Tue, 07 Nov 2023 15:52:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1331,7 +1331,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6caa248-b44c-41f2-85ec-da45be072d68
+      - d8be3f6a-a3cf-4597-a81b-a24510b104d7
     status: 200 OK
     code: 200
     duration: ""
@@ -1342,19 +1342,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:38:57 GMT
+      - Tue, 07 Nov 2023 15:52:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1364,7 +1364,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 656e19d9-0ffd-4b1a-b207-a6780bf1359e
+      - add77047-8d62-40b0-a0d7-334af28df35d
     status: 200 OK
     code: 200
     duration: ""
@@ -1375,19 +1375,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:39:02 GMT
+      - Tue, 07 Nov 2023 15:52:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1397,7 +1397,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9998200-7d63-49c6-bd7d-7a79c17b643c
+      - 68e8f8dd-d9a2-40bb-a0b8-c4c33a2e742a
     status: 200 OK
     code: 200
     duration: ""
@@ -1408,19 +1408,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:39:07 GMT
+      - Tue, 07 Nov 2023 15:52:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1430,7 +1430,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 599e653a-d144-49e3-be8d-b398535af156
+      - 17ab00db-9073-4134-97bf-907f9d773e8e
     status: 200 OK
     code: 200
     duration: ""
@@ -1441,19 +1441,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:39:12 GMT
+      - Tue, 07 Nov 2023 15:52:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1463,7 +1463,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55e3f330-242d-4ab4-9d94-f9c4b8549c0e
+      - b9758897-0b09-413a-88ab-6590e719954c
     status: 200 OK
     code: 200
     duration: ""
@@ -1474,19 +1474,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:39:17 GMT
+      - Tue, 07 Nov 2023 15:52:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1496,7 +1496,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f2075b9-99ed-4f8a-819d-c644675fc0df
+      - bf559a21-15c2-48fd-af49-9d211b5b8ccd
     status: 200 OK
     code: 200
     duration: ""
@@ -1507,19 +1507,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:39:22 GMT
+      - Tue, 07 Nov 2023 15:52:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1529,7 +1529,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15519ae5-5b3f-4d7e-88d7-e41bc4ba8590
+      - 963d0d6b-e1ee-48dd-90cc-30d2e8faf37f
     status: 200 OK
     code: 200
     duration: ""
@@ -1540,19 +1540,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:39:27 GMT
+      - Tue, 07 Nov 2023 15:52:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1562,7 +1562,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7956f95-6c21-435e-a123-a670ead4b835
+      - 4eb843e4-9f2f-46a6-9c1d-d33c721d5878
     status: 200 OK
     code: 200
     duration: ""
@@ -1573,19 +1573,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:39:32 GMT
+      - Tue, 07 Nov 2023 15:52:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1595,7 +1595,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22ccded4-7b75-4b11-8c9f-dc2256c220f2
+      - 46733cdf-b3b4-4449-9751-445c3424365a
     status: 200 OK
     code: 200
     duration: ""
@@ -1606,19 +1606,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:39:37 GMT
+      - Tue, 07 Nov 2023 15:53:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1628,7 +1628,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 800cdca6-d956-4938-bf79-6c4f3baf4baa
+      - 24d10c8a-4c4b-469d-aea0-383fdf8084d9
     status: 200 OK
     code: 200
     duration: ""
@@ -1639,19 +1639,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:39:42 GMT
+      - Tue, 07 Nov 2023 15:53:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1661,7 +1661,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c65e969-5345-4577-bb53-95b2f78caa39
+      - 1ea193e5-b60f-4697-b143-7cf2825ae877
     status: 200 OK
     code: 200
     duration: ""
@@ -1672,19 +1672,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:39:47 GMT
+      - Tue, 07 Nov 2023 15:53:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1694,7 +1694,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf675666-57a2-42a6-8726-1cff2bfc05c6
+      - 75556ea2-4ddb-40a8-8cd1-1557b8b6695f
     status: 200 OK
     code: 200
     duration: ""
@@ -1705,19 +1705,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:39:52 GMT
+      - Tue, 07 Nov 2023 15:53:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1727,7 +1727,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b6c1687-e5e1-4b18-856f-b8aa3617f5b0
+      - 6f998b99-baf1-4c39-b151-26f9c9164818
     status: 200 OK
     code: 200
     duration: ""
@@ -1738,19 +1738,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:39:58 GMT
+      - Tue, 07 Nov 2023 15:53:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1760,7 +1760,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 659bff71-2068-4bf6-a9e3-060a9a6a3231
+      - 20e82ce8-6086-4d10-baa8-4b5f72cb24b8
     status: 200 OK
     code: 200
     duration: ""
@@ -1771,19 +1771,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:40:03 GMT
+      - Tue, 07 Nov 2023 15:53:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1793,7 +1793,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d9cc158-caca-488f-bffa-400e3848e315
+      - db8bbd22-c8b3-4b14-b9d2-3f628076a32e
     status: 200 OK
     code: 200
     duration: ""
@@ -1804,19 +1804,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:40:08 GMT
+      - Tue, 07 Nov 2023 15:53:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1826,7 +1826,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 228349fb-c39b-4587-9f4a-efbea5241134
+      - caebbc49-044c-428b-9ff3-fd83f47cc593
     status: 200 OK
     code: 200
     duration: ""
@@ -1837,19 +1837,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:40:13 GMT
+      - Tue, 07 Nov 2023 15:53:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1859,7 +1859,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cab58758-00b2-4fd0-85d3-3555b1fc7821
+      - db836bd7-9fd4-4b62-96e1-dc6883267043
     status: 200 OK
     code: 200
     duration: ""
@@ -1870,19 +1870,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:40:18 GMT
+      - Tue, 07 Nov 2023 15:53:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1892,7 +1892,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54be13ab-be26-4ea7-b63f-bc1ebc76e1bb
+      - f8b4047f-4034-4413-a37d-b6efbcafd253
     status: 200 OK
     code: 200
     duration: ""
@@ -1903,19 +1903,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:40:23 GMT
+      - Tue, 07 Nov 2023 15:53:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1925,7 +1925,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77191c6b-72b0-48ee-a23a-397f37c754fb
+      - bb381e09-9557-446b-b993-4a4dc2658d79
     status: 200 OK
     code: 200
     duration: ""
@@ -1936,19 +1936,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:40:28 GMT
+      - Tue, 07 Nov 2023 15:53:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1958,7 +1958,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f433af7b-0616-4ac1-9116-a9a73c841cca
+      - 473d12dd-f3ab-4a85-9335-79654f4dfb56
     status: 200 OK
     code: 200
     duration: ""
@@ -1969,19 +1969,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:40:33 GMT
+      - Tue, 07 Nov 2023 15:53:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1991,7 +1991,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb55fd2e-884d-41ba-9b03-1bf891b0e259
+      - 8d288a72-6ffa-4bfd-90a7-d91994c5f777
     status: 200 OK
     code: 200
     duration: ""
@@ -2002,19 +2002,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:40:38 GMT
+      - Tue, 07 Nov 2023 15:54:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2024,7 +2024,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f35c48d5-2e20-42f7-adad-c585b4fdcd87
+      - 2e9a9d96-fc4a-475f-a04a-62284692161c
     status: 200 OK
     code: 200
     duration: ""
@@ -2035,19 +2035,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:40:43 GMT
+      - Tue, 07 Nov 2023 15:54:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2057,7 +2057,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 455b4568-d1f0-4c5f-a98a-79190ae8c10b
+      - c1183fbc-f6ef-4bb0-a37e-fdebc1c932f2
     status: 200 OK
     code: 200
     duration: ""
@@ -2068,19 +2068,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:40:48 GMT
+      - Tue, 07 Nov 2023 15:54:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2090,7 +2090,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec2db07d-67fd-4678-a995-cf0bad73bf28
+      - 595b3cdc-def4-4e4a-bfe1-c3c8e1bc5827
     status: 200 OK
     code: 200
     duration: ""
@@ -2101,19 +2101,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:40:53 GMT
+      - Tue, 07 Nov 2023 15:54:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2123,7 +2123,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71baee09-cb95-4c48-8812-a3c8a43fc62e
+      - 87538950-660d-4ad3-853f-eb2402484c7e
     status: 200 OK
     code: 200
     duration: ""
@@ -2134,19 +2134,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:40:58 GMT
+      - Tue, 07 Nov 2023 15:54:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2156,7 +2156,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ba46165-81ed-48b5-9884-1a4d1e8860aa
+      - 712603f8-84e3-45cd-81f3-e23e4235ffe7
     status: 200 OK
     code: 200
     duration: ""
@@ -2167,19 +2167,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:41:03 GMT
+      - Tue, 07 Nov 2023 15:54:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2189,7 +2189,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6073c6a-5bf0-4570-a208-0785f0e7388a
+      - 37944384-25f3-48f7-871a-e484d97649e8
     status: 200 OK
     code: 200
     duration: ""
@@ -2200,19 +2200,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:41:08 GMT
+      - Tue, 07 Nov 2023 15:54:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2222,7 +2222,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d69291e6-146c-4b2e-b990-4b428d824fa7
+      - 8af3e28c-87a3-4b38-84f6-d2088dca5238
     status: 200 OK
     code: 200
     duration: ""
@@ -2233,19 +2233,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:41:13 GMT
+      - Tue, 07 Nov 2023 15:54:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2255,7 +2255,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 537e2bac-1da6-4b6c-b51c-02b4a08d0913
+      - a252cc1a-41ab-4390-aa69-69fb9d7308b0
     status: 200 OK
     code: 200
     duration: ""
@@ -2266,19 +2266,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.769299Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:41:18 GMT
+      - Tue, 07 Nov 2023 15:54:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2288,7 +2288,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8556f59a-ab2f-49ec-961f-0a6c37e4617a
+      - 507d3d75-2613-40c5-b5e5-c87686b05e34
     status: 200 OK
     code: 200
     duration: ""
@@ -2299,19 +2299,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:46.428940Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "646"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:41:23 GMT
+      - Tue, 07 Nov 2023 15:54:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2321,7 +2321,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 13c46412-ebb3-4a7c-8163-595e167746e4
+      - f688ba19-5b51-43f5-99b0-be84f5a84850
     status: 200 OK
     code: 200
     duration: ""
@@ -2332,19 +2332,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:51:44.621754Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "671"
+      - "1468"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:41:28 GMT
+      - Tue, 07 Nov 2023 15:54:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2354,7 +2354,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 158e1fe3-4beb-4553-9163-7af0ca203807
+      - 0d388300-a6e2-4591-a8e5-e36256c08ccd
     status: 200 OK
     code: 200
     duration: ""
@@ -2365,19 +2365,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:46.428940Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "646"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:41:34 GMT
+      - Tue, 07 Nov 2023 15:54:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2387,7 +2387,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61c5be82-0be1-4cdc-bfce-6766876f1293
+      - de4cbec2-c748-40f5-bc8d-a170251497f2
     status: 200 OK
     code: 200
     duration: ""
@@ -2398,19 +2398,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5/nodes?order_by=created_at_asc&page=1&pool_id=f563d778-6543-42b7-bc3a-087d590a5137&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:52:07.329064Z","error_message":null,"id":"dc941279-ea09-4131-990f-e339d6867cb2","name":"scw-test-pool-placeme-test-pool-placeme-dc9412","pool_id":"f563d778-6543-42b7-bc3a-087d590a5137","provider_id":"scaleway://instance/fr-par-1/d495283b-b8ba-4f22-8ed3-5dbe8f04c12b","public_ip_v4":"163.172.177.183","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:46.413340Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "671"
+      - "643"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:41:39 GMT
+      - Tue, 07 Nov 2023 15:54:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2420,7 +2420,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09ab1549-8c70-4000-b258-fe63a6da8a8a
+      - 20b208f7-0005-4ca3-b12c-4c8b887d944e
     status: 200 OK
     code: 200
     duration: ""
@@ -2431,19 +2431,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:51:44.621754Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "671"
+      - "1468"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:41:44 GMT
+      - Tue, 07 Nov 2023 15:54:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2453,7 +2453,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40fd35c8-27c9-4a8e-a209-330bcd60ddfc
+      - aefe5325-44dd-47db-9952-c6de22935ec8
     status: 200 OK
     code: 200
     duration: ""
@@ -2464,19 +2464,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:46.428940Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "646"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:41:49 GMT
+      - Tue, 07 Nov 2023 15:54:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2486,7 +2486,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f161559-13f0-48ec-a095-d7c38abddfa8
+      - 094f7219-826f-459d-9667-c03900fece7b
     status: 200 OK
     code: 200
     duration: ""
@@ -2497,19 +2497,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d539826f-786f-4091-98fd-69d345ea1be0
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-07T15:49:51.166777Z","dhcp_enabled":true,"id":"d539826f-786f-4091-98fd-69d345ea1be0","name":"test-pool-placement-group","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.166777Z","id":"631a5559-4f8b-4d32-a176-969d1efa2a9d","subnet":"172.16.92.0/22","updated_at":"2023-11-07T15:49:51.166777Z"},{"created_at":"2023-11-07T15:49:51.166777Z","id":"3555dbc9-4a3a-42d1-9465-b7bf08ccea4c","subnet":"fd5f:519c:6d46:bde4::/64","updated_at":"2023-11-07T15:49:51.166777Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.166777Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "671"
+      - "709"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:41:54 GMT
+      - Tue, 07 Nov 2023 15:54:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2519,7 +2519,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64e8ae33-44b9-4555-a463-1317b7a81a7d
+      - 0bc98853-885e-46a7-ad2b-13cdb0353df5
     status: 200 OK
     code: 200
     duration: ""
@@ -2530,868 +2530,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/c94a9260-bb00-4afa-ac71-37ddc8138240
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:41:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 64aa5093-6cad-493a-afdb-06ffc1dc8749
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:42:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f917c58b-e6f4-4916-ac4e-2b84223d6ce7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:42:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a2caae47-668b-423f-87a5-6bc158dec305
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:42:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 240087b2-745a-4712-9575-61e9abf5b23a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:42:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5a6fd229-c524-4491-a349-fc9dbb1a4630
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:42:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7e562447-4b54-44a2-b8b5-5aeaf9874289
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:42:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 218e6b34-6f91-4fa0-9d3e-d66ba3f2be07
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:42:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e7136111-ec5f-41e0-be71-3bba5d2a7d25
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:42:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 353459a3-760c-450e-afbb-47fda38e6403
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:42:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a2e93bb7-ad7d-4d4d-afeb-91a7802f795a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:42:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1b27e70c-b6a8-4c3a-8c00-512a3baf27af
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:42:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7c5e4ad6-e54a-4cda-b4a8-634f4a39d999
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:43:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f73f715b-32fd-458e-89e2-afc0790b0a15
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:43:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 29772af1-919f-477a-bdac-5adeb25f09db
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:43:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4505374e-a3c0-4eba-9818-f8cbf1ecb9c6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:43:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7d36b996-fdaa-41a3-b566-9a814a6c768c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:43:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0beccf5b-9653-4cce-8645-916a04b8a9d9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:43:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2660b5ad-14bb-41a3-bef6-1e218c6c3c51
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:36:35.247982Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:43:30 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cc2d6d0a-96c6-47db-b402-6454b2583cb1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:43:34.315228Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "669"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:43:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ab08b179-fdc9-4b63-98a5-6c4e2e6c92fa
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f7540fdb-410d-4d7d-8137-bb6dba36f1c7
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f7540fdb-410d-4d7d-8137-bb6dba36f1c7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:36:29.542789Z","created_at":"2023-10-19T16:36:29.542789Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f7540fdb-410d-4d7d-8137-bb6dba36f1c7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9589709f-af0f-49cb-923c-013c1e52a7e9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:37:50.991377Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1513"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:43:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8ed11c88-c89c-4111-8867-4a63b29aef63
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:43:34.315228Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "669"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:43:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 15527cf9-38c7-4d9a-9687-d54a29e24ddc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f7540fdb-410d-4d7d-8137-bb6dba36f1c7/nodes?order_by=created_at_asc&page=1&pool_id=fc2f2114-245c-4126-af09-d4a626251412&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:39:21.654888Z","error_message":null,"id":"4027894d-57fa-4340-ad9d-f70613b6563b","name":"scw-test-pool-placeme-test-pool-placeme-402789","pool_id":"fc2f2114-245c-4126-af09-d4a626251412","provider_id":"scaleway://instance/fr-par-1/df8b6ad0-9aee-4bd8-9173-530acbaef773","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:43:34.297070Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "660"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:43:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 02f07477-bddf-436a-a7fa-67ae42268b0e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f7540fdb-410d-4d7d-8137-bb6dba36f1c7
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f7540fdb-410d-4d7d-8137-bb6dba36f1c7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:36:29.542789Z","created_at":"2023-10-19T16:36:29.542789Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f7540fdb-410d-4d7d-8137-bb6dba36f1c7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9589709f-af0f-49cb-923c-013c1e52a7e9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:37:50.991377Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1513"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:43:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - af597d16-7adb-4167-bfa0-ec48c391b61e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:43:34.315228Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "669"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:43:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3a1d23ff-2400-42e9-bcf4-dd69a9748009
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9589709f-af0f-49cb-923c-013c1e52a7e9
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-19T16:36:28.273413Z","dhcp_enabled":true,"id":"9589709f-af0f-49cb-923c-013c1e52a7e9","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-19T16:36:28.273413Z","id":"f1cb0c41-9384-4d62-9cd7-6ef07d1830af","subnet":"172.16.12.0/22","updated_at":"2023-10-19T16:36:28.273413Z"},{"created_at":"2023-10-19T16:36:28.273413Z","id":"e465714b-f596-4260-8e5a-1a8bee719b49","subnet":"fd63:256c:45f7:dc6::/64","updated_at":"2023-10-19T16:36:28.273413Z"}],"tags":[],"updated_at":"2023-10-19T16:36:28.273413Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "725"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:43:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ed1f044b-eecc-46da-9e8e-f0f22aca2315
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0
-    method: GET
-  response:
-    body: '{"placement_group":{"id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"fr-par-1"}}'
+    body: '{"placement_group":{"id":"c94a9260-bb00-4afa-ac71-37ddc8138240","name":"test-pool-placement-group","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "331"
@@ -3400,7 +2542,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:36 GMT
+      - Tue, 07 Nov 2023 15:54:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3410,7 +2552,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c11eed4-16bd-4205-8fcb-b36e233c004e
+      - 62d9a6b8-8fe5-4cdc-854d-81efd0b51678
     status: 200 OK
     code: 200
     duration: ""
@@ -3421,19 +2563,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f7540fdb-410d-4d7d-8137-bb6dba36f1c7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f7540fdb-410d-4d7d-8137-bb6dba36f1c7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:36:29.542789Z","created_at":"2023-10-19T16:36:29.542789Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f7540fdb-410d-4d7d-8137-bb6dba36f1c7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9589709f-af0f-49cb-923c-013c1e52a7e9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:37:50.991377Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:51:44.621754Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1513"
+      - "1468"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:36 GMT
+      - Tue, 07 Nov 2023 15:54:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3443,7 +2585,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84321f4e-9c91-4a18-8795-3959e3438207
+      - 469aa9dd-cee4-44ca-95ca-b7d21da07557
     status: 200 OK
     code: 200
     duration: ""
@@ -3454,19 +2596,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f7540fdb-410d-4d7d-8137-bb6dba36f1c7/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoUFJFVXlUWHBaZWsxV2IxaEVWRTE2VFZSQmVFOUVSVEpOZWxsNlRWWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFhvNENtYzNObTVrY1ZBdlVDOUNaVVJPWTFZNGF6Tk5ORko0Ym5CSE1HVjRkVkpuZEZoRFpGaDBSblZNWkV4a09VdzBNM05IVVVWWE1URTNSVFExYzI5alFrZ0taREZaVVhZeU5UQkJTVlpOYzNJMVRsQXZSMVYzWWtaNmN6Y3hMekV2WTIxWVNuQm1NMnN4U0dKT1MzRnNWMEp6UzNweFZFcGxWRFJGSzNKR1puaFVOQXBVZDJFNWFsUTVkbEp5U1dwRWRFTkVjV3hUTDNZeWFWRjBOMFp2VVhsR2VuTnlNSE5TVjJGSGJXSnJjSEY0WWxJd1EzRkNNV3NyYTFGME4ybFhNVFJsQ25VNFkzQlhTVUpFTlRsa1NXaERORVZDVERoSFFrNWlXbmhLVEVkMEwxVlZkMmhSYld4eU5qWnBTMUo2WW5SMFZYVjRXbVYyYkdOdGFIQjNSVkp2WmpRS2FWWlJNbUphS3pReFpYZEdLMkZoZVZsSFoyUXdiR0UzT1ZGRmNUaDRSazk2ZDNVMFlVZDVWVU5wU2xacmREZzBVRzVrZVhNcmJrbHZMMEZpUTFreFl3cDVkaTkyTlZRNFZVWldkM1J1UTFVelQxcGpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkRUelJDZW5oall6aE5WRFJoY1VoMWVXWlhTRTlaVmpSYVdFNU5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJhV0poVkcxdlQyWjFhME5EWjBGdFNtZFhlR1F3Y1dzcmQyMHpaMDVqZFRSaFExaElTMEZNWVZWbGNGRlhOVGhDV0FwQ1pEaFJhbEU0TjBsblZIcFdaRVo1UnpOUFVXZFdNWGxsZDIxbmJrbEVXbG9yUW1aQlNYbDZMMms0TWpkWVVXMW1SSG95WjJVNGJtWk5TMW8xUmxWSENtVTJiMFJITWxsUEszbEhVVVZGUzFoTE1HTllURXB1TmpWU2FVdERPSHBMYVhrd1ZFVjZhM1JxVjJwTWIzcFdaRFJGYkZsWlQyRmtaVXRPWW1GWGVtZ0tkRXN5TjFseWRsZHRjbVJsU2tSalJ5OUJZMVp0VjJWbFYzQkNUM1pLTjAxQ1MzcGlNMGcxVkc4clUzRnVRbkEyWVRVNFlTOWtiMGd2T0VodlVuVlFWZ3BpV0U1bU1VUTBiRUpDV0dadlUwVkNNVUpwTVdSbVJ6QnBNRVlyYnpOb2FXRkNSVkJCYVd0SlRqWTBMM1l4TkVzdmFVMHlWbGxIZWk5aWFURk5jVGRoQ2k4eE1rZFJaMVZWWkRGblZVcDRjMnhIZHpCTmIxSm5SbTFJWlZseEwxZDZhMHd3Y2dvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2Y3NTQwZmRiLTQxMGQtNGQ3ZC04MTM3LWJiNmRiYTM2ZjFjNy5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBBMkIycjdDNm1kZFp4cEdUcXRPSFA5R0d5dE55WVJBYW9UdENXYTBNeVY4YTdhTU5MQmZocFcwQw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXhUa1JyTVU1R2IxaEVWRTE2VFZSRmQwNXFSVEZPUkdzeFRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVERoRUNtMVdjMEp4TkVzMmNWaDRabXRGZW01aGNUWlFVVkk1T1d4bVRuWTFTemhLVERReFEwZExTelpWYVVKWGRtRnBWME5wZGxGdGNTOVlheTgwYUc1Q1ZqWUtjbWg1VXl0NlJ5c3ZRVmRVZDBaNU9VRldiMmhpZVZwT2ExUnpOMEZ3U0hGeU9XNXhabkZ0UW1rMWVHaExPVzVFU1RoT1NFbEVORVpNSzNvNGRFdExTZ3BoVDFZNWN6STFiSFpJU25CSlRtSkNkRWhOT0M5QlEwaFRjMjk0WWtKbFVXbGlVbmxETlZaSk5EbGpieXRCZG5wYUwyZDFURTlNVm1jM0wyUkJRbUkyQ21ZMWFqWkRiRWN5VG5kQ2VqaEtRVE5JUW1rNU5HcHNZWE5pTjBWSldtbFphWFIxYjBaR2NuaFBVamx6TW1Od1lVVk9NRUV6UTNKT1ZXbEhNM1pQVUcwS09WTTNWbkIwVFZWVWNWZGhTM0JwZUV0UlUwWkJhak5MVFc4eWJreFBNbmhZYkRNNFdHdFhVMUUxU3k5SVVIQlVUbGhxVG1oT1dscFFOV2czTTNCV2JBcFZXVGRzU1dkd2FrWlVlWEpJTUhwa01YVnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkdVVmRNYTNObVpFOWhkV3d5U2t3eE1XTlVSbXg0WlVFeFNtUk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJWbFY2YUdSYVZsVnJhVXAyUTFsV09YTnlkR2hzWW5FMk1GQnVWVFJWYVU1M05sVk5OR1p1TVU4MFpqTm9UbmhCYWdwV0swWkJkbEZuYm1wbFlVZHVlVk5yZVZsUGVUZG1WRU1yYm10R2IzVmtORmgxUzBkWWFGVkpiVmhrUlRaMFpsTnBhSEZHU21zNVNsVk9NM0Y1Yld0VENrUnlZVTlIUzA5SGIwRm5XbEZ3YVVOd1dXcFRlQ3RKVHpCcFJsSnNjMjVGTURoSllUTlZha2h5VmxjMlJtSlJibU5zTkVodmFXZDNOSFZDV1ZoMmNIUUtkV1JqVTBoa1MxZDViM0U1YW04eldtSnlObXRuVWtwbGVDdE5VR2Q1WWt0TU9VcGxkV0poTVM5WU1taHBSbVpuTTFZNU5USlhOekJ3WVVRNWNFNUdSZ3BxTUVkSFlXdHpla2hIYTNkQ05YTkRXbVJ5V25SdGIxWllXWGhTWTBNdmIwc3lWV3hwTWxGWVVYZE1UR3BGTW0wME9VY3phMU00ZDNSNmNtTTRlSGRsQ21wTk1YaGpWSHBQTUZONlRuVTRla1Y1U3pWT00yOWFVazVrWjNSbmVWRXdTRFJhYlFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2UxNTk3NjYwLWY5OTQtNDM4Zi1hYTk5LWE0MmM2NWYwMTBhNS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBsNnJJdnFZZTFvdjd2MEw5TUNTWHdxVmYyVDh2azdtNjFuWWpDS3lQVTFoZ2hkSUljMk5GeEYySA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2694"
+      - "2692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:36 GMT
+      - Tue, 07 Nov 2023 15:54:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3476,7 +2618,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 151d15f1-47cf-435a-938f-466e31a053ca
+      - 64ee0639-c425-4cc3-9cb8-e007381bd15b
     status: 200 OK
     code: 200
     duration: ""
@@ -3487,19 +2629,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:43:34.315228Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:46.428940Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "669"
+      - "646"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:36 GMT
+      - Tue, 07 Nov 2023 15:54:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3509,7 +2651,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5fe31828-6c71-424c-8421-c71caca9d744
+      - c612f033-64b0-4d79-8cfa-5890d55be66c
     status: 200 OK
     code: 200
     duration: ""
@@ -3520,19 +2662,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f7540fdb-410d-4d7d-8137-bb6dba36f1c7/nodes?order_by=created_at_asc&page=1&pool_id=fc2f2114-245c-4126-af09-d4a626251412&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5/nodes?order_by=created_at_asc&page=1&pool_id=f563d778-6543-42b7-bc3a-087d590a5137&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:39:21.654888Z","error_message":null,"id":"4027894d-57fa-4340-ad9d-f70613b6563b","name":"scw-test-pool-placeme-test-pool-placeme-402789","pool_id":"fc2f2114-245c-4126-af09-d4a626251412","provider_id":"scaleway://instance/fr-par-1/df8b6ad0-9aee-4bd8-9173-530acbaef773","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:43:34.297070Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:52:07.329064Z","error_message":null,"id":"dc941279-ea09-4131-990f-e339d6867cb2","name":"scw-test-pool-placeme-test-pool-placeme-dc9412","pool_id":"f563d778-6543-42b7-bc3a-087d590a5137","provider_id":"scaleway://instance/fr-par-1/d495283b-b8ba-4f22-8ed3-5dbe8f04c12b","public_ip_v4":"163.172.177.183","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:46.413340Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "660"
+      - "643"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:36 GMT
+      - Tue, 07 Nov 2023 15:54:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3542,7 +2684,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - abd0950d-f473-4a99-9622-b207c21a3c3c
+      - 243e4b2c-f1dc-4b91-9d1f-1e907535f7d0
     status: 200 OK
     code: 200
     duration: ""
@@ -3553,19 +2695,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f7540fdb-410d-4d7d-8137-bb6dba36f1c7
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d539826f-786f-4091-98fd-69d345ea1be0
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f7540fdb-410d-4d7d-8137-bb6dba36f1c7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:36:29.542789Z","created_at":"2023-10-19T16:36:29.542789Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f7540fdb-410d-4d7d-8137-bb6dba36f1c7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9589709f-af0f-49cb-923c-013c1e52a7e9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:37:50.991377Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"created_at":"2023-11-07T15:49:51.166777Z","dhcp_enabled":true,"id":"d539826f-786f-4091-98fd-69d345ea1be0","name":"test-pool-placement-group","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.166777Z","id":"631a5559-4f8b-4d32-a176-969d1efa2a9d","subnet":"172.16.92.0/22","updated_at":"2023-11-07T15:49:51.166777Z"},{"created_at":"2023-11-07T15:49:51.166777Z","id":"3555dbc9-4a3a-42d1-9465-b7bf08ccea4c","subnet":"fd5f:519c:6d46:bde4::/64","updated_at":"2023-11-07T15:49:51.166777Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.166777Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "1513"
+      - "709"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:37 GMT
+      - Tue, 07 Nov 2023 15:54:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3575,7 +2717,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 639439f4-7d0e-46f0-b6c2-5a81f2d9ffb0
+      - 7200ae92-0915-425b-bf54-5ec3873fb102
     status: 200 OK
     code: 200
     duration: ""
@@ -3586,19 +2728,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9589709f-af0f-49cb-923c-013c1e52a7e9
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
     method: GET
   response:
-    body: '{"created_at":"2023-10-19T16:36:28.273413Z","dhcp_enabled":true,"id":"9589709f-af0f-49cb-923c-013c1e52a7e9","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-19T16:36:28.273413Z","id":"f1cb0c41-9384-4d62-9cd7-6ef07d1830af","subnet":"172.16.12.0/22","updated_at":"2023-10-19T16:36:28.273413Z"},{"created_at":"2023-10-19T16:36:28.273413Z","id":"e465714b-f596-4260-8e5a-1a8bee719b49","subnet":"fd63:256c:45f7:dc6::/64","updated_at":"2023-10-19T16:36:28.273413Z"}],"tags":[],"updated_at":"2023-10-19T16:36:28.273413Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:51:44.621754Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "725"
+      - "1468"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:37 GMT
+      - Tue, 07 Nov 2023 15:54:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3608,7 +2750,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 924ad88b-557e-4143-8a82-b4345bee4b61
+      - 592604d6-c802-4122-a1f0-3a5ec73cc2de
     status: 200 OK
     code: 200
     duration: ""
@@ -3619,19 +2761,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:43:34.315228Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:46.428940Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "669"
+      - "646"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:37 GMT
+      - Tue, 07 Nov 2023 15:54:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3641,7 +2783,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ebf66ff-ec7b-462a-b4f3-2b3f9a00b994
+      - db35e323-883b-4cf2-a7a1-fa7ec83ccee3
     status: 200 OK
     code: 200
     duration: ""
@@ -3652,10 +2794,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/c94a9260-bb00-4afa-ac71-37ddc8138240
     method: GET
   response:
-    body: '{"placement_group":{"id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"fr-par-1"}}'
+    body: '{"placement_group":{"id":"c94a9260-bb00-4afa-ac71-37ddc8138240","name":"test-pool-placement-group","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "331"
@@ -3664,7 +2806,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:37 GMT
+      - Tue, 07 Nov 2023 15:54:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3674,7 +2816,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8185b7bb-e71a-44e0-9505-0fc63e9a110a
+      - 5c243216-639b-4cc0-8533-3c4a35384e3e
     status: 200 OK
     code: 200
     duration: ""
@@ -3685,19 +2827,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f7540fdb-410d-4d7d-8137-bb6dba36f1c7/nodes?order_by=created_at_asc&page=1&pool_id=fc2f2114-245c-4126-af09-d4a626251412&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5/nodes?order_by=created_at_asc&page=1&pool_id=f563d778-6543-42b7-bc3a-087d590a5137&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:39:21.654888Z","error_message":null,"id":"4027894d-57fa-4340-ad9d-f70613b6563b","name":"scw-test-pool-placeme-test-pool-placeme-402789","pool_id":"fc2f2114-245c-4126-af09-d4a626251412","provider_id":"scaleway://instance/fr-par-1/df8b6ad0-9aee-4bd8-9173-530acbaef773","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:43:34.297070Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:52:07.329064Z","error_message":null,"id":"dc941279-ea09-4131-990f-e339d6867cb2","name":"scw-test-pool-placeme-test-pool-placeme-dc9412","pool_id":"f563d778-6543-42b7-bc3a-087d590a5137","provider_id":"scaleway://instance/fr-par-1/d495283b-b8ba-4f22-8ed3-5dbe8f04c12b","public_ip_v4":"163.172.177.183","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:46.413340Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "660"
+      - "643"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:37 GMT
+      - Tue, 07 Nov 2023 15:54:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3707,7 +2849,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3fb11fd-d9fd-446d-a2d4-04a6fcccd474
+      - f95e484b-bae4-4986-8889-17ca5680e87c
     status: 200 OK
     code: 200
     duration: ""
@@ -3718,19 +2860,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f7540fdb-410d-4d7d-8137-bb6dba36f1c7/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoUFJFVXlUWHBaZWsxV2IxaEVWRTE2VFZSQmVFOUVSVEpOZWxsNlRWWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVFhvNENtYzNObTVrY1ZBdlVDOUNaVVJPWTFZNGF6Tk5ORko0Ym5CSE1HVjRkVkpuZEZoRFpGaDBSblZNWkV4a09VdzBNM05IVVVWWE1URTNSVFExYzI5alFrZ0taREZaVVhZeU5UQkJTVlpOYzNJMVRsQXZSMVYzWWtaNmN6Y3hMekV2WTIxWVNuQm1NMnN4U0dKT1MzRnNWMEp6UzNweFZFcGxWRFJGSzNKR1puaFVOQXBVZDJFNWFsUTVkbEp5U1dwRWRFTkVjV3hUTDNZeWFWRjBOMFp2VVhsR2VuTnlNSE5TVjJGSGJXSnJjSEY0WWxJd1EzRkNNV3NyYTFGME4ybFhNVFJsQ25VNFkzQlhTVUpFTlRsa1NXaERORVZDVERoSFFrNWlXbmhLVEVkMEwxVlZkMmhSYld4eU5qWnBTMUo2WW5SMFZYVjRXbVYyYkdOdGFIQjNSVkp2WmpRS2FWWlJNbUphS3pReFpYZEdLMkZoZVZsSFoyUXdiR0UzT1ZGRmNUaDRSazk2ZDNVMFlVZDVWVU5wU2xacmREZzBVRzVrZVhNcmJrbHZMMEZpUTFreFl3cDVkaTkyTlZRNFZVWldkM1J1UTFVelQxcGpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkRUelJDZW5oall6aE5WRFJoY1VoMWVXWlhTRTlaVmpSYVdFNU5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJhV0poVkcxdlQyWjFhME5EWjBGdFNtZFhlR1F3Y1dzcmQyMHpaMDVqZFRSaFExaElTMEZNWVZWbGNGRlhOVGhDV0FwQ1pEaFJhbEU0TjBsblZIcFdaRVo1UnpOUFVXZFdNWGxsZDIxbmJrbEVXbG9yUW1aQlNYbDZMMms0TWpkWVVXMW1SSG95WjJVNGJtWk5TMW8xUmxWSENtVTJiMFJITWxsUEszbEhVVVZGUzFoTE1HTllURXB1TmpWU2FVdERPSHBMYVhrd1ZFVjZhM1JxVjJwTWIzcFdaRFJGYkZsWlQyRmtaVXRPWW1GWGVtZ0tkRXN5TjFseWRsZHRjbVJsU2tSalJ5OUJZMVp0VjJWbFYzQkNUM1pLTjAxQ1MzcGlNMGcxVkc4clUzRnVRbkEyWVRVNFlTOWtiMGd2T0VodlVuVlFWZ3BpV0U1bU1VUTBiRUpDV0dadlUwVkNNVUpwTVdSbVJ6QnBNRVlyYnpOb2FXRkNSVkJCYVd0SlRqWTBMM1l4TkVzdmFVMHlWbGxIZWk5aWFURk5jVGRoQ2k4eE1rZFJaMVZWWkRGblZVcDRjMnhIZHpCTmIxSm5SbTFJWlZseEwxZDZhMHd3Y2dvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2Y3NTQwZmRiLTQxMGQtNGQ3ZC04MTM3LWJiNmRiYTM2ZjFjNy5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBBMkIycjdDNm1kZFp4cEdUcXRPSFA5R0d5dE55WVJBYW9UdENXYTBNeVY4YTdhTU5MQmZocFcwQw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXhUa1JyTVU1R2IxaEVWRTE2VFZSRmQwNXFSVEZPUkdzeFRrWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVERoRUNtMVdjMEp4TkVzMmNWaDRabXRGZW01aGNUWlFVVkk1T1d4bVRuWTFTemhLVERReFEwZExTelpWYVVKWGRtRnBWME5wZGxGdGNTOVlheTgwYUc1Q1ZqWUtjbWg1VXl0NlJ5c3ZRVmRVZDBaNU9VRldiMmhpZVZwT2ExUnpOMEZ3U0hGeU9XNXhabkZ0UW1rMWVHaExPVzVFU1RoT1NFbEVORVpNSzNvNGRFdExTZ3BoVDFZNWN6STFiSFpJU25CSlRtSkNkRWhOT0M5QlEwaFRjMjk0WWtKbFVXbGlVbmxETlZaSk5EbGpieXRCZG5wYUwyZDFURTlNVm1jM0wyUkJRbUkyQ21ZMWFqWkRiRWN5VG5kQ2VqaEtRVE5JUW1rNU5HcHNZWE5pTjBWSldtbFphWFIxYjBaR2NuaFBVamx6TW1Od1lVVk9NRUV6UTNKT1ZXbEhNM1pQVUcwS09WTTNWbkIwVFZWVWNWZGhTM0JwZUV0UlUwWkJhak5MVFc4eWJreFBNbmhZYkRNNFdHdFhVMUUxU3k5SVVIQlVUbGhxVG1oT1dscFFOV2czTTNCV2JBcFZXVGRzU1dkd2FrWlVlWEpJTUhwa01YVnpRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkdVVmRNYTNObVpFOWhkV3d5U2t3eE1XTlVSbXg0WlVFeFNtUk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJWbFY2YUdSYVZsVnJhVXAyUTFsV09YTnlkR2hzWW5FMk1GQnVWVFJWYVU1M05sVk5OR1p1TVU4MFpqTm9UbmhCYWdwV0swWkJkbEZuYm1wbFlVZHVlVk5yZVZsUGVUZG1WRU1yYm10R2IzVmtORmgxUzBkWWFGVkpiVmhrUlRaMFpsTnBhSEZHU21zNVNsVk9NM0Y1Yld0VENrUnlZVTlIUzA5SGIwRm5XbEZ3YVVOd1dXcFRlQ3RKVHpCcFJsSnNjMjVGTURoSllUTlZha2h5VmxjMlJtSlJibU5zTkVodmFXZDNOSFZDV1ZoMmNIUUtkV1JqVTBoa1MxZDViM0U1YW04eldtSnlObXRuVWtwbGVDdE5VR2Q1WWt0TU9VcGxkV0poTVM5WU1taHBSbVpuTTFZNU5USlhOekJ3WVVRNWNFNUdSZ3BxTUVkSFlXdHpla2hIYTNkQ05YTkRXbVJ5V25SdGIxWllXWGhTWTBNdmIwc3lWV3hwTWxGWVVYZE1UR3BGTW0wME9VY3phMU00ZDNSNmNtTTRlSGRsQ21wTk1YaGpWSHBQTUZONlRuVTRla1Y1U3pWT00yOWFVazVrWjNSbmVWRXdTRFJhYlFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2UxNTk3NjYwLWY5OTQtNDM4Zi1hYTk5LWE0MmM2NWYwMTBhNS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXBvb2wtcGxhY2VtZW50LWdyb3VwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBsNnJJdnFZZTFvdjd2MEw5TUNTWHdxVmYyVDh2azdtNjFuWWpDS3lQVTFoZ2hkSUljMk5GeEYySA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2694"
+      - "2692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:37 GMT
+      - Tue, 07 Nov 2023 15:54:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3740,7 +2882,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e2dc45d-d382-47c8-aa97-7626e334593a
+      - 2a817cdf-61d6-49bb-9974-35d01951447c
     status: 200 OK
     code: 200
     duration: ""
@@ -3751,19 +2893,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/fc2f2114-245c-4126-af09-d4a626251412
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
     method: DELETE
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","container_runtime":"containerd","created_at":"2023-10-19T16:36:35.239008Z","id":"fc2f2114-245c-4126-af09-d4a626251412","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-10-19T16:43:38.201796924Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:54:53.517101106Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "675"
+      - "652"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:38 GMT
+      - Tue, 07 Nov 2023 15:54:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3773,7 +2915,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49ec3cbb-2fa6-494a-9939-95d27c72b017
+      - b51d0631-db53-4684-b3e1-128b409d40e9
     status: 200 OK
     code: 200
     duration: ""
@@ -3784,15 +2926,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/ab8ca2ef-a0d7-4a79-a2b9-e7176646c0d0
-    method: DELETE
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    method: GET
   response:
-    body: ""
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:54:53.517101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
+      Content-Length:
+      - "649"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:38 GMT
+      - Tue, 07 Nov 2023 15:54:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3802,7 +2948,201 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 913c4130-e6f9-456f-af5b-6720dfe06b3f
+      - 717ac99e-29a8-4e15-907f-c35b03fb5a22
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:54:53.517101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "649"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:54:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 95be636b-ec72-4a86-94ec-9d4c18b807dd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:54:53.517101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "649"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7db6b678-479d-43fa-bbca-8ac056f105d2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"e1597660-f994-438f-aa99-a42c65f010a5","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.757238Z","id":"f563d778-6543-42b7-bc3a-087d590a5137","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group","node_type":"gp1_xs","placement_group_id":"c94a9260-bb00-4afa-ac71-37ddc8138240","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:54:53.517101Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "649"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 732c992b-2566-49bc-8eb6-bf359637d07e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f563d778-6543-42b7-bc3a-087d590a5137
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"f563d778-6543-42b7-bc3a-087d590a5137","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "125"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3bec5bfe-0894-48bc-952d-a089ce20bd72
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5?with_additional_resources=true
+    method: DELETE
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:55:13.825727679Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1474"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0c12f931-9381-4006-a372-dc4a05299097
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/placement_groups/c94a9260-bb00-4afa-ac71-37ddc8138240
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Tue, 07 Nov 2023 15:55:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 866ee651-b7ca-4689-bf6e-d143f08d1008
     status: 204 No Content
     code: 204
     duration: ""
@@ -3813,52 +3153,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f7540fdb-410d-4d7d-8137-bb6dba36f1c7?with_additional_resources=true
-    method: DELETE
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f7540fdb-410d-4d7d-8137-bb6dba36f1c7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:36:29.542789Z","created_at":"2023-10-19T16:36:29.542789Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f7540fdb-410d-4d7d-8137-bb6dba36f1c7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9589709f-af0f-49cb-923c-013c1e52a7e9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:43:38.276489896Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1519"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:43:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5f66e7f4-b0f6-4e3e-aa54-522eb070d4a8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f7540fdb-410d-4d7d-8137-bb6dba36f1c7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f7540fdb-410d-4d7d-8137-bb6dba36f1c7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:36:29.542789Z","created_at":"2023-10-19T16:36:29.542789Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f7540fdb-410d-4d7d-8137-bb6dba36f1c7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9589709f-af0f-49cb-923c-013c1e52a7e9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:43:38.276490Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:55:13.825728Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:38 GMT
+      - Tue, 07 Nov 2023 15:55:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3868,12 +3175,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a574296-90bc-416d-975d-e5f52c9ab437
+      - b13f4233-7a9b-47c5-ab52-95072f711980
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-placement-group","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_type":"max_availability"}'
+    body: '{"name":"test-pool-placement-group","project":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_type":"max_availability"}'
     form: {}
     headers:
       Content-Type:
@@ -3884,7 +3191,7 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups
     method: POST
   response:
-    body: '{"placement_group":{"id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-2"}}'
+    body: '{"placement_group":{"id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","name":"test-pool-placement-group","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"nl-ams-2"}}'
     headers:
       Content-Length:
       - "331"
@@ -3893,9 +3200,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:38 GMT
+      - Tue, 07 Nov 2023 15:55:14 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/7f6f05c9-ac80-412f-9a34-8a656e6ff284
+      - https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/16dcbca1-8d35-47bd-9973-6c8a5d7136e3
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3905,7 +3212,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c45f8f4e-af42-4c79-841d-cfc008ecb7e0
+      - 4b5a5429-eb02-432d-926c-4268ecc861a0
     status: 201 Created
     code: 201
     duration: ""
@@ -3916,10 +3223,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/7f6f05c9-ac80-412f-9a34-8a656e6ff284
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/16dcbca1-8d35-47bd-9973-6c8a5d7136e3
     method: GET
   response:
-    body: '{"placement_group":{"id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-2"}}'
+    body: '{"placement_group":{"id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","name":"test-pool-placement-group","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"nl-ams-2"}}'
     headers:
       Content-Length:
       - "331"
@@ -3928,7 +3235,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:38 GMT
+      - Tue, 07 Nov 2023 15:55:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3938,7 +3245,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d423634-ac14-43aa-a645-f28254001dd9
+      - bf5682fe-4eea-405c-b0a0-a8dd57b3b705
     status: 200 OK
     code: 200
     duration: ""
@@ -3949,19 +3256,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f7540fdb-410d-4d7d-8137-bb6dba36f1c7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f7540fdb-410d-4d7d-8137-bb6dba36f1c7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:36:29.542789Z","created_at":"2023-10-19T16:36:29.542789Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f7540fdb-410d-4d7d-8137-bb6dba36f1c7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9589709f-af0f-49cb-923c-013c1e52a7e9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:43:38.276490Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:55:13.825728Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:43 GMT
+      - Tue, 07 Nov 2023 15:55:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3971,7 +3278,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57b0b69b-db6d-4553-a83f-57a98711f258
+      - a78b211a-ae38-4734-860b-7fd616fcc610
     status: 200 OK
     code: 200
     duration: ""
@@ -3982,19 +3289,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f7540fdb-410d-4d7d-8137-bb6dba36f1c7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f7540fdb-410d-4d7d-8137-bb6dba36f1c7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:36:29.542789Z","created_at":"2023-10-19T16:36:29.542789Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f7540fdb-410d-4d7d-8137-bb6dba36f1c7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9589709f-af0f-49cb-923c-013c1e52a7e9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:43:38.276490Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:55:13.825728Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:48 GMT
+      - Tue, 07 Nov 2023 15:55:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4004,7 +3311,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b994bce8-4f1f-4dff-b84c-5132ecb21368
+      - d1d71eb6-6e20-4601-856d-ddf7cf2507a8
     status: 200 OK
     code: 200
     duration: ""
@@ -4015,19 +3322,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f7540fdb-410d-4d7d-8137-bb6dba36f1c7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f7540fdb-410d-4d7d-8137-bb6dba36f1c7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:36:29.542789Z","created_at":"2023-10-19T16:36:29.542789Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f7540fdb-410d-4d7d-8137-bb6dba36f1c7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"9589709f-af0f-49cb-923c-013c1e52a7e9","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:43:38.276490Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e1597660-f994-438f-aa99-a42c65f010a5.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:53.224347Z","created_at":"2023-11-07T15:49:53.224347Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e1597660-f994-438f-aa99-a42c65f010a5.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e1597660-f994-438f-aa99-a42c65f010a5","ingress":"none","name":"test-pool-placement-group","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"d539826f-786f-4091-98fd-69d345ea1be0","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:55:13.825728Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:53 GMT
+      - Tue, 07 Nov 2023 15:55:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4037,7 +3344,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e85d34d4-d116-486a-bc8c-1c4c59b775f0
+      - a560a082-1a73-4dfa-86b9-4d4644bfc81c
     status: 200 OK
     code: 200
     duration: ""
@@ -4048,10 +3355,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f7540fdb-410d-4d7d-8137-bb6dba36f1c7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e1597660-f994-438f-aa99-a42c65f010a5
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"f7540fdb-410d-4d7d-8137-bb6dba36f1c7","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"e1597660-f994-438f-aa99-a42c65f010a5","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -4060,7 +3367,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:58 GMT
+      - Tue, 07 Nov 2023 15:55:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4070,7 +3377,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - efd973e6-0aa9-48d2-8dac-45ef3d23b905
+      - 5dbd8869-04d7-405f-af91-c96ab364e0c5
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4081,10 +3388,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9589709f-af0f-49cb-923c-013c1e52a7e9
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d539826f-786f-4091-98fd-69d345ea1be0
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"9589709f-af0f-49cb-923c-013c1e52a7e9","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"d539826f-786f-4091-98fd-69d345ea1be0","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -4093,7 +3400,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:58 GMT
+      - Tue, 07 Nov 2023 15:55:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4103,12 +3410,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ab8a419-a23d-4cee-8180-f668f56da3fa
+      - 6a9a48d7-8dc7-4375-9a8c-acf82b79822c
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"name":"test-pool-placement-group","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"test-pool-placement-group","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -4119,16 +3426,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-19T16:43:58.680766Z","dhcp_enabled":true,"id":"4411aeed-e6da-4aa8-bcf2-62092760e70a","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-19T16:43:58.680766Z","id":"9ebe3614-855f-49c6-addc-39856c1577db","subnet":"172.16.4.0/22","updated_at":"2023-10-19T16:43:58.680766Z"},{"created_at":"2023-10-19T16:43:58.680766Z","id":"d2807e41-8a46-4431-acf1-cca1adc4449a","subnet":"fd68:d440:21c4:d87b::/64","updated_at":"2023-10-19T16:43:58.680766Z"}],"tags":[],"updated_at":"2023-10-19T16:43:58.680766Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-07T15:55:34.222869Z","dhcp_enabled":true,"id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","name":"test-pool-placement-group","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-07T15:55:34.222869Z","id":"8288ef17-3d79-4711-b932-6a388353bddd","subnet":"172.16.16.0/22","updated_at":"2023-11-07T15:55:34.222869Z"},{"created_at":"2023-11-07T15:55:34.222869Z","id":"99b04b07-3bc6-47f6-9b0a-d058622f495f","subnet":"fd5c:d510:d730:ed79::/64","updated_at":"2023-11-07T15:55:34.222869Z"}],"tags":[],"updated_at":"2023-11-07T15:55:34.222869Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
     headers:
       Content-Length:
-      - "725"
+      - "709"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:59 GMT
+      - Tue, 07 Nov 2023 15:55:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4138,7 +3445,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd62a8e8-97d6-4dc5-a46f-07d040bf767c
+      - 0329a7f0-92cb-4f82-8b68-655bd3399974
     status: 200 OK
     code: 200
     duration: ""
@@ -4149,19 +3456,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/4411aeed-e6da-4aa8-bcf2-62092760e70a
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/8de1f7a3-88bf-4638-8306-a9b136db35ee
     method: GET
   response:
-    body: '{"created_at":"2023-10-19T16:43:58.680766Z","dhcp_enabled":true,"id":"4411aeed-e6da-4aa8-bcf2-62092760e70a","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-19T16:43:58.680766Z","id":"9ebe3614-855f-49c6-addc-39856c1577db","subnet":"172.16.4.0/22","updated_at":"2023-10-19T16:43:58.680766Z"},{"created_at":"2023-10-19T16:43:58.680766Z","id":"d2807e41-8a46-4431-acf1-cca1adc4449a","subnet":"fd68:d440:21c4:d87b::/64","updated_at":"2023-10-19T16:43:58.680766Z"}],"tags":[],"updated_at":"2023-10-19T16:43:58.680766Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-07T15:55:34.222869Z","dhcp_enabled":true,"id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","name":"test-pool-placement-group","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-07T15:55:34.222869Z","id":"8288ef17-3d79-4711-b932-6a388353bddd","subnet":"172.16.16.0/22","updated_at":"2023-11-07T15:55:34.222869Z"},{"created_at":"2023-11-07T15:55:34.222869Z","id":"99b04b07-3bc6-47f6-9b0a-d058622f495f","subnet":"fd5c:d510:d730:ed79::/64","updated_at":"2023-11-07T15:55:34.222869Z"}],"tags":[],"updated_at":"2023-11-07T15:55:34.222869Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
     headers:
       Content-Length:
-      - "725"
+      - "709"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:00 GMT
+      - Tue, 07 Nov 2023 15:55:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4171,12 +3478,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74fe5b9e-117b-4db4-909c-68c82267507d
+      - 8910aab1-13c5-4205-bd42-fa2e778f3005
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-placement-group-2","description":"","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":"4411aeed-e6da-4aa8-bcf2-62092760e70a"}'
+    body: '{"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","type":"","name":"test-pool-placement-group-2","description":"","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee"}'
     form: {}
     headers:
       Content-Type:
@@ -4187,16 +3494,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ea2b3b34-650f-4e4b-b8bb-34e9042c198f.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:44:00.220505685Z","created_at":"2023-10-19T16:44:00.220505685Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ea2b3b34-650f-4e4b-b8bb-34e9042c198f.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"4411aeed-e6da-4aa8-bcf2-62092760e70a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:44:00.238460647Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:55:35.886773868Z","created_at":"2023-11-07T15:55:35.886773868Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:55:35.906055566Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1527"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:00 GMT
+      - Tue, 07 Nov 2023 15:55:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4206,7 +3513,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b060f78-898c-4907-a860-9320aebfd691
+      - 217be422-d2b5-4dda-b31c-802b5a896863
     status: 200 OK
     code: 200
     duration: ""
@@ -4217,19 +3524,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ea2b3b34-650f-4e4b-b8bb-34e9042c198f
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ea2b3b34-650f-4e4b-b8bb-34e9042c198f.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:44:00.220506Z","created_at":"2023-10-19T16:44:00.220506Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ea2b3b34-650f-4e4b-b8bb-34e9042c198f.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"4411aeed-e6da-4aa8-bcf2-62092760e70a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:44:00.238461Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:55:35.886774Z","created_at":"2023-11-07T15:55:35.886774Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:55:35.906056Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1518"
+      - "1473"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:00 GMT
+      - Tue, 07 Nov 2023 15:55:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4239,7 +3546,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 928d1d9b-2cdb-4cb6-80af-c67539ccda6b
+      - 4174c4c1-af50-4e99-8748-1e731dee2215
     status: 200 OK
     code: 200
     duration: ""
@@ -4250,19 +3557,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ea2b3b34-650f-4e4b-b8bb-34e9042c198f
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ea2b3b34-650f-4e4b-b8bb-34e9042c198f.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:44:00.220506Z","created_at":"2023-10-19T16:44:00.220506Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ea2b3b34-650f-4e4b-b8bb-34e9042c198f.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"4411aeed-e6da-4aa8-bcf2-62092760e70a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:44:02.043807Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:55:35.886774Z","created_at":"2023-11-07T15:55:35.886774Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:55:37.891856Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1523"
+      - "1478"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:05 GMT
+      - Tue, 07 Nov 2023 15:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4272,7 +3579,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 995bd3b2-22d0-439b-8754-38414d0c7e90
+      - e807b94a-6499-4738-a171-5711b26627b7
     status: 200 OK
     code: 200
     duration: ""
@@ -4283,19 +3590,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ea2b3b34-650f-4e4b-b8bb-34e9042c198f
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ea2b3b34-650f-4e4b-b8bb-34e9042c198f.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:44:00.220506Z","created_at":"2023-10-19T16:44:00.220506Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ea2b3b34-650f-4e4b-b8bb-34e9042c198f.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"4411aeed-e6da-4aa8-bcf2-62092760e70a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:44:02.043807Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:55:35.886774Z","created_at":"2023-11-07T15:55:35.886774Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:55:37.891856Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1523"
+      - "1478"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:05 GMT
+      - Tue, 07 Nov 2023 15:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4305,7 +3612,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19ef5f9b-4e5b-4c00-b1b5-c1bb8be112fb
+      - 7c6add2c-259d-4c45-95d3-aa7bf3dac6eb
     status: 200 OK
     code: 200
     duration: ""
@@ -4316,19 +3623,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ea2b3b34-650f-4e4b-b8bb-34e9042c198f/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhQUkVVeVRrUlJkMDFXYjFoRVZFMTZUVlJCZUU5RVJUSk9SRkYzVFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUWFJpQ2pCQ1dVSktOalZ3YUM4d2NHNXhkR1p4VTA1MFFtUmtUV2hYVnpGSE5uRnVTeXRwVDNkd1lWQmxMeXM0ZDFZNGVrNU1VR0pSWTNsSWNIZGFSMDlhVG1RS04xRkVRbGhxUkRKdk1XbFJjbGh4SzAxVWFGZG9SVXRTU2xKUWIwcDNOMjlKT0N0V1dFdFlSMVVyVERCVlNYbHZVU3M1VldsWGRrOXNjUzk2Y0Zsck1RcHFVVkIxVTJSNk5rY3dhRXB3TkdSVFJUSXhjWGhTVlRnelNVaDZRVlp6TkhBMVpXMXZUblJpYkRkbE5UY3lXSEoxVDJ4Q2NWbFRhMUJ1ZG05eksyMXRDa1ZCV2paelJGWjFlbTUyTUhWVVJGTnpNM2Q0TUVKd1EwVlpabmhZT1dabFpETlNOMHRTUkdJd1VXRTJNSGQxZEdNM2JIUnROMjlaTDJKWEx6UklRbkFLZUV0VWJ6aHpORzQwWlRSVU4ySXJVbkJGYzBrME1EZFZSbFp0WXpWcVZHOHpiVWhoUjJSTU9IVXJXa3gwYm1KNWRWRm1Sa3BLV2lzclNVbEVSVEp5UWdwb2JFeDZObEZwVDJSU1NESnNibnA2V0RoclEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUVowMXlSMGgzUjFaSlRXcGpWQzk2YVRoMllsSmFSMWR4VnpsTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2NFZFJlR1ZCYmk5VU0xbHFVV2hIVFhKbFZraEtRWEZsVmpRckwzbExhSE5HYmpCYVpsVnRjM0JOUTJFNVJVaEdVUXAyTTBkdlNHeHZWbXBrV21obE1VdFBOMmhHVGxBck1WQjRXV2xUVTJScllXMXpXbkJoZFc0MFpuWTNSRTlEYlhGelVqbHBVekZTV1hSSFNqWmpXVVo0Q25ac2RGWkxkQ3QwYzBReGFHMDJPVlZTT0VSTWEwOXhXa1JVVmpVM2Rua3JSbXAyTDFWR01rWTNRMWRpY3pCa0wxWnZNMmhhT0ZGa2JrcFFlV1J4Y20wS2RrTm5hR0ZqVERoMFNVTmFlR1ZsWWtoVGVIZHVRa294Y1hsR2JWaHdjakpETHpZcmIwMTZUMmN5TUdwQlIzWXdXalJtUkVvd1ZGRnlkQzh4U0dOMGJncEJaVWRIYTFCWFlqUkRXbVpWYWpReFFtNWpObUpYUXpGNVJuQlJjakozUkdoRGFGaE1OR3BOT0ZsUGMwSnVNRlZMTlRsbGIyRkdhRUZKZDFjeE5TdDZDbkF2Y0U1NU9EWnpaRk1yTkZOUFRrZ3pWVTVGUmk4MVRtZGtSRVF6YTNNeGRVZDVNUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZWEyYjNiMzQtNjUwZi00ZTRiLWI4YmItMzRlOTA0MmMxOThmLmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpSllzNU1nSlUxMUVEd2s1dkNoSm5abDhMY0xZRlRldTJ0Q21XaXBDZWU5dnhZMWNFaFJjN0dqeQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeFRsUlZlazR4YjFoRVZFMTZUVlJGZDA1cVJURk9WRlY2VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVXRXQ2psYVJsbHJkVGRpZVdGVlJrOWtka3BtY3pnd2IzVkJhRXh1WTNGVGNWRnRaR3RtYWpWV09IZEhaVVZKVkM5VFp6SllhR05RTld0MU5sSllUMUpDUWpRS2FHSlFPVGhRVlM5a2JHMXlOa3BWT0RKeVQwRjBUbmRSUTB0QlNFOHlkbkZWY1RONFIxcEVWakF3TDJ0T1dFUjNibFZOT0VWTFlrWjZObFJqUjAxak53b3ZTbE1yT0Rnd1ZVRlFRVkZ1Y2pJeVMwMVNZakZSYW5kWVZIUmpkMGR2TjBrMlIzbG9MMlJ2VWtkeVpETnJUbWxvVVM5dE16UlZkVlpvWVhJeGNrOXFDamRNUW5waFl6bEtjQ3RTUVZacmJtMWxabU5wZWxBNWNVSlBTekJ1TUdZeFUwTnRSRTg1SzNReVIyRkZOMFJTTkZaQ1pVcHdURzlSTm1aT1ozTnVlV01LY0dGNk5WaFljRzlMTDJWSkwwOTBOVUpYTkZnNWNrODBaWEJJVWtGVGRWZDBlR1ZYVERoQmNsWkRRbnBCVEdwYVdYSXZUWEprWmxCTVpqVmtReTgwVEFwTFoyaFdLM2RXWm5ocFMwSlRZaTh3Vkc1TlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQlRHTXJZV2xzTTJaMVExTkxNRkJ6ZEV0T1F6ZEhWbXRUYVdoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1V5ODFZa2xUTm05bWVVNUJNa3B2TjBsb1JGTnpSekJaTW5oNFJVTmFhR2xqUmtOUVdFRXJaeXRCZVRReWVqRlJVd3BSYm1kMFQxSkhkVkZQTm1sS1ozZHFOREZhVWpRNU9XbzRaalZpUlZwTmFUaHFla2cxTlZRd0szcENXV3BuWml0TWF6VjNSRTUyYmpjMmFFRnVNV2R1Q2tKSE5USllRM05uYlZKS2VqUmhXa00yVlRnNGREWkdRMWx0ZVd4RFJtTm9VR1JQT1VGRWRYWnRabFl4VERkVFkyVnJVbU5TTlhJNGVVMU9aR2xJT1dVS2N5czNSMk5EZG5KcE1rSlhPR2R2UTJaRWMySlRkR3gzTWtkS1ZYRTJTSE5wY21VNFNrcGtNMU5FUnk4MmVFTjRWMWREZVRKTlowaFVaVXhUU2tJMVpncFFNREZoUkU5RGNUUmtZa0ZFWWtWSVdGWnlNVEp6YjNrNWRtdElVVUpzVWtsUVVEYzVObEpuTUVONmVUYzJaVEpEYWtST1ltSTJTMmhHVURsRVVIQllDblJZWjNCbGRGWkVkSFZDTnpSamJWVlVTa2RsWlN0dGNYRk1TV2hFYlhoNlJtaE5VUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNmVhMmYzZTUtYjdmMi00NGVmLWFmMGItMTc3NjJiYTgxYjI1LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB5S1VUM3RtNEt0dnh5NG8yTEJYa2FZYWxjWmw5ck9TRHhpZTVLMEpEdTNHMVpQNk1RdXQ1blAwNw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2710"
+      - "2708"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:05 GMT
+      - Tue, 07 Nov 2023 15:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4338,7 +3645,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b724cf6-e430-41a3-8d19-b94191f3b7fb
+      - dc33b355-0d2d-4238-b87a-ee0bcc7519cd
     status: 200 OK
     code: 200
     duration: ""
@@ -4349,19 +3656,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ea2b3b34-650f-4e4b-b8bb-34e9042c198f
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ea2b3b34-650f-4e4b-b8bb-34e9042c198f.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:44:00.220506Z","created_at":"2023-10-19T16:44:00.220506Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ea2b3b34-650f-4e4b-b8bb-34e9042c198f.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"4411aeed-e6da-4aa8-bcf2-62092760e70a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:44:02.043807Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:55:35.886774Z","created_at":"2023-11-07T15:55:35.886774Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:55:37.891856Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1523"
+      - "1478"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:05 GMT
+      - Tue, 07 Nov 2023 15:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4371,12 +3678,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64d99123-4f96-4dff-a273-5dc22dffef7a
+      - ff26d866-62eb-4428-8a27-a97368ddbd41
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"upgrade_policy":null,"zone":"nl-ams-2","root_volume_type":"default_volume_type","root_volume_size":null,"public_ip_disabled":false}'
+    body: '{"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"zone":"nl-ams-2","root_volume_type":"default_volume_type","public_ip_disabled":false}'
     form: {}
     headers:
       Content-Type:
@@ -4384,19 +3691,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ea2b3b34-650f-4e4b-b8bb-34e9042c198f/pools
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25/pools
     method: POST
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214077Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186326Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "676"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:06 GMT
+      - Tue, 07 Nov 2023 15:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4406,7 +3713,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d49f0ff2-9af1-43eb-aa99-8591e6dd483a
+      - 6197d28e-8f21-4be6-bb62-0e86eac9d9ea
     status: 200 OK
     code: 200
     duration: ""
@@ -4417,19 +3724,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:06 GMT
+      - Tue, 07 Nov 2023 15:55:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4439,7 +3746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0c36b02-30a8-4654-b5a5-e95ad23c9b1e
+      - 47438e42-3b76-4dc7-a779-d4decb0d0527
     status: 200 OK
     code: 200
     duration: ""
@@ -4450,19 +3757,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:11 GMT
+      - Tue, 07 Nov 2023 15:55:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4472,7 +3779,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5ad0e1d-47ef-4ff8-a774-47f5391ce844
+      - a81136b2-4134-4f83-9c65-0f85089ea66d
     status: 200 OK
     code: 200
     duration: ""
@@ -4483,19 +3790,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:16 GMT
+      - Tue, 07 Nov 2023 15:55:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4505,7 +3812,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0a9894a-f150-4f2d-8410-cf8520dbbc87
+      - ad47c972-8415-40b4-81a7-0f6026f62ad0
     status: 200 OK
     code: 200
     duration: ""
@@ -4516,19 +3823,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:21 GMT
+      - Tue, 07 Nov 2023 15:55:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4538,7 +3845,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e915c46f-2a2a-4d77-8ea6-92c37d7090a6
+      - 8c31460d-d4a1-41b2-a26b-ab742399be25
     status: 200 OK
     code: 200
     duration: ""
@@ -4549,19 +3856,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:26 GMT
+      - Tue, 07 Nov 2023 15:56:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4571,7 +3878,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 775324d8-714e-47cd-a322-7470bf0c22d8
+      - 0bd8badc-2648-48d2-9c18-85b08abe78d3
     status: 200 OK
     code: 200
     duration: ""
@@ -4582,19 +3889,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:31 GMT
+      - Tue, 07 Nov 2023 15:56:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4604,7 +3911,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5d05024-41b1-45d5-be0f-922f9770dfee
+      - bb3ae7b4-1450-4309-989a-757eb119a884
     status: 200 OK
     code: 200
     duration: ""
@@ -4615,19 +3922,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:37 GMT
+      - Tue, 07 Nov 2023 15:56:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4637,7 +3944,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de371d6f-75d6-4d9d-a30f-06998680c65a
+      - 89a95d54-60dc-4b46-bb4b-b9e4de554a51
     status: 200 OK
     code: 200
     duration: ""
@@ -4648,19 +3955,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:42 GMT
+      - Tue, 07 Nov 2023 15:56:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4670,7 +3977,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f47571f-5f6c-4df9-bd4a-5b7fcc48e26e
+      - 8125eff1-8dd4-403a-8293-44e0a7263149
     status: 200 OK
     code: 200
     duration: ""
@@ -4681,19 +3988,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:47 GMT
+      - Tue, 07 Nov 2023 15:56:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4703,7 +4010,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6ff6fb3-88f8-4d78-bdb2-c127f4e369fd
+      - 135b4bb6-22e8-4cc8-ab02-dd007ab2bf81
     status: 200 OK
     code: 200
     duration: ""
@@ -4714,19 +4021,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:52 GMT
+      - Tue, 07 Nov 2023 15:56:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4736,7 +4043,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16523be0-7dba-4283-b006-b171e8bf07ff
+      - 40bd432e-a705-46d9-b8bd-537b4f5aec09
     status: 200 OK
     code: 200
     duration: ""
@@ -4747,19 +4054,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:57 GMT
+      - Tue, 07 Nov 2023 15:56:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4769,7 +4076,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bedad5ee-edb8-4ea5-8e63-8d3ecdfe1635
+      - c15d3251-2666-4595-984b-944dfff1afdf
     status: 200 OK
     code: 200
     duration: ""
@@ -4780,19 +4087,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:45:02 GMT
+      - Tue, 07 Nov 2023 15:56:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4802,7 +4109,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2963a5bf-85be-41bc-b57a-1d30b49f76ac
+      - 24a588d5-9e73-49f3-b3dd-7bb17f5fa35b
     status: 200 OK
     code: 200
     duration: ""
@@ -4813,19 +4120,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:45:07 GMT
+      - Tue, 07 Nov 2023 15:56:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4835,7 +4142,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7fd703ae-cf73-4fc7-b209-3c9051a81ffd
+      - 35994b64-b9e8-4e0e-bcde-e57a8ab55f66
     status: 200 OK
     code: 200
     duration: ""
@@ -4846,19 +4153,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:45:12 GMT
+      - Tue, 07 Nov 2023 15:56:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4868,7 +4175,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10cf9ecb-a8e7-4fbd-9827-09d4c0e8298c
+      - dc239222-b285-4148-99ba-6735c481983a
     status: 200 OK
     code: 200
     duration: ""
@@ -4879,19 +4186,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:45:17 GMT
+      - Tue, 07 Nov 2023 15:56:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4901,7 +4208,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19bb171e-6ff0-44b8-b7f1-1040fa2aca89
+      - 67d691d9-e4c5-4126-9d70-dd60f59807c1
     status: 200 OK
     code: 200
     duration: ""
@@ -4912,19 +4219,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:45:22 GMT
+      - Tue, 07 Nov 2023 15:56:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4934,7 +4241,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eae4d566-da26-4bf4-9ae9-8e25ce630935
+      - b1977125-9a49-4fe8-b998-7549e18295b2
     status: 200 OK
     code: 200
     duration: ""
@@ -4945,19 +4252,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:45:27 GMT
+      - Tue, 07 Nov 2023 15:57:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4967,7 +4274,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4267db32-14a6-4d42-b356-5169043c8784
+      - 6a1bb7d9-ae42-46b3-9b9a-784cb090639f
     status: 200 OK
     code: 200
     duration: ""
@@ -4978,19 +4285,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:45:32 GMT
+      - Tue, 07 Nov 2023 15:57:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5000,7 +4307,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9e41fde-5a57-45a9-b9b4-6251cb539689
+      - 8de09beb-c454-456b-9ec9-58cc77af0600
     status: 200 OK
     code: 200
     duration: ""
@@ -5011,19 +4318,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:45:38 GMT
+      - Tue, 07 Nov 2023 15:57:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5033,7 +4340,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0161a54-5469-44e6-801a-2a92f107d5db
+      - 5595202a-dcd3-4f2c-b44e-55b3fbbba8e6
     status: 200 OK
     code: 200
     duration: ""
@@ -5044,19 +4351,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:45:43 GMT
+      - Tue, 07 Nov 2023 15:57:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5066,7 +4373,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 922880be-61b0-4e39-b8ea-a3ef45fbe927
+      - ab1776e9-daea-450f-adc3-e458e3bcdbb3
     status: 200 OK
     code: 200
     duration: ""
@@ -5077,19 +4384,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:45:48 GMT
+      - Tue, 07 Nov 2023 15:57:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5099,7 +4406,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8cc3f241-d229-4270-92be-9a578726f568
+      - 8b89963b-3134-44be-a216-653ed5baeb2e
     status: 200 OK
     code: 200
     duration: ""
@@ -5110,19 +4417,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:45:53 GMT
+      - Tue, 07 Nov 2023 15:57:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5132,7 +4439,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ffa86cdb-3636-4327-bab3-7482a7c22e2f
+      - fb3022a6-17a4-4092-bb09-ce4b2a4284a2
     status: 200 OK
     code: 200
     duration: ""
@@ -5143,19 +4450,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:45:58 GMT
+      - Tue, 07 Nov 2023 15:57:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5165,7 +4472,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5984ddbe-0495-49e4-8ca3-325b941945a9
+      - 429a04a1-ac1c-414a-ab07-29ecb7b5c39e
     status: 200 OK
     code: 200
     duration: ""
@@ -5176,19 +4483,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:46:03 GMT
+      - Tue, 07 Nov 2023 15:57:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5198,7 +4505,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 558b24fa-c9c5-4d80-be11-633dda57ac53
+      - 76eeec04-f86f-4d18-a999-160f60feaf5d
     status: 200 OK
     code: 200
     duration: ""
@@ -5209,19 +4516,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:46:08 GMT
+      - Tue, 07 Nov 2023 15:57:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5231,7 +4538,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9a11caf-2d6e-47bc-b833-06eb3602d65c
+      - 5ffc9a23-a61c-44e8-8130-adecbc8eb98a
     status: 200 OK
     code: 200
     duration: ""
@@ -5242,19 +4549,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:46:13 GMT
+      - Tue, 07 Nov 2023 15:57:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5264,7 +4571,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3d3c856-cead-4abe-a954-f5a2083fbbb9
+      - 93cc2e87-f43c-4991-9bf6-2cd19a05346b
     status: 200 OK
     code: 200
     duration: ""
@@ -5275,19 +4582,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:46:19 GMT
+      - Tue, 07 Nov 2023 15:57:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5297,7 +4604,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a59cf4ea-e4e9-44d7-82c1-2acc36edc214
+      - 8124fe6b-0e8f-47be-aee8-88b9f21bf0d0
     status: 200 OK
     code: 200
     duration: ""
@@ -5308,19 +4615,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:46:24 GMT
+      - Tue, 07 Nov 2023 15:57:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5330,7 +4637,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 029a626f-e56e-492d-b1c2-cfc449d8d0ee
+      - 97403502-c517-4d62-b808-81bbea8bdb72
     status: 200 OK
     code: 200
     duration: ""
@@ -5341,19 +4648,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:46:29 GMT
+      - Tue, 07 Nov 2023 15:58:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5363,7 +4670,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e453c61b-2941-4e07-ba07-af31e2c39b54
+      - 0628ff3d-7811-4cdc-a083-296ff9ff62ac
     status: 200 OK
     code: 200
     duration: ""
@@ -5374,19 +4681,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:46:34 GMT
+      - Tue, 07 Nov 2023 15:58:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5396,7 +4703,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e153796-8363-4d8a-a5f5-1626920231fc
+      - 314a8ff6-a104-4b74-b05b-35792b4257ea
     status: 200 OK
     code: 200
     duration: ""
@@ -5407,19 +4714,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:46:39 GMT
+      - Tue, 07 Nov 2023 15:58:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5429,7 +4736,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2348a1fa-2452-4a31-bc40-bf7a6ac9a739
+      - d0cb1fef-14db-4fde-aaa5-18ea6eecf141
     status: 200 OK
     code: 200
     duration: ""
@@ -5440,19 +4747,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:46:44 GMT
+      - Tue, 07 Nov 2023 15:58:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5462,7 +4769,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8866099f-6df7-4e80-93a5-0e7a68260a03
+      - 9aecf73f-19aa-4f9b-aca6-0be30729ff55
     status: 200 OK
     code: 200
     duration: ""
@@ -5473,19 +4780,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:46:49 GMT
+      - Tue, 07 Nov 2023 15:58:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5495,7 +4802,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9405163a-5f09-4e47-9b4c-0f65f7422ffe
+      - 19958ca7-096a-4e87-b1b6-7408202ab1c3
     status: 200 OK
     code: 200
     duration: ""
@@ -5506,19 +4813,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:46:54 GMT
+      - Tue, 07 Nov 2023 15:58:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5528,7 +4835,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31dbce97-53b6-43c8-b2b0-5e1a6f05013a
+      - e9033fb7-195a-459b-9143-602a163953c8
     status: 200 OK
     code: 200
     duration: ""
@@ -5539,19 +4846,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:46:59 GMT
+      - Tue, 07 Nov 2023 15:58:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5561,7 +4868,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e02630b-84ab-46d1-b733-f1116cc497ff
+      - d930c10f-ed6c-42a1-8bba-3a182b56abe6
     status: 200 OK
     code: 200
     duration: ""
@@ -5572,19 +4879,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:47:04 GMT
+      - Tue, 07 Nov 2023 15:58:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5594,7 +4901,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 432b5316-d43b-4237-bd56-2250c4abf56e
+      - 6e6f3441-a54a-4ce4-a867-73445b21b68f
     status: 200 OK
     code: 200
     duration: ""
@@ -5605,19 +4912,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:47:09 GMT
+      - Tue, 07 Nov 2023 15:58:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5627,7 +4934,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1bd65ad3-1ff1-4933-b6ff-7573252fe95e
+      - c4e927fc-a7a6-491d-9567-39b9d46ca537
     status: 200 OK
     code: 200
     duration: ""
@@ -5638,19 +4945,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:47:14 GMT
+      - Tue, 07 Nov 2023 15:58:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5660,7 +4967,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0b7df3a5-c72b-410a-bd1a-cf435e41b724
+      - c3673598-88b0-4e2c-a765-9ef29f276576
     status: 200 OK
     code: 200
     duration: ""
@@ -5671,19 +4978,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:47:19 GMT
+      - Tue, 07 Nov 2023 15:58:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5693,7 +5000,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53464567-c846-4055-9106-9c70863ed51f
+      - 1e4062db-986e-49b0-b9ef-e7e947e2b038
     status: 200 OK
     code: 200
     duration: ""
@@ -5704,19 +5011,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:47:25 GMT
+      - Tue, 07 Nov 2023 15:59:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5726,7 +5033,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d184834-fc45-46c7-877a-df85591e557f
+      - a1fe3f20-b9db-4802-9bd5-17d61fe1607d
     status: 200 OK
     code: 200
     duration: ""
@@ -5737,19 +5044,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:47:30 GMT
+      - Tue, 07 Nov 2023 15:59:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5759,7 +5066,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ed232cb-6c35-4711-b2c5-d29fb4da81fc
+      - 0262e0b4-45b6-494d-8a49-74639083f933
     status: 200 OK
     code: 200
     duration: ""
@@ -5770,19 +5077,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:47:35 GMT
+      - Tue, 07 Nov 2023 15:59:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5792,7 +5099,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76982e33-7d4c-41b0-949f-368233dc0d05
+      - 1a7e0f87-0434-4a46-b27e-402ac223eef4
     status: 200 OK
     code: 200
     duration: ""
@@ -5803,19 +5110,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:47:40 GMT
+      - Tue, 07 Nov 2023 15:59:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5825,7 +5132,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c72dc151-9932-4146-b38a-b704a5ac6550
+      - 95155b82-c208-4793-b0dd-edd1c7bc37e4
     status: 200 OK
     code: 200
     duration: ""
@@ -5836,19 +5143,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:47:45 GMT
+      - Tue, 07 Nov 2023 15:59:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5858,7 +5165,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7119c654-7c92-4242-941d-376691000732
+      - 7d6ad861-4273-4759-b88b-c6a8308c5f5d
     status: 200 OK
     code: 200
     duration: ""
@@ -5869,19 +5176,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:47:50 GMT
+      - Tue, 07 Nov 2023 15:59:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5891,7 +5198,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8aecfd91-5a55-43b9-9070-ed7dc1152d63
+      - 8ce74164-63e4-4687-a3ea-727689a4bcc0
     status: 200 OK
     code: 200
     duration: ""
@@ -5902,19 +5209,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:47:55 GMT
+      - Tue, 07 Nov 2023 15:59:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5924,7 +5231,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3afafd0-4e65-4cd6-9002-597cbd16d8ba
+      - c6995330-8480-4028-9929-81dacafc8311
     status: 200 OK
     code: 200
     duration: ""
@@ -5935,19 +5242,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:48:00 GMT
+      - Tue, 07 Nov 2023 15:59:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5957,7 +5264,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78b5e3de-b87d-484e-b741-0eba3979c743
+      - 3bd8c8bc-9727-4ea0-83fd-161e44d350a6
     status: 200 OK
     code: 200
     duration: ""
@@ -5968,19 +5275,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:48:05 GMT
+      - Tue, 07 Nov 2023 15:59:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5990,7 +5297,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d06605a5-810e-4e1f-9592-7cada3139dee
+      - 74c268ed-132e-4771-ac89-72206a83f331
     status: 200 OK
     code: 200
     duration: ""
@@ -6001,19 +5308,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:48:10 GMT
+      - Tue, 07 Nov 2023 15:59:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6023,7 +5330,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4a38db8-9269-4fb9-a353-cbc067ec21c2
+      - 4d504984-b849-43e5-96f7-400999f3f5d8
     status: 200 OK
     code: 200
     duration: ""
@@ -6034,19 +5341,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:48:15 GMT
+      - Tue, 07 Nov 2023 15:59:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6056,7 +5363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72f36f73-0f12-4210-8f9e-90dcd68eeecb
+      - 3e2f5c02-dc33-4543-a3ef-d32d5e6cc780
     status: 200 OK
     code: 200
     duration: ""
@@ -6067,19 +5374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:48:20 GMT
+      - Tue, 07 Nov 2023 15:59:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6089,7 +5396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f56ecc4d-9662-4ef3-9db6-e65f84663ac7
+      - 1207b469-3b3a-432f-ba1f-e99d954ac3eb
     status: 200 OK
     code: 200
     duration: ""
@@ -6100,19 +5407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:55:41.758186Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:48:25 GMT
+      - Tue, 07 Nov 2023 16:00:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6122,7 +5429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8955265-960e-482e-8adf-e1ad7d020931
+      - 8ee0f265-0880-481b-bc83-f2c08577f1c2
     status: 200 OK
     code: 200
     duration: ""
@@ -6133,19 +5440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:00:01.365006Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:48:31 GMT
+      - Tue, 07 Nov 2023 16:00:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6155,7 +5462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba747848-3139-4de9-acbf-446c26d3133f
+      - 3301baf6-bb6a-44ce-8279-ded05ec97f61
     status: 200 OK
     code: 200
     duration: ""
@@ -6166,19 +5473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:55:35.886774Z","created_at":"2023-11-07T15:55:35.886774Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:56:48.152325Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "673"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:48:36 GMT
+      - Tue, 07 Nov 2023 16:00:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6188,7 +5495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d272f4c3-df02-4967-91ad-7d2306be224b
+      - 5f350e84-7585-4052-98b1-3e7dc0c7f9b5
     status: 200 OK
     code: 200
     duration: ""
@@ -6199,19 +5506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:00:01.365006Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:48:41 GMT
+      - Tue, 07 Nov 2023 16:00:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6221,7 +5528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84f52faf-4d78-40d8-acc9-f91ddec98082
+      - 9552ebe1-b7bd-4a61-b823-8a9dd2e63eec
     status: 200 OK
     code: 200
     duration: ""
@@ -6232,19 +5539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25/nodes?order_by=created_at_asc&page=1&pool_id=8209488d-594a-4812-8626-fac5f2638d54&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"nodes":[{"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:57:18.505045Z","error_message":null,"id":"36e290f5-856a-4eb3-a9f0-c518385de2f5","name":"scw-test-pool-placeme-test-pool-placeme-36e290","pool_id":"8209488d-594a-4812-8626-fac5f2638d54","provider_id":"scaleway://instance/nl-ams-2/f0886bfc-9043-447f-9f66-33cbdbf903f0","public_ip_v4":"51.158.236.40","public_ip_v6":null,"region":"nl-ams","status":"ready","updated_at":"2023-11-07T16:00:01.341362Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "673"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:48:46 GMT
+      - Tue, 07 Nov 2023 16:00:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6254,7 +5561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0eb1131-a14c-42a8-8ec4-b9a455639ed7
+      - 5abed34f-7cd8-43d1-b1c2-e7cbc00e1ef1
     status: 200 OK
     code: 200
     duration: ""
@@ -6265,19 +5572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:55:35.886774Z","created_at":"2023-11-07T15:55:35.886774Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:56:48.152325Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "673"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:48:51 GMT
+      - Tue, 07 Nov 2023 16:00:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6287,7 +5594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 910324f8-cd87-4a13-9a44-ceb9ca77f720
+      - f1233475-9112-4d11-9d3d-66e94dad30d2
     status: 200 OK
     code: 200
     duration: ""
@@ -6298,19 +5605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:00:01.365006Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "673"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:48:56 GMT
+      - Tue, 07 Nov 2023 16:00:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6320,7 +5627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2e706b8-c458-4a14-82bc-15824a537b7a
+      - 474356ad-b9f0-4ae5-9216-2a43590594cc
     status: 200 OK
     code: 200
     duration: ""
@@ -6331,19 +5638,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/8de1f7a3-88bf-4638-8306-a9b136db35ee
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"created_at":"2023-11-07T15:55:34.222869Z","dhcp_enabled":true,"id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","name":"test-pool-placement-group","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-07T15:55:34.222869Z","id":"8288ef17-3d79-4711-b932-6a388353bddd","subnet":"172.16.16.0/22","updated_at":"2023-11-07T15:55:34.222869Z"},{"created_at":"2023-11-07T15:55:34.222869Z","id":"99b04b07-3bc6-47f6-9b0a-d058622f495f","subnet":"fd5c:d510:d730:ed79::/64","updated_at":"2023-11-07T15:55:34.222869Z"}],"tags":[],"updated_at":"2023-11-07T15:55:34.222869Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
     headers:
       Content-Length:
-      - "673"
+      - "709"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:49:01 GMT
+      - Tue, 07 Nov 2023 16:00:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6353,7 +5660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20a6b833-f5fb-4a6e-a6a6-e9fc7808eb92
+      - fef28077-d543-4fea-88cd-2494c58d1732
     status: 200 OK
     code: 200
     duration: ""
@@ -6364,967 +5671,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/16dcbca1-8d35-47bd-9973-6c8a5d7136e3
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:49:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 86f124b7-d842-4765-9b74-7d5861be6c09
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:49:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2d2b1d27-88a0-44a0-89b9-3ce38bae0bfc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:49:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 95800267-e78e-4973-ae28-e39667ed84c3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:49:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d158c90d-f7e5-4c05-9adb-76e77867628d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:49:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 631ca147-4131-4bd2-bec7-738ff3a18733
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:49:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7a85cab2-e9ad-47c4-a8bf-694cd658b7a8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:49:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 062f86c0-7f68-4119-b278-74752588c00c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:49:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7b35570c-199a-4246-a58f-74094048f4f9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:49:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a0f7d2f7-e09b-43fb-b8c0-6da5bc3dc607
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:49:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 194b7d4e-c733-4096-aad7-e4dd1061cfa1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:49:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3411f03c-3bca-49ab-bcc9-982f8c84750d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0cd246a1-3d3b-470e-b4b9-2d419213c95d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b13fd8c3-d387-4035-8e6e-393279d4e8f4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1c016aa9-1f26-4603-84b9-0fb0810d874f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3f08b3e2-6683-40ba-85fc-5b3836bc765a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - face6a1c-002f-4568-8c3e-f5c962aeace5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4196dad1-2955-4684-91b1-39ee6d78da52
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 54aa9abd-c288-46e5-bd99-01ddcd0e99d6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 175c9c8f-5db6-4da1-8373-a0d755ebc8d1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ae8d2dfc-111d-45b5-a6e9-380088bad1ce
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 21cd9f12-4352-4ba2-b6d7-93d0408e1c1f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:44:06.106214Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 89880c35-eece-41ca-8de0-a5927393ceb8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:50:56.432701Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 73576738-c5a4-4bb9-b35c-77fd54a22b88
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ea2b3b34-650f-4e4b-b8bb-34e9042c198f
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ea2b3b34-650f-4e4b-b8bb-34e9042c198f.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:44:00.220506Z","created_at":"2023-10-19T16:44:00.220506Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ea2b3b34-650f-4e4b-b8bb-34e9042c198f.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"4411aeed-e6da-4aa8-bcf2-62092760e70a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:45:35.123441Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6c4d9db6-975f-40f9-bb6d-b4c91f4c1092
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:50:56.432701Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1ff6c8eb-9131-45e7-8f8d-cf3e6ad2919d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ea2b3b34-650f-4e4b-b8bb-34e9042c198f/nodes?order_by=created_at_asc&page=1&pool_id=191ddb9e-ba87-4da8-9061-d8c56e7a2ebf&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:45:42.503754Z","error_message":null,"id":"8864a053-4996-433a-9f95-fa89d676da87","name":"scw-test-pool-placeme-test-pool-placeme-8864a0","pool_id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","provider_id":"scaleway://instance/nl-ams-2/d8dcf8f6-65f6-4e8b-b9c6-bb898179c46b","public_ip_v4":"51.158.238.63","public_ip_v6":null,"region":"nl-ams","status":"ready","updated_at":"2023-10-19T16:50:56.412994Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "658"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 425fc6f5-edaf-4c1c-91e6-3ceab2b785f0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ea2b3b34-650f-4e4b-b8bb-34e9042c198f
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ea2b3b34-650f-4e4b-b8bb-34e9042c198f.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:44:00.220506Z","created_at":"2023-10-19T16:44:00.220506Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ea2b3b34-650f-4e4b-b8bb-34e9042c198f.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"4411aeed-e6da-4aa8-bcf2-62092760e70a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:45:35.123441Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c321c77a-2481-40cb-8dfb-1c9c1f3b1f9c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:50:56.432701Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b0021af2-58ab-4697-9684-5a4d9f8004ba
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/4411aeed-e6da-4aa8-bcf2-62092760e70a
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-19T16:43:58.680766Z","dhcp_enabled":true,"id":"4411aeed-e6da-4aa8-bcf2-62092760e70a","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-19T16:43:58.680766Z","id":"9ebe3614-855f-49c6-addc-39856c1577db","subnet":"172.16.4.0/22","updated_at":"2023-10-19T16:43:58.680766Z"},{"created_at":"2023-10-19T16:43:58.680766Z","id":"d2807e41-8a46-4431-acf1-cca1adc4449a","subnet":"fd68:d440:21c4:d87b::/64","updated_at":"2023-10-19T16:43:58.680766Z"}],"tags":[],"updated_at":"2023-10-19T16:43:58.680766Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
-    headers:
-      Content-Length:
-      - "725"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5d6a6906-bc2d-4b80-89e7-5cce433c24cd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/7f6f05c9-ac80-412f-9a34-8a656e6ff284
-    method: GET
-  response:
-    body: '{"placement_group":{"id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-2"}}'
+    body: '{"placement_group":{"id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","name":"test-pool-placement-group","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"nl-ams-2"}}'
     headers:
       Content-Length:
       - "331"
@@ -7333,7 +5683,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:59 GMT
+      - Tue, 07 Nov 2023 16:00:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7343,7 +5693,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e8a519b-7360-48e9-b41a-a27a5a4bc739
+      - a42342ae-e4dc-4419-bc71-bb0c9bcdb3d0
     status: 200 OK
     code: 200
     duration: ""
@@ -7354,19 +5704,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ea2b3b34-650f-4e4b-b8bb-34e9042c198f
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ea2b3b34-650f-4e4b-b8bb-34e9042c198f.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:44:00.220506Z","created_at":"2023-10-19T16:44:00.220506Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ea2b3b34-650f-4e4b-b8bb-34e9042c198f.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"4411aeed-e6da-4aa8-bcf2-62092760e70a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:45:35.123441Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:55:35.886774Z","created_at":"2023-11-07T15:55:35.886774Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:56:48.152325Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:59 GMT
+      - Tue, 07 Nov 2023 16:00:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7376,7 +5726,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6bdf99ae-3a6e-4f7e-b61d-f4270aa1a804
+      - d19c0541-1318-4930-9d44-981522e91477
     status: 200 OK
     code: 200
     duration: ""
@@ -7387,19 +5737,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ea2b3b34-650f-4e4b-b8bb-34e9042c198f/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhQUkVVeVRrUlJkMDFXYjFoRVZFMTZUVlJCZUU5RVJUSk9SRkYzVFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUWFJpQ2pCQ1dVSktOalZ3YUM4d2NHNXhkR1p4VTA1MFFtUmtUV2hYVnpGSE5uRnVTeXRwVDNkd1lWQmxMeXM0ZDFZNGVrNU1VR0pSWTNsSWNIZGFSMDlhVG1RS04xRkVRbGhxUkRKdk1XbFJjbGh4SzAxVWFGZG9SVXRTU2xKUWIwcDNOMjlKT0N0V1dFdFlSMVVyVERCVlNYbHZVU3M1VldsWGRrOXNjUzk2Y0Zsck1RcHFVVkIxVTJSNk5rY3dhRXB3TkdSVFJUSXhjWGhTVlRnelNVaDZRVlp6TkhBMVpXMXZUblJpYkRkbE5UY3lXSEoxVDJ4Q2NWbFRhMUJ1ZG05eksyMXRDa1ZCV2paelJGWjFlbTUyTUhWVVJGTnpNM2Q0TUVKd1EwVlpabmhZT1dabFpETlNOMHRTUkdJd1VXRTJNSGQxZEdNM2JIUnROMjlaTDJKWEx6UklRbkFLZUV0VWJ6aHpORzQwWlRSVU4ySXJVbkJGYzBrME1EZFZSbFp0WXpWcVZHOHpiVWhoUjJSTU9IVXJXa3gwYm1KNWRWRm1Sa3BLV2lzclNVbEVSVEp5UWdwb2JFeDZObEZwVDJSU1NESnNibnA2V0RoclEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUVowMXlSMGgzUjFaSlRXcGpWQzk2YVRoMllsSmFSMWR4VnpsTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2NFZFJlR1ZCYmk5VU0xbHFVV2hIVFhKbFZraEtRWEZsVmpRckwzbExhSE5HYmpCYVpsVnRjM0JOUTJFNVJVaEdVUXAyTTBkdlNHeHZWbXBrV21obE1VdFBOMmhHVGxBck1WQjRXV2xUVTJScllXMXpXbkJoZFc0MFpuWTNSRTlEYlhGelVqbHBVekZTV1hSSFNqWmpXVVo0Q25ac2RGWkxkQ3QwYzBReGFHMDJPVlZTT0VSTWEwOXhXa1JVVmpVM2Rua3JSbXAyTDFWR01rWTNRMWRpY3pCa0wxWnZNMmhhT0ZGa2JrcFFlV1J4Y20wS2RrTm5hR0ZqVERoMFNVTmFlR1ZsWWtoVGVIZHVRa294Y1hsR2JWaHdjakpETHpZcmIwMTZUMmN5TUdwQlIzWXdXalJtUkVvd1ZGRnlkQzh4U0dOMGJncEJaVWRIYTFCWFlqUkRXbVpWYWpReFFtNWpObUpYUXpGNVJuQlJjakozUkdoRGFGaE1OR3BOT0ZsUGMwSnVNRlZMTlRsbGIyRkdhRUZKZDFjeE5TdDZDbkF2Y0U1NU9EWnpaRk1yTkZOUFRrZ3pWVTVGUmk4MVRtZGtSRVF6YTNNeGRVZDVNUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZWEyYjNiMzQtNjUwZi00ZTRiLWI4YmItMzRlOTA0MmMxOThmLmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpSllzNU1nSlUxMUVEd2s1dkNoSm5abDhMY0xZRlRldTJ0Q21XaXBDZWU5dnhZMWNFaFJjN0dqeQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeFRsUlZlazR4YjFoRVZFMTZUVlJGZDA1cVJURk9WRlY2VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVXRXQ2psYVJsbHJkVGRpZVdGVlJrOWtka3BtY3pnd2IzVkJhRXh1WTNGVGNWRnRaR3RtYWpWV09IZEhaVVZKVkM5VFp6SllhR05RTld0MU5sSllUMUpDUWpRS2FHSlFPVGhRVlM5a2JHMXlOa3BWT0RKeVQwRjBUbmRSUTB0QlNFOHlkbkZWY1RONFIxcEVWakF3TDJ0T1dFUjNibFZOT0VWTFlrWjZObFJqUjAxak53b3ZTbE1yT0Rnd1ZVRlFRVkZ1Y2pJeVMwMVNZakZSYW5kWVZIUmpkMGR2TjBrMlIzbG9MMlJ2VWtkeVpETnJUbWxvVVM5dE16UlZkVlpvWVhJeGNrOXFDamRNUW5waFl6bEtjQ3RTUVZacmJtMWxabU5wZWxBNWNVSlBTekJ1TUdZeFUwTnRSRTg1SzNReVIyRkZOMFJTTkZaQ1pVcHdURzlSTm1aT1ozTnVlV01LY0dGNk5WaFljRzlMTDJWSkwwOTBOVUpYTkZnNWNrODBaWEJJVWtGVGRWZDBlR1ZYVERoQmNsWkRRbnBCVEdwYVdYSXZUWEprWmxCTVpqVmtReTgwVEFwTFoyaFdLM2RXWm5ocFMwSlRZaTh3Vkc1TlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQlRHTXJZV2xzTTJaMVExTkxNRkJ6ZEV0T1F6ZEhWbXRUYVdoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1V5ODFZa2xUTm05bWVVNUJNa3B2TjBsb1JGTnpSekJaTW5oNFJVTmFhR2xqUmtOUVdFRXJaeXRCZVRReWVqRlJVd3BSYm1kMFQxSkhkVkZQTm1sS1ozZHFOREZhVWpRNU9XbzRaalZpUlZwTmFUaHFla2cxTlZRd0szcENXV3BuWml0TWF6VjNSRTUyYmpjMmFFRnVNV2R1Q2tKSE5USllRM05uYlZKS2VqUmhXa00yVlRnNGREWkdRMWx0ZVd4RFJtTm9VR1JQT1VGRWRYWnRabFl4VERkVFkyVnJVbU5TTlhJNGVVMU9aR2xJT1dVS2N5czNSMk5EZG5KcE1rSlhPR2R2UTJaRWMySlRkR3gzTWtkS1ZYRTJTSE5wY21VNFNrcGtNMU5FUnk4MmVFTjRWMWREZVRKTlowaFVaVXhUU2tJMVpncFFNREZoUkU5RGNUUmtZa0ZFWWtWSVdGWnlNVEp6YjNrNWRtdElVVUpzVWtsUVVEYzVObEpuTUVONmVUYzJaVEpEYWtST1ltSTJTMmhHVURsRVVIQllDblJZWjNCbGRGWkVkSFZDTnpSamJWVlVTa2RsWlN0dGNYRk1TV2hFYlhoNlJtaE5VUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNmVhMmYzZTUtYjdmMi00NGVmLWFmMGItMTc3NjJiYTgxYjI1LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB5S1VUM3RtNEt0dnh5NG8yTEJYa2FZYWxjWmw5ck9TRHhpZTVLMEpEdTNHMVpQNk1RdXQ1blAwNw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2710"
+      - "2708"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:59 GMT
+      - Tue, 07 Nov 2023 16:00:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7409,7 +5759,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 215573ca-8e03-4253-b0bc-a9aa07c668be
+      - 93214aed-0916-45ca-b6c1-2f9ebf27fb94
     status: 200 OK
     code: 200
     duration: ""
@@ -7420,19 +5770,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:50:56.432701Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:00:01.365006Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:59 GMT
+      - Tue, 07 Nov 2023 16:00:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7442,7 +5792,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7059611e-5d5b-46c8-ba7a-92b36ad47750
+      - 3685cf04-a78c-4dc5-8cb7-a76d4b53eec6
     status: 200 OK
     code: 200
     duration: ""
@@ -7453,19 +5803,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ea2b3b34-650f-4e4b-b8bb-34e9042c198f/nodes?order_by=created_at_asc&page=1&pool_id=191ddb9e-ba87-4da8-9061-d8c56e7a2ebf&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25/nodes?order_by=created_at_asc&page=1&pool_id=8209488d-594a-4812-8626-fac5f2638d54&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:45:42.503754Z","error_message":null,"id":"8864a053-4996-433a-9f95-fa89d676da87","name":"scw-test-pool-placeme-test-pool-placeme-8864a0","pool_id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","provider_id":"scaleway://instance/nl-ams-2/d8dcf8f6-65f6-4e8b-b9c6-bb898179c46b","public_ip_v4":"51.158.238.63","public_ip_v6":null,"region":"nl-ams","status":"ready","updated_at":"2023-10-19T16:50:56.412994Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:57:18.505045Z","error_message":null,"id":"36e290f5-856a-4eb3-a9f0-c518385de2f5","name":"scw-test-pool-placeme-test-pool-placeme-36e290","pool_id":"8209488d-594a-4812-8626-fac5f2638d54","provider_id":"scaleway://instance/nl-ams-2/f0886bfc-9043-447f-9f66-33cbdbf903f0","public_ip_v4":"51.158.236.40","public_ip_v6":null,"region":"nl-ams","status":"ready","updated_at":"2023-11-07T16:00:01.341362Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "658"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:59 GMT
+      - Tue, 07 Nov 2023 16:00:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7475,7 +5825,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1c5042a-5bbb-4411-b344-9c7648507478
+      - 21f5e09d-0380-4665-83b6-92531d98ee80
     status: 200 OK
     code: 200
     duration: ""
@@ -7486,19 +5836,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ea2b3b34-650f-4e4b-b8bb-34e9042c198f
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ea2b3b34-650f-4e4b-b8bb-34e9042c198f.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:44:00.220506Z","created_at":"2023-10-19T16:44:00.220506Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ea2b3b34-650f-4e4b-b8bb-34e9042c198f.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"4411aeed-e6da-4aa8-bcf2-62092760e70a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:45:35.123441Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:55:35.886774Z","created_at":"2023-11-07T15:55:35.886774Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T15:56:48.152325Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:00 GMT
+      - Tue, 07 Nov 2023 16:00:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7508,7 +5858,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29a54c00-c874-4a8a-8449-9fc0fdf5a680
+      - 003d8abc-2f32-45e6-ac0e-a97ce3bf5c5f
     status: 200 OK
     code: 200
     duration: ""
@@ -7519,19 +5869,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/4411aeed-e6da-4aa8-bcf2-62092760e70a
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/8de1f7a3-88bf-4638-8306-a9b136db35ee
     method: GET
   response:
-    body: '{"created_at":"2023-10-19T16:43:58.680766Z","dhcp_enabled":true,"id":"4411aeed-e6da-4aa8-bcf2-62092760e70a","name":"test-pool-placement-group","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2023-10-19T16:43:58.680766Z","id":"9ebe3614-855f-49c6-addc-39856c1577db","subnet":"172.16.4.0/22","updated_at":"2023-10-19T16:43:58.680766Z"},{"created_at":"2023-10-19T16:43:58.680766Z","id":"d2807e41-8a46-4431-acf1-cca1adc4449a","subnet":"fd68:d440:21c4:d87b::/64","updated_at":"2023-10-19T16:43:58.680766Z"}],"tags":[],"updated_at":"2023-10-19T16:43:58.680766Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    body: '{"created_at":"2023-11-07T15:55:34.222869Z","dhcp_enabled":true,"id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","name":"test-pool-placement-group","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-07T15:55:34.222869Z","id":"8288ef17-3d79-4711-b932-6a388353bddd","subnet":"172.16.16.0/22","updated_at":"2023-11-07T15:55:34.222869Z"},{"created_at":"2023-11-07T15:55:34.222869Z","id":"99b04b07-3bc6-47f6-9b0a-d058622f495f","subnet":"fd5c:d510:d730:ed79::/64","updated_at":"2023-11-07T15:55:34.222869Z"}],"tags":[],"updated_at":"2023-11-07T15:55:34.222869Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
     headers:
       Content-Length:
-      - "725"
+      - "709"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:00 GMT
+      - Tue, 07 Nov 2023 16:00:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7541,7 +5891,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f55ff71d-d67d-4a16-bb7d-68448e3d75a4
+      - d75138c6-888a-461e-8420-215d0813fa0a
     status: 200 OK
     code: 200
     duration: ""
@@ -7552,10 +5902,76 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/7f6f05c9-ac80-412f-9a34-8a656e6ff284
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25/kubeconfig
     method: GET
   response:
-    body: '{"placement_group":{"id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-2"}}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeFRsUlZlazR4YjFoRVZFMTZUVlJGZDA1cVJURk9WRlY2VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUVXRXQ2psYVJsbHJkVGRpZVdGVlJrOWtka3BtY3pnd2IzVkJhRXh1WTNGVGNWRnRaR3RtYWpWV09IZEhaVVZKVkM5VFp6SllhR05RTld0MU5sSllUMUpDUWpRS2FHSlFPVGhRVlM5a2JHMXlOa3BWT0RKeVQwRjBUbmRSUTB0QlNFOHlkbkZWY1RONFIxcEVWakF3TDJ0T1dFUjNibFZOT0VWTFlrWjZObFJqUjAxak53b3ZTbE1yT0Rnd1ZVRlFRVkZ1Y2pJeVMwMVNZakZSYW5kWVZIUmpkMGR2TjBrMlIzbG9MMlJ2VWtkeVpETnJUbWxvVVM5dE16UlZkVlpvWVhJeGNrOXFDamRNUW5waFl6bEtjQ3RTUVZacmJtMWxabU5wZWxBNWNVSlBTekJ1TUdZeFUwTnRSRTg1SzNReVIyRkZOMFJTTkZaQ1pVcHdURzlSTm1aT1ozTnVlV01LY0dGNk5WaFljRzlMTDJWSkwwOTBOVUpYTkZnNWNrODBaWEJJVWtGVGRWZDBlR1ZYVERoQmNsWkRRbnBCVEdwYVdYSXZUWEprWmxCTVpqVmtReTgwVEFwTFoyaFdLM2RXWm5ocFMwSlRZaTh3Vkc1TlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQlRHTXJZV2xzTTJaMVExTkxNRkJ6ZEV0T1F6ZEhWbXRUYVdoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1V5ODFZa2xUTm05bWVVNUJNa3B2TjBsb1JGTnpSekJaTW5oNFJVTmFhR2xqUmtOUVdFRXJaeXRCZVRReWVqRlJVd3BSYm1kMFQxSkhkVkZQTm1sS1ozZHFOREZhVWpRNU9XbzRaalZpUlZwTmFUaHFla2cxTlZRd0szcENXV3BuWml0TWF6VjNSRTUyYmpjMmFFRnVNV2R1Q2tKSE5USllRM05uYlZKS2VqUmhXa00yVlRnNGREWkdRMWx0ZVd4RFJtTm9VR1JQT1VGRWRYWnRabFl4VERkVFkyVnJVbU5TTlhJNGVVMU9aR2xJT1dVS2N5czNSMk5EZG5KcE1rSlhPR2R2UTJaRWMySlRkR3gzTWtkS1ZYRTJTSE5wY21VNFNrcGtNMU5FUnk4MmVFTjRWMWREZVRKTlowaFVaVXhUU2tJMVpncFFNREZoUkU5RGNUUmtZa0ZFWWtWSVdGWnlNVEp6YjNrNWRtdElVVUpzVWtsUVVEYzVObEpuTUVONmVUYzJaVEpEYWtST1ltSTJTMmhHVURsRVVIQllDblJZWjNCbGRGWkVkSFZDTnpSamJWVlVTa2RsWlN0dGNYRk1TV2hFYlhoNlJtaE5VUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNmVhMmYzZTUtYjdmMi00NGVmLWFmMGItMTc3NjJiYTgxYjI1LmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB5S1VUM3RtNEt0dnh5NG8yTEJYa2FZYWxjWmw5ck9TRHhpZTVLMEpEdTNHMVpQNk1RdXQ1blAwNw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2708"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:00:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e172b5c7-a14b-4428-a008-7f3c0cc6fe92
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25/available-types
+    method: GET
+  response:
+    body: '{"cluster_types":[{"availability":"available","commitment_delay":"0s","dedicated":false,"max_nodes":150,"memory":4000000000,"name":"kapsule","resiliency":"standard","sla":0},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":250,"memory":4000000000,"name":"kapsule-dedicated-4","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":4}'
+    headers:
+      Content-Length:
+      - "748"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:00:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 10497c73-70f1-4982-968f-e78df1adc9c4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/16dcbca1-8d35-47bd-9973-6c8a5d7136e3
+    method: GET
+  response:
+    body: '{"placement_group":{"id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","name":"test-pool-placement-group","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"nl-ams-2"}}'
     headers:
       Content-Length:
       - "331"
@@ -7564,7 +5980,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:00 GMT
+      - Tue, 07 Nov 2023 16:00:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7574,7 +5990,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa65683d-fd2d-4265-93c5-4854d551adc3
+      - 178c0279-3a23-4ec2-a0e4-16f5b4c24193
     status: 200 OK
     code: 200
     duration: ""
@@ -7585,19 +6001,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ea2b3b34-650f-4e4b-b8bb-34e9042c198f/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhQUkVVeVRrUlJkMDFXYjFoRVZFMTZUVlJCZUU5RVJUSk9SRkYzVFZadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUWFJpQ2pCQ1dVSktOalZ3YUM4d2NHNXhkR1p4VTA1MFFtUmtUV2hYVnpGSE5uRnVTeXRwVDNkd1lWQmxMeXM0ZDFZNGVrNU1VR0pSWTNsSWNIZGFSMDlhVG1RS04xRkVRbGhxUkRKdk1XbFJjbGh4SzAxVWFGZG9SVXRTU2xKUWIwcDNOMjlKT0N0V1dFdFlSMVVyVERCVlNYbHZVU3M1VldsWGRrOXNjUzk2Y0Zsck1RcHFVVkIxVTJSNk5rY3dhRXB3TkdSVFJUSXhjWGhTVlRnelNVaDZRVlp6TkhBMVpXMXZUblJpYkRkbE5UY3lXSEoxVDJ4Q2NWbFRhMUJ1ZG05eksyMXRDa1ZCV2paelJGWjFlbTUyTUhWVVJGTnpNM2Q0TUVKd1EwVlpabmhZT1dabFpETlNOMHRTUkdJd1VXRTJNSGQxZEdNM2JIUnROMjlaTDJKWEx6UklRbkFLZUV0VWJ6aHpORzQwWlRSVU4ySXJVbkJGYzBrME1EZFZSbFp0WXpWcVZHOHpiVWhoUjJSTU9IVXJXa3gwYm1KNWRWRm1Sa3BLV2lzclNVbEVSVEp5UWdwb2JFeDZObEZwVDJSU1NESnNibnA2V0RoclEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUVowMXlSMGgzUjFaSlRXcGpWQzk2YVRoMllsSmFSMWR4VnpsTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2NFZFJlR1ZCYmk5VU0xbHFVV2hIVFhKbFZraEtRWEZsVmpRckwzbExhSE5HYmpCYVpsVnRjM0JOUTJFNVJVaEdVUXAyTTBkdlNHeHZWbXBrV21obE1VdFBOMmhHVGxBck1WQjRXV2xUVTJScllXMXpXbkJoZFc0MFpuWTNSRTlEYlhGelVqbHBVekZTV1hSSFNqWmpXVVo0Q25ac2RGWkxkQ3QwYzBReGFHMDJPVlZTT0VSTWEwOXhXa1JVVmpVM2Rua3JSbXAyTDFWR01rWTNRMWRpY3pCa0wxWnZNMmhhT0ZGa2JrcFFlV1J4Y20wS2RrTm5hR0ZqVERoMFNVTmFlR1ZsWWtoVGVIZHVRa294Y1hsR2JWaHdjakpETHpZcmIwMTZUMmN5TUdwQlIzWXdXalJtUkVvd1ZGRnlkQzh4U0dOMGJncEJaVWRIYTFCWFlqUkRXbVpWYWpReFFtNWpObUpYUXpGNVJuQlJjakozUkdoRGFGaE1OR3BOT0ZsUGMwSnVNRlZMTlRsbGIyRkdhRUZKZDFjeE5TdDZDbkF2Y0U1NU9EWnpaRk1yTkZOUFRrZ3pWVTVGUmk4MVRtZGtSRVF6YTNNeGRVZDVNUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZWEyYjNiMzQtNjUwZi00ZTRiLWI4YmItMzRlOTA0MmMxOThmLmFwaS5rOHMubmwtYW1zLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpSllzNU1nSlUxMUVEd2s1dkNoSm5abDhMY0xZRlRldTJ0Q21XaXBDZWU5dnhZMWNFaFJjN0dqeQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:00:01.365006Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "2710"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:01 GMT
+      - Tue, 07 Nov 2023 16:00:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7607,7 +6023,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05b92d95-87d4-4baa-a530-876895a5fe9d
+      - f8891f79-d0a7-4e77-b156-af1094cd59ef
     status: 200 OK
     code: 200
     duration: ""
@@ -7618,19 +6034,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ea2b3b34-650f-4e4b-b8bb-34e9042c198f/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25/nodes?order_by=created_at_asc&page=1&pool_id=8209488d-594a-4812-8626-fac5f2638d54&status=unknown
     method: GET
   response:
-    body: '{"cluster_types":[{"availability":"available","commitment_delay":"0s","dedicated":false,"max_nodes":150,"memory":4000000000,"name":"kapsule","resiliency":"standard","sla":0},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":250,"memory":4000000000,"name":"kapsule-dedicated-4","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":4}'
+    body: '{"nodes":[{"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:57:18.505045Z","error_message":null,"id":"36e290f5-856a-4eb3-a9f0-c518385de2f5","name":"scw-test-pool-placeme-test-pool-placeme-36e290","pool_id":"8209488d-594a-4812-8626-fac5f2638d54","provider_id":"scaleway://instance/nl-ams-2/f0886bfc-9043-447f-9f66-33cbdbf903f0","public_ip_v4":"51.158.236.40","public_ip_v6":null,"region":"nl-ams","status":"ready","updated_at":"2023-11-07T16:00:01.341362Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "780"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:01 GMT
+      - Tue, 07 Nov 2023 16:00:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7640,7 +6056,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 426dd13e-0079-430d-a0c9-a871c33ee72f
+      - 6dd695af-39b5-449a-b88b-b4444f67ce62
     status: 200 OK
     code: 200
     duration: ""
@@ -7651,85 +6067,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:50:56.432701Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:51:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6d78e307-dae4-4061-b095-f1928b947f58
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ea2b3b34-650f-4e4b-b8bb-34e9042c198f/nodes?order_by=created_at_asc&page=1&pool_id=191ddb9e-ba87-4da8-9061-d8c56e7a2ebf&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:45:42.503754Z","error_message":null,"id":"8864a053-4996-433a-9f95-fa89d676da87","name":"scw-test-pool-placeme-test-pool-placeme-8864a0","pool_id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","provider_id":"scaleway://instance/nl-ams-2/d8dcf8f6-65f6-4e8b-b9c6-bb898179c46b","public_ip_v4":"51.158.238.63","public_ip_v6":null,"region":"nl-ams","status":"ready","updated_at":"2023-10-19T16:50:56.412994Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "658"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:51:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 30b4969e-d24a-429b-ad7f-a7453892ffed
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ea2b3b34-650f-4e4b-b8bb-34e9042c198f/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"0s","dedicated":false,"max_nodes":150,"memory":4000000000,"name":"kapsule","resiliency":"standard","sla":0},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":250,"memory":4000000000,"name":"kapsule-dedicated-4","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":4}'
     headers:
       Content-Length:
-      - "780"
+      - "748"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:02 GMT
+      - Tue, 07 Nov 2023 16:00:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7739,7 +6089,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4ce72cd-319e-427c-b0c0-93714864763e
+      - 45f219b3-40cf-4699-a77d-1052c45e051c
     status: 200 OK
     code: 200
     duration: ""
@@ -7750,19 +6100,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/191ddb9e-ba87-4da8-9061-d8c56e7a2ebf
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
     method: DELETE
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","container_runtime":"containerd","created_at":"2023-10-19T16:44:06.092527Z","id":"191ddb9e-ba87-4da8-9061-d8c56e7a2ebf","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"7f6f05c9-ac80-412f-9a34-8a656e6ff284","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-10-19T16:51:02.629326974Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:00:10.320515900Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
       Content-Length:
-      - "677"
+      - "654"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:02 GMT
+      - Tue, 07 Nov 2023 16:00:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7772,7 +6122,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40b7da2c-06be-47c3-8631-9d26f74b600f
+      - 55a9c5a2-9a91-40b0-bdc8-761b5d1e9392
     status: 200 OK
     code: 200
     duration: ""
@@ -7783,15 +6133,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/7f6f05c9-ac80-412f-9a34-8a656e6ff284
-    method: DELETE
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    method: GET
   response:
-    body: ""
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:00:10.320516Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
     headers:
+      Content-Length:
+      - "651"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:02 GMT
+      - Tue, 07 Nov 2023 16:00:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7801,7 +6155,102 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 479e36d4-935b-405e-ade3-801e67e3a484
+      - b105b591-40f8-4b38-8ca0-5d5221e5570c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","container_runtime":"containerd","created_at":"2023-11-07T15:55:41.739164Z","id":"8209488d-594a-4812-8626-fac5f2638d54","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"16dcbca1-8d35-47bd-9973-6c8a5d7136e3","public_ip_disabled":false,"region":"nl-ams","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:00:10.320516Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-2"}'
+    headers:
+      Content-Length:
+      - "651"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:00:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5b2eb909-8a1a-4b08-99ec-35454bb999a4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/pools/8209488d-594a-4812-8626-fac5f2638d54
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"8209488d-594a-4812-8626-fac5f2638d54","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "125"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:00:20 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1e5552ab-565c-42ab-833a-f817c10530d4
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-2/placement_groups/16dcbca1-8d35-47bd-9973-6c8a5d7136e3
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Tue, 07 Nov 2023 16:00:20 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 85ea820e-e812-4bb2-885f-1126d22e8c5c
     status: 204 No Content
     code: 204
     duration: ""
@@ -7812,19 +6261,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ea2b3b34-650f-4e4b-b8bb-34e9042c198f?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ea2b3b34-650f-4e4b-b8bb-34e9042c198f.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:44:00.220506Z","created_at":"2023-10-19T16:44:00.220506Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ea2b3b34-650f-4e4b-b8bb-34e9042c198f.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"4411aeed-e6da-4aa8-bcf2-62092760e70a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:51:02.784937238Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:55:35.886774Z","created_at":"2023-11-07T15:55:35.886774Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T16:00:20.740129591Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1521"
+      - "1476"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:02 GMT
+      - Tue, 07 Nov 2023 16:00:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7834,7 +6283,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d44699f1-e65d-4493-b323-99d84574c2a3
+      - 9c5aeb40-23dc-4467-96d7-6f9b76b54d37
     status: 200 OK
     code: 200
     duration: ""
@@ -7845,19 +6294,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ea2b3b34-650f-4e4b-b8bb-34e9042c198f
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ea2b3b34-650f-4e4b-b8bb-34e9042c198f.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:44:00.220506Z","created_at":"2023-10-19T16:44:00.220506Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ea2b3b34-650f-4e4b-b8bb-34e9042c198f.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"4411aeed-e6da-4aa8-bcf2-62092760e70a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:51:02.784937Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:55:35.886774Z","created_at":"2023-11-07T15:55:35.886774Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T16:00:20.740130Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1518"
+      - "1473"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:02 GMT
+      - Tue, 07 Nov 2023 16:00:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7867,12 +6316,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a26145c-5051-448f-b437-42285cc12fdc
+      - 6c141eae-3deb-404b-a0d1-816b981f322d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-placement-group","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_type":"max_availability"}'
+    body: '{"name":"test-pool-placement-group","project":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_type":"max_availability"}'
     form: {}
     headers:
       Content-Type:
@@ -7883,7 +6332,7 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups
     method: POST
   response:
-    body: '{"placement_group":{"id":"fa772429-94bf-457b-91f1-445587df6dce","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-1"}}'
+    body: '{"placement_group":{"id":"277c0192-f423-47ec-89ca-3e416daea91c","name":"test-pool-placement-group","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"nl-ams-1"}}'
     headers:
       Content-Length:
       - "331"
@@ -7892,9 +6341,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:03 GMT
+      - Tue, 07 Nov 2023 16:00:21 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/fa772429-94bf-457b-91f1-445587df6dce
+      - https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/277c0192-f423-47ec-89ca-3e416daea91c
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7904,7 +6353,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3cb74df-39bd-47e6-9b0a-26200ce83e8d
+      - 4fd2098b-35d8-4bb5-9a81-53cfb5b1b818
     status: 201 Created
     code: 201
     duration: ""
@@ -7915,10 +6364,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/fa772429-94bf-457b-91f1-445587df6dce
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/277c0192-f423-47ec-89ca-3e416daea91c
     method: GET
   response:
-    body: '{"placement_group":{"id":"fa772429-94bf-457b-91f1-445587df6dce","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-1"}}'
+    body: '{"placement_group":{"id":"277c0192-f423-47ec-89ca-3e416daea91c","name":"test-pool-placement-group","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"nl-ams-1"}}'
     headers:
       Content-Length:
       - "331"
@@ -7927,7 +6376,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:03 GMT
+      - Tue, 07 Nov 2023 16:00:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7937,7 +6386,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c6f043d-794b-49ee-94c8-1456c314253e
+      - 839fad0c-2221-4e5d-877d-a6683a8be7d6
     status: 200 OK
     code: 200
     duration: ""
@@ -7948,19 +6397,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ea2b3b34-650f-4e4b-b8bb-34e9042c198f
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ea2b3b34-650f-4e4b-b8bb-34e9042c198f.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:44:00.220506Z","created_at":"2023-10-19T16:44:00.220506Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ea2b3b34-650f-4e4b-b8bb-34e9042c198f.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"4411aeed-e6da-4aa8-bcf2-62092760e70a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:51:02.784937Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:55:35.886774Z","created_at":"2023-11-07T15:55:35.886774Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.6ea2f3e5-b7f2-44ef-af0b-17762ba81b25.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-11-07T16:00:20.740130Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1518"
+      - "1473"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:08 GMT
+      - Tue, 07 Nov 2023 16:00:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7970,7 +6419,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a46a5c63-f53c-4736-9c2d-7313ff6f1767
+      - eaeb2cd4-52ce-4b85-917e-fa808455d367
     status: 200 OK
     code: 200
     duration: ""
@@ -7981,76 +6430,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ea2b3b34-650f-4e4b-b8bb-34e9042c198f
+    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/6ea2f3e5-b7f2-44ef-af0b-17762ba81b25
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ea2b3b34-650f-4e4b-b8bb-34e9042c198f.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:44:00.220506Z","created_at":"2023-10-19T16:44:00.220506Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ea2b3b34-650f-4e4b-b8bb-34e9042c198f.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"4411aeed-e6da-4aa8-bcf2-62092760e70a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:51:02.784937Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1518"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:51:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3dd254bd-f0bc-4d53-a923-7f50098bc4fa
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ea2b3b34-650f-4e4b-b8bb-34e9042c198f
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://ea2b3b34-650f-4e4b-b8bb-34e9042c198f.api.k8s.nl-ams.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:44:00.220506Z","created_at":"2023-10-19T16:44:00.220506Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.ea2b3b34-650f-4e4b-b8bb-34e9042c198f.nodes.k8s.nl-ams.scw.cloud","feature_gates":[],"id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"4411aeed-e6da-4aa8-bcf2-62092760e70a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"kapsule","updated_at":"2023-10-19T16:51:02.784937Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1518"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:51:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d8357c1b-0bb6-491c-8db5-0cb07ed7c3af
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/nl-ams/clusters/ea2b3b34-650f-4e4b-b8bb-34e9042c198f
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"ea2b3b34-650f-4e4b-b8bb-34e9042c198f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"6ea2f3e5-b7f2-44ef-af0b-17762ba81b25","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -8059,7 +6442,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:23 GMT
+      - Tue, 07 Nov 2023 16:00:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8069,7 +6452,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88188420-bb01-49d2-89af-7ec97e12e82e
+      - 9cd67f98-43a2-4eb8-b51d-45765dbb7c73
     status: 404 Not Found
     code: 404
     duration: ""
@@ -8080,10 +6463,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/4411aeed-e6da-4aa8-bcf2-62092760e70a
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/8de1f7a3-88bf-4638-8306-a9b136db35ee
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"4411aeed-e6da-4aa8-bcf2-62092760e70a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"8de1f7a3-88bf-4638-8306-a9b136db35ee","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -8092,7 +6475,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:23 GMT
+      - Tue, 07 Nov 2023 16:00:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8102,12 +6485,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cee9e080-15bf-4983-a394-fcf4f6bd0b21
+      - d00829cb-3d9a-4172-abb7-97ef0c9aebc5
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"multicloud","name":"test-pool-placement-group-2","description":"","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"version":"1.28.2","cni":"kilo","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":null}'
+    body: '{"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","type":"multicloud","name":"test-pool-placement-group-2","description":"","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"version":"1.28.2","cni":"kilo","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null}'
     form: {}
     headers:
       Content-Type:
@@ -8118,16 +6501,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484072572Z","created_at":"2023-10-19T16:51:23.484072572Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:51:23.494273309Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592693550Z","created_at":"2023-11-07T16:00:31.592693550Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013467Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1494"
+      - "1449"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:23 GMT
+      - Tue, 07 Nov 2023 16:00:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8137,7 +6520,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51cfac18-7031-4aba-b533-bcaed8cee1fc
+      - 88d5a6ea-229c-4410-9b51-8b84aefe1a39
     status: 200 OK
     code: 200
     duration: ""
@@ -8148,19 +6531,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:51:23.494273Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1485"
+      - "1440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:23 GMT
+      - Tue, 07 Nov 2023 16:00:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8170,7 +6553,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c4eaa1d-5cb8-4717-99e5-83d7e85a2916
+      - e6ddff5f-4468-46c9-9110-020ad24f1315
     status: 200 OK
     code: 200
     duration: ""
@@ -8181,19 +6564,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:51:23.494273Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1485"
+      - "1440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:28 GMT
+      - Tue, 07 Nov 2023 16:00:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8203,7 +6586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 47804ff6-48e2-49e8-a9d2-9eecbc09ab8d
+      - 66e68d07-978c-4944-8cd2-afc97af0a4bf
     status: 200 OK
     code: 200
     duration: ""
@@ -8214,19 +6597,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:51:23.494273Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1485"
+      - "1440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:33 GMT
+      - Tue, 07 Nov 2023 16:00:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8236,7 +6619,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6978b93a-a57c-49ac-a02e-3ce073a3533c
+      - a3c7decd-74a2-4d46-bb99-a3fb83992ebc
     status: 200 OK
     code: 200
     duration: ""
@@ -8247,19 +6630,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:51:23.494273Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1485"
+      - "1440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:38 GMT
+      - Tue, 07 Nov 2023 16:00:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8269,7 +6652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4857feb5-937c-4b6a-83a6-31c5f257966c
+      - 6786e345-b45e-4c23-929e-b61160ce022a
     status: 200 OK
     code: 200
     duration: ""
@@ -8280,19 +6663,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:51:23.494273Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1485"
+      - "1440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:43 GMT
+      - Tue, 07 Nov 2023 16:00:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8302,7 +6685,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c512418-1b1c-4ea3-9d3d-6424afd8cb9b
+      - d78dfb5f-b5e5-4de7-b875-8430aff37739
     status: 200 OK
     code: 200
     duration: ""
@@ -8313,19 +6696,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:51:23.494273Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1485"
+      - "1440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:48 GMT
+      - Tue, 07 Nov 2023 16:00:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8335,7 +6718,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1013471-bd03-4640-9f9c-8308b338cd1c
+      - 0d42762f-d561-4f98-8b70-08055807b6f5
     status: 200 OK
     code: 200
     duration: ""
@@ -8346,19 +6729,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:51:23.494273Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1485"
+      - "1440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:53 GMT
+      - Tue, 07 Nov 2023 16:01:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8368,7 +6751,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fdf732d6-ccdf-41f3-94b4-d929e9d37d7d
+      - 4c453854-9480-44c2-9433-cde939cbf8c7
     status: 200 OK
     code: 200
     duration: ""
@@ -8379,19 +6762,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:51:23.494273Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1485"
+      - "1440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:58 GMT
+      - Tue, 07 Nov 2023 16:01:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8401,7 +6784,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 017952af-8d1d-4205-9930-97545003fffa
+      - 6b205e04-feb6-4dae-9433-3bacc830d1d5
     status: 200 OK
     code: 200
     duration: ""
@@ -8412,19 +6795,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:51:23.494273Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1485"
+      - "1440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:52:04 GMT
+      - Tue, 07 Nov 2023 16:01:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8434,7 +6817,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59395100-49d8-45b5-8720-51593ec55049
+      - e7118b50-cb17-4cda-951a-dd13d5906c49
     status: 200 OK
     code: 200
     duration: ""
@@ -8445,19 +6828,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:51:23.494273Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1485"
+      - "1440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:52:09 GMT
+      - Tue, 07 Nov 2023 16:01:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8467,7 +6850,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4369e6aa-7fba-4566-8346-f38c845d0861
+      - c7bfc0eb-bcc2-476e-989f-867ef10d9994
     status: 200 OK
     code: 200
     duration: ""
@@ -8478,19 +6861,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:51:23.494273Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1485"
+      - "1440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:52:14 GMT
+      - Tue, 07 Nov 2023 16:01:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8500,7 +6883,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 644d5ed9-8b41-4836-97d7-57c4428570e2
+      - 70fc90e5-9bf9-4b4a-b77b-99876873e4b1
     status: 200 OK
     code: 200
     duration: ""
@@ -8511,19 +6894,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:51:23.494273Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1485"
+      - "1440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:52:19 GMT
+      - Tue, 07 Nov 2023 16:01:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8533,7 +6916,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78e20d01-1203-4a93-9737-b2eef0856b64
+      - 79365c94-db6c-4e66-9420-4bd4b2be6502
     status: 200 OK
     code: 200
     duration: ""
@@ -8544,19 +6927,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:51:23.494273Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1485"
+      - "1440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:52:24 GMT
+      - Tue, 07 Nov 2023 16:01:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8566,7 +6949,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0527517c-7464-4796-bc0c-43bf651459a2
+      - 44d11b15-f928-4c83-9dd9-31fc533351ef
     status: 200 OK
     code: 200
     duration: ""
@@ -8577,19 +6960,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:51:23.494273Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1485"
+      - "1440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:52:29 GMT
+      - Tue, 07 Nov 2023 16:01:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8599,7 +6982,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c04d1156-e437-4639-a3b4-fc8d1cb512a8
+      - d3fd1957-be87-4756-a89d-815276cf76be
     status: 200 OK
     code: 200
     duration: ""
@@ -8610,19 +6993,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:51:23.494273Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1485"
+      - "1440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:52:34 GMT
+      - Tue, 07 Nov 2023 16:01:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8632,7 +7015,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ca9c8af-38f1-417d-998e-c4e8ff3491d2
+      - 2b14c96a-ea6c-4635-ae4a-12e6cfbe2685
     status: 200 OK
     code: 200
     duration: ""
@@ -8643,19 +7026,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:52:35.902005Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:52:39 GMT
+      - Tue, 07 Nov 2023 16:01:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8665,7 +7048,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7a721f9-a5f0-4e26-b6d7-0f6440885cca
+      - b0907aa6-955c-4116-ba82-63ce396e50d2
     status: 200 OK
     code: 200
     duration: ""
@@ -8676,19 +7059,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:52:35.902005Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:52:39 GMT
+      - Tue, 07 Nov 2023 16:01:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8698,7 +7081,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dddf2783-c317-4077-9000-360ce3618948
+      - 0d26da0c-0fbc-45dc-98ab-aa0a6b79abaf
     status: 200 OK
     code: 200
     duration: ""
@@ -8709,19 +7092,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhQUkVVeVRsUkZlVTVHYjFoRVZFMTZUVlJCZUU5RVJUSk9WRVY1VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMlZhQ2xsSVNDc3djR0l3WWtkcE0yTktlVFJDUjNSdmRHVnlibTlqWWtKdFVUQXdXSGRzVjNwVmVGTnViRzF3YlhNeWJtdEdVRmMwUjJWNGEyRk9UekZxYXpnS1NVMXFLelp0TnpkaVlVRnNXRm8wVm1ORlNIRjVMMjlCUmxoMFZESXhiM2hVVDJOUGFVNUlUV1ZoYm1oamVXbFRaME5DU1ZoTGVVZFhkR2N5VFdaTFNBcFNZekZKVkhGRVZGTk9SRGd4VjFneVpUYzBZMHR1Ym04dk5EZG5OVUoxYlhwc2FqTjNjR0ZXYVRkNVR6Rk5LM0pZWkZoNU5sUXljRGRVYlZGdFprdFhDbXdyZWpOT1VUSkVaMUJ6Y0VjMmVsQjBNazFOWkhaTldUUktlV0ZTWkdaWllsaENiVWd4VWxkblpUSkhNbFp1UWtSQldWUjVPU3RCUWxGMWNYTm5VR3dLUW5KcWFFMVdWa3h0Tm5scFJVUlFSbWhUTm1kbGJVbDNSbTFSWjNOSFJXeDRaa05ZTld0MVdteDFhak5NTnpVM2VXUTVTSEZKVDBGRlkySTBWMUJWS3dvNGNIbHRZa3RRVWpSVFluWk9UM2RhZURKVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSWRsZE1UV3MyZUU5VFYwdGFaa05vYUVwQmJXVXdZVXR5VmxaTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFUxcGlWWFJPZWxkWE1XbHVaVmxsU0hBemQwaFBUVmxaYkdsNGFsSmtMMlIwZFVGb1VFUkxSeXRHWVVWTlEwNTZXUXBIT0ZCc1ZtRlBWaXRzUlZWMlVuUXhNbkJRWms4NUswaEpjbWhYTDNSSEwxQktMMGhhUzFObFkzZElUamN5U2tORk9EQkxiRFJ5Y21WM2RXTjZTbFZXQ25CcGNHcDRSbFU1WTFSRFkyaFVlR2RqYUZKUU9UUkZkbE01YkRjMFdFbG9iMnRSTm1ObmJ6VlhVRU0xUzFnME5YbERTa1ZRZEhsbVUzWktPV2MyTVhNS09HeDFiMFlyWVROMU1sTllVemxVVHpkc04xbEVSa2ROUWtkQmVVOURZbGxFWWxJM2JHZFBXV0ZtUmtGR05XUnNUR3hOTUM4M04zRkRVMDltZVdwQmRRb3dOVTF1Ukhac016Vk9ZVWhoVERsMVltOTFTR2x2T1cwNFNXdDFkMDVrSzFGb1JHSTRaSGRXVkhwNldWQXlTbVJTWjNGUk9ERjRaR05oTTFCWlVGWlRDbGd3Y21kUU4wTjJSVTVTTTB4TVVtaFFOamM0Y2t3emQyOXFPREpKYVdkMkwxSnhNZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNDBjNGRiYzUtZGQwMy00MWUxLTlhMzEtNWNjNGNjZDQ3NWE2LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAwSWtJM2YzSWxDOWNIUE1YWjV1NWttNmtaUjNtV1dZQXJ5S0tuUDV3QVZSanlwOGdNeEw5aEFzdg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:00:31.612013Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2710"
+      - "1440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:52:39 GMT
+      - Tue, 07 Nov 2023 16:01:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8731,7 +7114,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9add7448-cbb0-4991-8504-0ef04603bd91
+      - 637ecd9e-b953-4c5d-9478-74ce5880d185
     status: 200 OK
     code: 200
     duration: ""
@@ -8742,19 +7125,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:52:35.902005Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:01:57.959064Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:52:39 GMT
+      - Tue, 07 Nov 2023 16:02:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8764,12 +7147,111 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc8b8709-ebdc-4bed-b88e-c7192399dde4
+      - d73688b9-8e34-4be6-bb25-ccd771d98ad4
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"upgrade_policy":null,"zone":"nl-ams-1","root_volume_type":"default_volume_type","root_volume_size":null,"public_ip_disabled":false}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:01:57.959064Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1437"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:02:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e6f5f7f8-0d41-4f51-9028-15c8deecfd0e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRVUkJlazFzYjFoRVZFMTZUVlJGZDA1cVJUSk5SRUY2VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUMFE0Q21JcmRFWnVRbW96UmxSUGNYRkxVSGhLVFVwNFNVMTZlSEF5YkM5a1JsWlZZVVY2VkVRNVFsTXpiMlF6UkZOVmFGVkNXVTlQTjFoVVUycEJVVEZSUzJRS2EwMUpiV0ZuTlVKWlMzWlVlbTVGZFVOR1dESlJlRWNyVFVFMVVHaHBjRWN3Y0dRNWRXdE1UMHhTVFRJM1dFUlZhVkpLWW05a1RVbG5OSEJuTmxRMlJ3cEdORlZrVTJSa2FqWm5VWEpCVFhKR2FrOUxibEY2V0U1TVMyMXRlRWxpUTA4elFXWkRWekZqYUZOellYZHlTMmRqWW5oeVltVlFVa3cxSzBoVllYQnhDbUUwTkRrNVZFVXpjMjVoZURkVkwwRnBjM1JSUXpBcmRFUTBjemxvVEdoUFltZ3hSRnAxT0hCU1YycEdWMnhQVDJZclNsQmpXa1kzSzFOQ1ozTnRWSGNLYVRZMWVreDVjVlJMU1VoSUwyMUNPWEpPVFdkblRpdEhaMUpRY0RGVUwzaDNNalV2Tkc5bFJXbFBja2MwTmpkMlZFTjRTR2g1WXpkUU1WWlZkamR6YWdwUFZUUXhPVVJxWTJOS1pqUnhka2RFYkV4elEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ1ZqSmxOWE5DVUcxTVlUSnlUR2Q1TURCRGEzUlFXSEZEVDJOTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFpVVkZORXhZTjNGak5UWlBhRUUzYWl0eU1scGhRVFpTYWtaNFJsbHhiRlZOYVVrM1RDdG5kVTlqVjFsTVRqTm9NQW95YlZCT2QySkJXVkZRWkdoSGIyRmFRbWhMYms1YVNqUmxSVVp6YlZoS1ZYZG5WeTg0ZW5VMlVHUndNMGwwU1ZreWVWSTRWMmRVTDJaU09WcEtkMVJIQ25oV04waGFjV3A0VTJweFIyNDVkbTlaVnpCblduTm5hMlo0T0ZBd1kydDJOV2MyWmtOeFYxWnNabk5MVlhCNWRFcE9MME5KTlhWbFNUbGFTMUpwVTJjS2RIRkhSM0kyUTJKaFlWVnNaQzluWmtKRlFVUk9iV0pIUVRVelRFWTJjMWczYWtzdk9WSlZaSGMzVUdsV1NGQlBjMU40VFZsRVVWSjNTRTF1T0daQlRBcFlUR3RJWTFSSVNEWmpTazlSWkdkdFdYWXhaSFZCVmpOcFVYTk5TM2RFZUZGQlNXUktiRmhDTWxoQlVUbE5lRlpLZG1GaVNEWnhMMkZKYVdob1FUaGtDbUpVZWxGWVVtdE1TVUo2TUhoUloyNTJNakExYldsS1JtSlBTWEV2WlZsUk5XdFhWd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMGUxYTNjYjItMjgzMy00N2UyLWJhZWYtMzA5Y2JhZWE3ZTVlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBPZHhUUjlZdzJ1dk44Z3ZPTWxhM2w1QWN2Tmt1T0xLcUJORVc0cXdJa3paMVRDeFdHMjMzZldEYg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2708"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:02:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 62098921-bae1-4b42-996c-cc50160e86d4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:01:57.959064Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1437"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:02:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9ed9eefb-3033-4b3f-876d-2395980d6fae
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"zone":"nl-ams-1","root_volume_type":"default_volume_type","public_ip_disabled":false}'
     form: {}
     headers:
       Content-Type:
@@ -8777,19 +7259,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e/pools
     method: POST
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838743844Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177947680Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "676"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:52:40 GMT
+      - Tue, 07 Nov 2023 16:02:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8799,7 +7281,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19bf3be8-ef93-4012-aace-8357fe60eeca
+      - 22155d5c-cfbf-44bd-ab5e-413058130a06
     status: 200 OK
     code: 200
     duration: ""
@@ -8810,19 +7292,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:52:40 GMT
+      - Tue, 07 Nov 2023 16:02:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8832,7 +7314,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c15b41ab-1731-4261-be8e-fb83122ff53c
+      - a998acdb-3c21-4e26-a747-27ff020d9344
     status: 200 OK
     code: 200
     duration: ""
@@ -8843,19 +7325,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:52:45 GMT
+      - Tue, 07 Nov 2023 16:02:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8865,7 +7347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5a0f9ee-fc2e-434f-9725-27c841d3bf11
+      - 4bee0cdb-ba67-42a9-89d5-7cda9377f4ca
     status: 200 OK
     code: 200
     duration: ""
@@ -8876,19 +7358,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:52:50 GMT
+      - Tue, 07 Nov 2023 16:02:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8898,7 +7380,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 684b8172-4838-44c3-8735-94c502844fa1
+      - 7918fc6d-ae9d-4de3-bc06-e0b539913293
     status: 200 OK
     code: 200
     duration: ""
@@ -8909,19 +7391,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:52:55 GMT
+      - Tue, 07 Nov 2023 16:02:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8931,7 +7413,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9d1870b-54e4-43d9-bbb5-9fdc2203b2fc
+      - f55531f5-83e7-4bf5-83d1-42a5fb7474af
     status: 200 OK
     code: 200
     duration: ""
@@ -8942,19 +7424,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:53:00 GMT
+      - Tue, 07 Nov 2023 16:02:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8964,7 +7446,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca678e2f-51df-4b29-b0c1-59f93f4a7b65
+      - 7beef514-e232-489d-adf9-8be42e1f6189
     status: 200 OK
     code: 200
     duration: ""
@@ -8975,19 +7457,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:53:05 GMT
+      - Tue, 07 Nov 2023 16:02:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8997,7 +7479,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f545575-c009-41ac-b51b-900e43edb16b
+      - cb823c30-66b1-4552-b596-0ee8269eac02
     status: 200 OK
     code: 200
     duration: ""
@@ -9008,19 +7490,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:53:10 GMT
+      - Tue, 07 Nov 2023 16:02:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9030,7 +7512,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 679a2803-2d3e-4fb7-bd9b-d4e147366a5a
+      - edd04dc4-d003-45ee-994a-ceb587bfc7d9
     status: 200 OK
     code: 200
     duration: ""
@@ -9041,19 +7523,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:53:15 GMT
+      - Tue, 07 Nov 2023 16:02:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9063,7 +7545,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ec13779-8502-4a75-acc2-1270fc50e1dc
+      - a7ffdc29-b6f8-49ca-904b-97caf0b7b579
     status: 200 OK
     code: 200
     duration: ""
@@ -9074,19 +7556,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:53:20 GMT
+      - Tue, 07 Nov 2023 16:02:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9096,7 +7578,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc84ddd9-ea5b-4d47-9bb0-9b5436f8b507
+      - 7aa4299c-8a4d-4993-93fa-1ca63d032023
     status: 200 OK
     code: 200
     duration: ""
@@ -9107,19 +7589,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:53:25 GMT
+      - Tue, 07 Nov 2023 16:02:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9129,7 +7611,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56ef475f-3650-4b18-9dcd-0f80e234094d
+      - 59a401aa-9420-40d7-aa49-398c3f2ce9b6
     status: 200 OK
     code: 200
     duration: ""
@@ -9140,19 +7622,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:53:30 GMT
+      - Tue, 07 Nov 2023 16:02:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9162,7 +7644,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cda27d78-b885-4015-ae6e-73f23efcf614
+      - e1e697e3-ea93-413a-a1e5-0f0ec41cb3a9
     status: 200 OK
     code: 200
     duration: ""
@@ -9173,19 +7655,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:53:35 GMT
+      - Tue, 07 Nov 2023 16:02:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9195,7 +7677,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 370fbd9e-922c-45d6-9085-584985d0cca4
+      - b7d5c5a6-f514-4d07-856a-498b756b0718
     status: 200 OK
     code: 200
     duration: ""
@@ -9206,19 +7688,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:53:40 GMT
+      - Tue, 07 Nov 2023 16:03:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9228,7 +7710,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 823780d1-78b6-4526-a4d8-911ce8655169
+      - 856f0aa6-75b7-492d-a690-feda49a17e5b
     status: 200 OK
     code: 200
     duration: ""
@@ -9239,19 +7721,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:53:45 GMT
+      - Tue, 07 Nov 2023 16:03:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9261,7 +7743,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8bc936b2-5490-4ae0-8970-cd1fa73c6bf7
+      - c473e5b5-4fd7-4f5b-baec-b419d31c9f5a
     status: 200 OK
     code: 200
     duration: ""
@@ -9272,19 +7754,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:53:50 GMT
+      - Tue, 07 Nov 2023 16:03:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9294,7 +7776,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a61c0eb1-e8b7-4249-bf3c-1c143df49452
+      - 897f5d09-a764-42bb-aa4d-2f259299bf10
     status: 200 OK
     code: 200
     duration: ""
@@ -9305,19 +7787,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:53:56 GMT
+      - Tue, 07 Nov 2023 16:03:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9327,7 +7809,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 122dea10-3a04-4e46-8440-04fe4796445b
+      - 3c8b1568-4436-4d06-a4d6-eb0d76e2d791
     status: 200 OK
     code: 200
     duration: ""
@@ -9338,19 +7820,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:54:01 GMT
+      - Tue, 07 Nov 2023 16:03:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9360,7 +7842,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 016da5c4-2a04-44de-820a-bea8eb36d2dc
+      - 35299821-bd08-4aac-8ad4-f4fb5b309e80
     status: 200 OK
     code: 200
     duration: ""
@@ -9371,19 +7853,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:54:06 GMT
+      - Tue, 07 Nov 2023 16:03:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9393,7 +7875,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a665d4f9-23de-42f5-aaac-3dccc8fd60c3
+      - 4f18beee-fe68-4969-b727-65e2e15bdf40
     status: 200 OK
     code: 200
     duration: ""
@@ -9404,19 +7886,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:54:11 GMT
+      - Tue, 07 Nov 2023 16:03:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9426,7 +7908,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38d528a8-586c-4250-8013-fed14d4c9661
+      - bf516dbb-e0e3-4f04-8ff9-4959479931c1
     status: 200 OK
     code: 200
     duration: ""
@@ -9437,19 +7919,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:54:16 GMT
+      - Tue, 07 Nov 2023 16:03:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9459,7 +7941,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b62693cf-1ed3-4988-90ba-1686a7b6e0cd
+      - d81671d5-7b83-4ffb-9c0d-c0b04c6a2997
     status: 200 OK
     code: 200
     duration: ""
@@ -9470,19 +7952,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:54:21 GMT
+      - Tue, 07 Nov 2023 16:03:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9492,7 +7974,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23bb3b47-d5dd-4804-a166-5d28b7dd9664
+      - 6db61a78-b83e-4648-b884-bba3cc46e4e1
     status: 200 OK
     code: 200
     duration: ""
@@ -9503,19 +7985,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:54:26 GMT
+      - Tue, 07 Nov 2023 16:03:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9525,7 +8007,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ec1187c-144f-4eb5-958d-d1abf75f600a
+      - e3a37417-4ecd-4367-b966-92606926b634
     status: 200 OK
     code: 200
     duration: ""
@@ -9536,19 +8018,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:02:03.177948Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:54:31 GMT
+      - Tue, 07 Nov 2023 16:03:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9558,7 +8040,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1930dd7-3ef9-40ca-a7b5-9960293f2866
+      - de8e6198-a977-4f77-bb94-3429bfa00c40
     status: 200 OK
     code: 200
     duration: ""
@@ -9569,19 +8051,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:03:56.084462Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:54:36 GMT
+      - Tue, 07 Nov 2023 16:03:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9591,7 +8073,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85160db7-4af5-461d-9484-4921e2b9b0ad
+      - 2bbc6f84-014e-43b6-a98a-d07bcf25e527
     status: 200 OK
     code: 200
     duration: ""
@@ -9602,19 +8084,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:03:56.084462Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:54:41 GMT
+      - Tue, 07 Nov 2023 16:03:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9624,7 +8106,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5444bbe9-fa4e-4920-a4ee-791f7c06aef6
+      - 73dce3eb-9fc7-4d91-b993-cab58fb7e614
     status: 200 OK
     code: 200
     duration: ""
@@ -9635,19 +8117,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e/nodes?order_by=created_at_asc&page=1&pool_id=021b5870-cc24-4f88-92b4-060c684209db&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"nodes":[{"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-11-07T16:02:03.724300Z","error_message":null,"id":"852e2de7-8494-48ab-87b0-0757a436b6a6","name":"scw-test-pool-placeme-test-pool-placeme-852e2d","pool_id":"021b5870-cc24-4f88-92b4-060c684209db","provider_id":"scaleway://instance/nl-ams-1/cf102a29-dcf2-4ebb-85d4-6beafb1ee12e","public_ip_v4":"51.15.66.165","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:03:56.068709Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "673"
+      - "604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:54:46 GMT
+      - Tue, 07 Nov 2023 16:04:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9657,7 +8139,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cdcd1ec8-43ba-4806-8071-e72981c8e0c8
+      - a396f814-0ba6-4f81-813a-f88e99aea060
     status: 200 OK
     code: 200
     duration: ""
@@ -9668,19 +8150,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:01:57.959064Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "673"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:54:51 GMT
+      - Tue, 07 Nov 2023 16:04:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9690,7 +8172,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f3d2daa-b4ce-436c-8134-203bde3a03b9
+      - ad86d33d-43b1-4407-a8cb-6e16b099a64e
     status: 200 OK
     code: 200
     duration: ""
@@ -9701,19 +8183,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:03:56.084462Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "673"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:54:56 GMT
+      - Tue, 07 Nov 2023 16:04:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9723,7 +8205,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4120525-1a60-4ceb-9b40-539eedb341e9
+      - b03b5c3f-1aab-4bfc-ad31-cda86d51b8c8
     status: 200 OK
     code: 200
     duration: ""
@@ -9734,19 +8216,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:01:57.959064Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "673"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:55:01 GMT
+      - Tue, 07 Nov 2023 16:04:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9756,7 +8238,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ca96483-b785-4587-8afe-ef4da4091673
+      - 6de9b5da-1e8d-473b-8fb1-3d73895b05c1
     status: 200 OK
     code: 200
     duration: ""
@@ -9767,1990 +8249,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/277c0192-f423-47ec-89ca-3e416daea91c
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:55:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d69e72da-d93b-4cf5-a0e5-0ddd1c945cb2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:55:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d5d6d59e-a04d-44cd-a97d-44063101ec5e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:55:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 97c85727-6d65-46d3-92a9-110f511743a0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:55:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 49684360-9666-43c9-ba90-de66a293fd0a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:55:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 967af472-f762-47e1-bfc6-49af5d6c0b2a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:55:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 87116204-4991-4c26-8be5-6dd27cc46baf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:55:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e649fc9b-45a4-46cb-9ac4-3fac10f06799
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:55:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d5e45308-dcbe-4ff9-998e-3c962af4e2fc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:55:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8ad1c53c-ff63-44bf-8548-54c481128c45
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:55:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 484838ed-f735-4949-b3ad-5f2c00578399
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:55:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 02305e96-ed99-4b3c-a94e-16058dc0a893
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:56:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e803094b-5467-4761-977c-b8e0f4416292
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:56:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f4b1e99b-16af-4a8a-b100-19493b8eda49
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:56:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3deef45b-fc6b-45a8-a81e-79ef37da6cbf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:56:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8ecade9b-0244-4776-bad8-20ebfb49e1a1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:56:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e0a4aa7d-f7bb-4103-a8b7-6a30db12c2b1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:56:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 420fa09e-a223-4c8c-bf2d-5b96cd5f6f6b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:56:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 964cdc39-dc42-4dc9-bb89-eac1b1a69410
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:56:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9b8f6023-1d53-4d84-949d-b344e0f6f09d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:56:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 184c873b-5183-40e0-95aa-80ca8a9b2413
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:56:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e4f22de2-6a68-4478-a206-80b7099cf3fc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:56:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0034c7a2-a625-4b3a-bdc8-2de0bf136266
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:56:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 441a49d6-0633-4849-942c-138a0619142a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:57:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - beda67c8-0c76-43c3-9840-68bded61c54a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:57:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 65b13a0d-b114-435d-b501-4b5cb32d18f0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:57:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 34fd56e3-3b58-4caa-a67a-46dc33aa9199
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:57:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 874270ef-3431-48e0-8adf-0925ce7fd2ec
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:57:23 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e8d0a4b9-dd56-4336-a96c-09b4e5139527
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:57:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4edc0e40-65c1-41ad-863c-737c07d17bcf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:57:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a8d46a55-3a0c-42e2-ae6e-6a4264af6f89
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:57:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 28d673bd-f6f9-4003-8151-d7a7b67d4780
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:57:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c5da1e23-cf0b-4532-b6a5-bb36e94ea840
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:57:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 66b4582b-2dca-485c-aaf5-7ad51ea7aa6d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:57:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 588cc0b8-cb6f-42e7-8536-f3b6c4cb1468
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:57:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d5d4ed64-3c5e-48f4-8d8e-6b03acf3cc58
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:58:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8fb258fe-8a8e-4182-9762-e3bc19895a09
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:58:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - acc7572f-d296-46f0-9b4f-aa0be05c5f9a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:58:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 78569f9f-0df8-4f76-b3c0-5c689b201479
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:58:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - babec1a8-24ab-4cb0-a5db-6ae624c8bc03
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:58:23 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8689fb9f-552c-42c4-804c-05b23865c3e7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:58:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e2e3162b-5308-400c-9120-97f247356826
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:58:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 75db072e-aa3c-4a21-ad6e-6706c2e8b875
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:58:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 33775b85-b72f-40a1-8c09-d65e0f1ab0ec
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:58:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - caab3c97-77f6-4223-93df-e2c59e555b78
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:58:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0b89564f-2d2b-42a7-aa47-b71ebcf2d0dc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:58:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a9f5cf68-511e-4947-8031-8b33a2fd29d3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:58:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2a27c75f-7720-4977-b126-82f2b86bbd54
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:59:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 76af70a6-bc7e-4267-9322-af997c0e6836
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:59:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bda8459e-57ec-44b3-9360-8e453a81706f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:59:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 821e8217-1fe5-482b-9065-dbeab0805c4b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:59:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3172677f-a93b-4ffe-997b-5b91ddbc76ea
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:59:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ba7850c2-d80b-40af-80aa-f3a41a17a9cb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:59:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a1842392-7028-4f24-ac97-ee3d00fdd98a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:52:39.838744Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "673"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:59:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 70ca178b-4100-49fe-9c4f-0354633550a2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:59:36.042950Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:59:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 94274fa5-9778-4870-83da-e8733a9ed82a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:59:36.042950Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:59:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2280ce4c-0406-4368-8235-9d3352b86a36
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6/nodes?order_by=created_at_asc&page=1&pool_id=cde6c814-851e-433b-9902-29439700fc3f&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-10-19T16:55:09.012722Z","error_message":null,"id":"049af804-49b9-4035-957c-cfb11ca7d862","name":"scw-test-pool-placeme-test-pool-placeme-049af8","pool_id":"cde6c814-851e-433b-9902-29439700fc3f","provider_id":"scaleway://instance/nl-ams-1/c3faf0d5-51c4-4b71-aee5-4dfd4c034845","public_ip_v4":"51.15.60.254","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:59:36.018948Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "620"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:59:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b62b6ce8-04bd-4708-94d8-fdd65fb933af
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:52:35.902005Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1482"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:59:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2c443f9b-7130-427c-97d7-ff9cecba2ba8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:59:36.042950Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:59:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f0fd01dc-3fc4-4cd4-814e-09e383116970
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:52:35.902005Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1482"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:59:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d5940ef4-0950-4045-9b38-ec08b4b68abc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/fa772429-94bf-457b-91f1-445587df6dce
-    method: GET
-  response:
-    body: '{"placement_group":{"id":"fa772429-94bf-457b-91f1-445587df6dce","name":"test-pool-placement-group","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"zone":"nl-ams-1"}}'
+    body: '{"placement_group":{"id":"277c0192-f423-47ec-89ca-3e416daea91c","name":"test-pool-placement-group","organization":"105bdce1-64c0-48ab-899d-868455867ecf","policy_mode":"optional","policy_respected":true,"policy_type":"max_availability","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"zone":"nl-ams-1"}}'
     headers:
       Content-Length:
       - "331"
@@ -11759,7 +8261,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:59:40 GMT
+      - Tue, 07 Nov 2023 16:04:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -11769,7 +8271,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d2db364-9038-4c48-a7ca-81fc6e4fe6b0
+      - 4380fa8f-9784-4886-96ae-336084b3e7c7
     status: 200 OK
     code: 200
     duration: ""
@@ -11780,19 +8282,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhQUkVVeVRsUkZlVTVHYjFoRVZFMTZUVlJCZUU5RVJUSk9WRVY1VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTMlZhQ2xsSVNDc3djR0l3WWtkcE0yTktlVFJDUjNSdmRHVnlibTlqWWtKdFVUQXdXSGRzVjNwVmVGTnViRzF3YlhNeWJtdEdVRmMwUjJWNGEyRk9UekZxYXpnS1NVMXFLelp0TnpkaVlVRnNXRm8wVm1ORlNIRjVMMjlCUmxoMFZESXhiM2hVVDJOUGFVNUlUV1ZoYm1oamVXbFRaME5DU1ZoTGVVZFhkR2N5VFdaTFNBcFNZekZKVkhGRVZGTk9SRGd4VjFneVpUYzBZMHR1Ym04dk5EZG5OVUoxYlhwc2FqTjNjR0ZXYVRkNVR6Rk5LM0pZWkZoNU5sUXljRGRVYlZGdFprdFhDbXdyZWpOT1VUSkVaMUJ6Y0VjMmVsQjBNazFOWkhaTldUUktlV0ZTWkdaWllsaENiVWd4VWxkblpUSkhNbFp1UWtSQldWUjVPU3RCUWxGMWNYTm5VR3dLUW5KcWFFMVdWa3h0Tm5scFJVUlFSbWhUTm1kbGJVbDNSbTFSWjNOSFJXeDRaa05ZTld0MVdteDFhak5NTnpVM2VXUTVTSEZKVDBGRlkySTBWMUJWS3dvNGNIbHRZa3RRVWpSVFluWk9UM2RhZURKVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaSWRsZE1UV3MyZUU5VFYwdGFaa05vYUVwQmJXVXdZVXR5VmxaTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFUxcGlWWFJPZWxkWE1XbHVaVmxsU0hBemQwaFBUVmxaYkdsNGFsSmtMMlIwZFVGb1VFUkxSeXRHWVVWTlEwNTZXUXBIT0ZCc1ZtRlBWaXRzUlZWMlVuUXhNbkJRWms4NUswaEpjbWhYTDNSSEwxQktMMGhhUzFObFkzZElUamN5U2tORk9EQkxiRFJ5Y21WM2RXTjZTbFZXQ25CcGNHcDRSbFU1WTFSRFkyaFVlR2RqYUZKUU9UUkZkbE01YkRjMFdFbG9iMnRSTm1ObmJ6VlhVRU0xUzFnME5YbERTa1ZRZEhsbVUzWktPV2MyTVhNS09HeDFiMFlyWVROMU1sTllVemxVVHpkc04xbEVSa2ROUWtkQmVVOURZbGxFWWxJM2JHZFBXV0ZtUmtGR05XUnNUR3hOTUM4M04zRkRVMDltZVdwQmRRb3dOVTF1Ukhac016Vk9ZVWhoVERsMVltOTFTR2x2T1cwNFNXdDFkMDVrSzFGb1JHSTRaSGRXVkhwNldWQXlTbVJTWjNGUk9ERjRaR05oTTFCWlVGWlRDbGd3Y21kUU4wTjJSVTVTTTB4TVVtaFFOamM0Y2t3emQyOXFPREpKYVdkMkwxSnhNZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNDBjNGRiYzUtZGQwMy00MWUxLTlhMzEtNWNjNGNjZDQ3NWE2LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiAwSWtJM2YzSWxDOWNIUE1YWjV1NWttNmtaUjNtV1dZQXJ5S0tuUDV3QVZSanlwOGdNeEw5aEFzdg==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMiIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRVUkJlazFzYjFoRVZFMTZUVlJGZDA1cVJUSk5SRUY2VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUMFE0Q21JcmRFWnVRbW96UmxSUGNYRkxVSGhLVFVwNFNVMTZlSEF5YkM5a1JsWlZZVVY2VkVRNVFsTXpiMlF6UkZOVmFGVkNXVTlQTjFoVVUycEJVVEZSUzJRS2EwMUpiV0ZuTlVKWlMzWlVlbTVGZFVOR1dESlJlRWNyVFVFMVVHaHBjRWN3Y0dRNWRXdE1UMHhTVFRJM1dFUlZhVkpLWW05a1RVbG5OSEJuTmxRMlJ3cEdORlZrVTJSa2FqWm5VWEpCVFhKR2FrOUxibEY2V0U1TVMyMXRlRWxpUTA4elFXWkRWekZqYUZOellYZHlTMmRqWW5oeVltVlFVa3cxSzBoVllYQnhDbUUwTkRrNVZFVXpjMjVoZURkVkwwRnBjM1JSUXpBcmRFUTBjemxvVEdoUFltZ3hSRnAxT0hCU1YycEdWMnhQVDJZclNsQmpXa1kzSzFOQ1ozTnRWSGNLYVRZMWVreDVjVlJMU1VoSUwyMUNPWEpPVFdkblRpdEhaMUpRY0RGVUwzaDNNalV2Tkc5bFJXbFBja2MwTmpkMlZFTjRTR2g1WXpkUU1WWlZkamR6YWdwUFZUUXhPVVJxWTJOS1pqUnhka2RFYkV4elEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ1ZqSmxOWE5DVUcxTVlUSnlUR2Q1TURCRGEzUlFXSEZEVDJOTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRFpVVkZORXhZTjNGak5UWlBhRUUzYWl0eU1scGhRVFpTYWtaNFJsbHhiRlZOYVVrM1RDdG5kVTlqVjFsTVRqTm9NQW95YlZCT2QySkJXVkZRWkdoSGIyRmFRbWhMYms1YVNqUmxSVVp6YlZoS1ZYZG5WeTg0ZW5VMlVHUndNMGwwU1ZreWVWSTRWMmRVTDJaU09WcEtkMVJIQ25oV04waGFjV3A0VTJweFIyNDVkbTlaVnpCblduTm5hMlo0T0ZBd1kydDJOV2MyWmtOeFYxWnNabk5MVlhCNWRFcE9MME5KTlhWbFNUbGFTMUpwVTJjS2RIRkhSM0kyUTJKaFlWVnNaQzluWmtKRlFVUk9iV0pIUVRVelRFWTJjMWczYWtzdk9WSlZaSGMzVUdsV1NGQlBjMU40VFZsRVVWSjNTRTF1T0daQlRBcFlUR3RJWTFSSVNEWmpTazlSWkdkdFdYWXhaSFZCVmpOcFVYTk5TM2RFZUZGQlNXUktiRmhDTWxoQlVUbE5lRlpLZG1GaVNEWnhMMkZKYVdob1FUaGtDbUpVZWxGWVVtdE1TVUo2TUhoUloyNTJNakExYldsS1JtSlBTWEV2WlZsUk5XdFhWd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMGUxYTNjYjItMjgzMy00N2UyLWJhZWYtMzA5Y2JhZWE3ZTVlLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC1wbGFjZW1lbnQtZ3JvdXAtMgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yIgogICAgdXNlcjogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXBsYWNlbWVudC1ncm91cC0yLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBPZHhUUjlZdzJ1dk44Z3ZPTWxhM2w1QWN2Tmt1T0xLcUJORVc0cXdJa3paMVRDeFdHMjMzZldEYg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2710"
+      - "2708"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:59:40 GMT
+      - Tue, 07 Nov 2023 16:04:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -11802,7 +8304,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14038353-3b8b-47b2-b5c6-183a5643f571
+      - 8435bfae-43c0-4066-8782-3dfa8fb93afe
     status: 200 OK
     code: 200
     duration: ""
@@ -11813,19 +8315,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:59:36.042950Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:03:56.084462Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "671"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:59:40 GMT
+      - Tue, 07 Nov 2023 16:04:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -11835,7 +8337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88220805-8eec-4319-9805-2e1a4a05876e
+      - 40601852-be2b-4471-b7e9-8637dd96970b
     status: 200 OK
     code: 200
     duration: ""
@@ -11846,19 +8348,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6/nodes?order_by=created_at_asc&page=1&pool_id=cde6c814-851e-433b-9902-29439700fc3f&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e/nodes?order_by=created_at_asc&page=1&pool_id=021b5870-cc24-4f88-92b4-060c684209db&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-10-19T16:55:09.012722Z","error_message":null,"id":"049af804-49b9-4035-957c-cfb11ca7d862","name":"scw-test-pool-placeme-test-pool-placeme-049af8","pool_id":"cde6c814-851e-433b-9902-29439700fc3f","provider_id":"scaleway://instance/nl-ams-1/c3faf0d5-51c4-4b71-aee5-4dfd4c034845","public_ip_v4":"51.15.60.254","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:59:36.018948Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","Ready":"True"},"created_at":"2023-11-07T16:02:03.724300Z","error_message":null,"id":"852e2de7-8494-48ab-87b0-0757a436b6a6","name":"scw-test-pool-placeme-test-pool-placeme-852e2d","pool_id":"021b5870-cc24-4f88-92b4-060c684209db","provider_id":"scaleway://instance/nl-ams-1/cf102a29-dcf2-4ebb-85d4-6beafb1ee12e","public_ip_v4":"51.15.66.165","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:03:56.068709Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "620"
+      - "604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:59:40 GMT
+      - Tue, 07 Nov 2023 16:04:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -11868,7 +8370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee66177d-9e7b-4b42-a26f-28e0a67d3064
+      - 597d87ca-ff1b-4b53-9ad8-af0c630cbc9b
     status: 200 OK
     code: 200
     duration: ""
@@ -11879,19 +8381,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/cde6c814-851e-433b-9902-29439700fc3f
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: DELETE
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","container_runtime":"containerd","created_at":"2023-10-19T16:52:39.830297Z","id":"cde6c814-851e-433b-9902-29439700fc3f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"fa772429-94bf-457b-91f1-445587df6dce","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-10-19T16:59:41.624951076Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:04:01.886748425Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "677"
+      - "654"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:59:41 GMT
+      - Tue, 07 Nov 2023 16:04:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -11901,7 +8403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 209b62ed-4d8e-4217-ae17-74a1e44d6609
+      - b0a6dfcd-9db2-448b-bd6d-90e7ba97d26e
     status: 200 OK
     code: 200
     duration: ""
@@ -11912,81 +8414,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6?with_additional_resources=true
-    method: DELETE
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:59:41.714825286Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1488"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:59:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 897569c4-e7c4-4e74-bc2c-11e5648d1ebf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/fa772429-94bf-457b-91f1-445587df6dce
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Date:
-      - Thu, 19 Oct 2023 16:59:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - aa92d6ac-27e1-472a-836c-3a7a4ba2d482
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:59:41.714825Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:04:01.886748Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1485"
+      - "651"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:59:41 GMT
+      - Tue, 07 Nov 2023 16:04:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -11996,7 +8436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 311f733c-e83d-474d-9c88-c959928970bb
+      - baa1213e-b76a-4466-8a22-7c4ac637a74b
     status: 200 OK
     code: 200
     duration: ""
@@ -12007,19 +8447,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:59:41.714825Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:04:01.886748Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1485"
+      - "651"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:59:47 GMT
+      - Tue, 07 Nov 2023 16:04:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -12029,7 +8469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 442c07fc-b1bc-4aef-aecb-58967d0ef0c0
+      - a7c60140-1ebb-4345-8794-2168f4ab939a
     status: 200 OK
     code: 200
     duration: ""
@@ -12040,19 +8480,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:59:41.714825Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:04:01.886748Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1485"
+      - "651"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:59:52 GMT
+      - Tue, 07 Nov 2023 16:04:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -12062,7 +8502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4474fa92-44cc-43aa-91bf-d7b15bb3f364
+      - 68dfcff1-37a2-4ee0-ab12-3be6d8052caf
     status: 200 OK
     code: 200
     duration: ""
@@ -12073,19 +8513,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:59:41.714825Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:04:01.886748Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1485"
+      - "651"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:59:57 GMT
+      - Tue, 07 Nov 2023 16:04:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -12095,7 +8535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35e38c96-c7df-4dd8-a8dd-efc48c1a9f1c
+      - e9fc0a91-bc6b-421e-a2dc-9982b0a47148
     status: 200 OK
     code: 200
     duration: ""
@@ -12106,19 +8546,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:59:41.714825Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:04:01.886748Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1485"
+      - "651"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 17:00:02 GMT
+      - Tue, 07 Nov 2023 16:04:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -12128,7 +8568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf048023-5eba-439e-8772-be965c7574bb
+      - 761efef3-4e93-4864-99ce-5e214c5bef4c
     status: 200 OK
     code: 200
     duration: ""
@@ -12139,19 +8579,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:59:41.714825Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:04:01.886748Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1485"
+      - "651"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 17:00:07 GMT
+      - Tue, 07 Nov 2023 16:04:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -12161,7 +8601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 503a460f-d09c-40e5-a037-ce19eb785cc3
+      - dad4a835-392b-499c-bafc-005a9d3b0137
     status: 200 OK
     code: 200
     duration: ""
@@ -12172,19 +8612,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-19T16:51:23.484073Z","created_at":"2023-10-19T16:51:23.484073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-10-19T16:59:41.714825Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","container_runtime":"containerd","created_at":"2023-11-07T16:02:03.169087Z","id":"021b5870-cc24-4f88-92b4-060c684209db","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-placement-group-2","node_type":"gp1_xs","placement_group_id":"277c0192-f423-47ec-89ca-3e416daea91c","public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:04:01.886748Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1485"
+      - "651"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 17:00:12 GMT
+      - Tue, 07 Nov 2023 16:04:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -12194,7 +8634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29fe9d72-fb5f-480e-9aea-30a3afcae544
+      - d254699d-2434-4dfa-961c-5e4a64f64b2a
     status: 200 OK
     code: 200
     duration: ""
@@ -12205,19 +8645,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/021b5870-cc24-4f88-92b4-060c684209db
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"021b5870-cc24-4f88-92b4-060c684209db","type":"not_found"}'
     headers:
       Content-Length:
-      - "128"
+      - "125"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 17:00:17 GMT
+      - Tue, 07 Nov 2023 16:04:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -12227,7 +8667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0153c0a7-095b-4922-a42c-124e44882e4a
+      - 34efbb8c-046f-467e-b8e8-0a926feca6d4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -12238,19 +8678,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6
-    method: GET
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e?with_additional_resources=true
+    method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"40c4dbc5-dd03-41e1-9a31-5cc4ccd475a6","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:04:37.508417156Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "128"
+      - "1443"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 17:00:17 GMT
+      - Tue, 07 Nov 2023 16:04:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -12260,7 +8700,168 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41bc82b0-a170-4e67-be44-8968aa191219
+      - 7268da73-872a-4f63-8915-6e2601cedfdd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:04:37.508417Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1440"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:04:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 01230575-bab2-4014-a521-a7cb3d4c9da8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/placement_groups/277c0192-f423-47ec-89ca-3e416daea91c
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Tue, 07 Nov 2023 16:04:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0472167b-f80a-4aa6-85df-68ff327026fa
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://0e1a3cb2-2833-47e2-baef-309cbaea7e5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:00:31.592694Z","created_at":"2023-11-07T16:00:31.592694Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.0e1a3cb2-2833-47e2-baef-309cbaea7e5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","ingress":"none","name":"test-pool-placement-group-2","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","placement_group"],"type":"multicloud","updated_at":"2023-11-07T16:04:37.508417Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1440"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:04:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b74d5e42-5a04-48e5-86f0-593dc09e65a4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:04:47 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e051d3a8-e664-4cc1-8346-6e7c9da1be57
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/0e1a3cb2-2833-47e2-baef-309cbaea7e5e
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"0e1a3cb2-2833-47e2-baef-309cbaea7e5e","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:04:47 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c3ce1cff-ee09-4697-a1a2-2573991343e3
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-private-network.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-private-network.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:41 GMT
+      - Tue, 07 Nov 2023 15:49:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,12 +34,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0ddd324-815d-4aba-8964-e1b93a589af1
+      - bfdd2b05-52d8-4a76-9fb8-2323342fcb52
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-k8s-private-network","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null}'
+    body: '{"name":"test-k8s-private-network","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null}'
     form: {}
     headers:
       Content-Type:
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
     method: POST
   response:
-    body: '{"created_at":"2023-10-18T16:35:44.902018Z","id":"89dac298-df98-45a1-8871-4b918eb86a0c","is_default":false,"name":"test-k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_count":0,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","tags":[],"updated_at":"2023-10-18T16:35:44.902018Z"}'
+    body: '{"created_at":"2023-11-07T15:49:50.909203Z","id":"ca01ec19-5e6a-461a-a75b-7f1f56bcfa42","is_default":false,"name":"test-k8s-private-network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2023-11-07T15:49:50.909203Z"}'
     headers:
       Content-Length:
-      - "356"
+      - "347"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:45 GMT
+      - Tue, 07 Nov 2023 15:49:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b12bc5ec-5439-44e0-ae56-3b745a80ae90
+      - 31fc8e88-3e3e-46dc-8ae2-698092f4a882
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/89dac298-df98-45a1-8871-4b918eb86a0c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/ca01ec19-5e6a-461a-a75b-7f1f56bcfa42
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:35:44.902018Z","id":"89dac298-df98-45a1-8871-4b918eb86a0c","is_default":false,"name":"test-k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_count":0,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","tags":[],"updated_at":"2023-10-18T16:35:44.902018Z"}'
+    body: '{"created_at":"2023-11-07T15:49:50.909203Z","id":"ca01ec19-5e6a-461a-a75b-7f1f56bcfa42","is_default":false,"name":"test-k8s-private-network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2023-11-07T15:49:50.909203Z"}'
     headers:
       Content-Length:
-      - "356"
+      - "347"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:45 GMT
+      - Tue, 07 Nov 2023 15:49:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4366ba9e-12cf-4148-9958-3be4eb22488c
+      - ab8834f7-b5bd-463a-8d2e-24ee987eb31c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-k8s-private-network","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":"89dac298-df98-45a1-8871-4b918eb86a0c"}'
+    body: '{"name":"test-k8s-private-network","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null,"vpc_id":"ca01ec19-5e6a-461a-a75b-7f1f56bcfa42"}'
     form: {}
     headers:
       Content-Type:
@@ -118,16 +118,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-18T16:35:45.258962Z","dhcp_enabled":true,"id":"c20560a7-d092-404a-8418-8aa95095399c","name":"test-k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:35:45.258962Z","id":"d146def6-a138-4e37-9ef7-f074dadbd5e5","subnet":"172.16.20.0/22","updated_at":"2023-10-18T16:35:45.258962Z"},{"created_at":"2023-10-18T16:35:45.258962Z","id":"eafe12c9-2714-4f1c-a76f-2ad3b9be8208","subnet":"fd63:256c:45f7:4f62::/64","updated_at":"2023-10-18T16:35:45.258962Z"}],"tags":[],"updated_at":"2023-10-18T16:35:45.258962Z","vpc_id":"89dac298-df98-45a1-8871-4b918eb86a0c"}'
+    body: '{"created_at":"2023-11-07T15:49:51.243805Z","dhcp_enabled":true,"id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","name":"test-k8s-private-network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.243805Z","id":"d26296a1-8f11-4d2b-8781-5c7cef7510f7","subnet":"172.16.68.0/22","updated_at":"2023-11-07T15:49:51.243805Z"},{"created_at":"2023-11-07T15:49:51.243805Z","id":"95bc8018-3c82-4917-a233-3066ab5210af","subnet":"fd5f:519c:6d46:ead6::/64","updated_at":"2023-11-07T15:49:51.243805Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.243805Z","vpc_id":"ca01ec19-5e6a-461a-a75b-7f1f56bcfa42"}'
     headers:
       Content-Length:
-      - "725"
+      - "708"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:45 GMT
+      - Tue, 07 Nov 2023 15:49:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 987fe0a8-3860-44fb-b20f-30ed9ec9a535
+      - 2ab82976-4173-4223-b489-288449ca8559
     status: 200 OK
     code: 200
     duration: ""
@@ -148,19 +148,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c20560a7-d092-404a-8418-8aa95095399c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6ec88d41-f0fc-4501-9810-dd9de4cbc098
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:35:45.258962Z","dhcp_enabled":true,"id":"c20560a7-d092-404a-8418-8aa95095399c","name":"test-k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:35:45.258962Z","id":"d146def6-a138-4e37-9ef7-f074dadbd5e5","subnet":"172.16.20.0/22","updated_at":"2023-10-18T16:35:45.258962Z"},{"created_at":"2023-10-18T16:35:45.258962Z","id":"eafe12c9-2714-4f1c-a76f-2ad3b9be8208","subnet":"fd63:256c:45f7:4f62::/64","updated_at":"2023-10-18T16:35:45.258962Z"}],"tags":[],"updated_at":"2023-10-18T16:35:45.258962Z","vpc_id":"89dac298-df98-45a1-8871-4b918eb86a0c"}'
+    body: '{"created_at":"2023-11-07T15:49:51.243805Z","dhcp_enabled":true,"id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","name":"test-k8s-private-network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.243805Z","id":"d26296a1-8f11-4d2b-8781-5c7cef7510f7","subnet":"172.16.68.0/22","updated_at":"2023-11-07T15:49:51.243805Z"},{"created_at":"2023-11-07T15:49:51.243805Z","id":"95bc8018-3c82-4917-a233-3066ab5210af","subnet":"fd5f:519c:6d46:ead6::/64","updated_at":"2023-11-07T15:49:51.243805Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.243805Z","vpc_id":"ca01ec19-5e6a-461a-a75b-7f1f56bcfa42"}'
     headers:
       Content-Length:
-      - "725"
+      - "708"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:46 GMT
+      - Tue, 07 Nov 2023 15:49:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,12 +170,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc051afd-ea66-43b7-ba74-ee8ddd1af7fb
+      - 896854b8-11ce-4348-a33f-8f64c0878d30
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-k8s-private-network","description":"","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":"c20560a7-d092-404a-8418-8aa95095399c"}'
+    body: '{"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","type":"","name":"test-k8s-private-network","description":"","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098"}'
     form: {}
     headers:
       Content-Type:
@@ -186,16 +186,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8e5066b6-c900-4851-8e01-76feb9e34acd.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:46.197356181Z","created_at":"2023-10-18T16:35:46.197356181Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8e5066b6-c900-4851-8e01-76feb9e34acd.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8e5066b6-c900-4851-8e01-76feb9e34acd","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c20560a7-d092-404a-8418-8aa95095399c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T16:35:46.206480417Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://54bd7937-ba2e-4cce-86e5-67bf9bb82553.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.385540355Z","created_at":"2023-11-07T15:49:53.385540355Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54bd7937-ba2e-4cce-86e5-67bf9bb82553.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T15:49:53.410350167Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1524"
+      - "1479"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:46 GMT
+      - Tue, 07 Nov 2023 15:49:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -205,7 +205,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 988805ff-d497-43ad-b9b8-563fe189181d
+      - b8e7b9c6-4a1a-45b7-8f05-42b4c701d17c
     status: 200 OK
     code: 200
     duration: ""
@@ -216,19 +216,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8e5066b6-c900-4851-8e01-76feb9e34acd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8e5066b6-c900-4851-8e01-76feb9e34acd.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:46.197356Z","created_at":"2023-10-18T16:35:46.197356Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8e5066b6-c900-4851-8e01-76feb9e34acd.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8e5066b6-c900-4851-8e01-76feb9e34acd","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c20560a7-d092-404a-8418-8aa95095399c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T16:35:46.206480Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://54bd7937-ba2e-4cce-86e5-67bf9bb82553.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.385540Z","created_at":"2023-11-07T15:49:53.385540Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54bd7937-ba2e-4cce-86e5-67bf9bb82553.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T15:49:53.410350Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:46 GMT
+      - Tue, 07 Nov 2023 15:49:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -238,7 +238,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f041ede8-8e41-458a-951a-b40f5ae31263
+      - 0eeab453-8e63-4620-91e7-41b6ac5a8856
     status: 200 OK
     code: 200
     duration: ""
@@ -249,19 +249,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8e5066b6-c900-4851-8e01-76feb9e34acd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8e5066b6-c900-4851-8e01-76feb9e34acd.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:46.197356Z","created_at":"2023-10-18T16:35:46.197356Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8e5066b6-c900-4851-8e01-76feb9e34acd.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8e5066b6-c900-4851-8e01-76feb9e34acd","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c20560a7-d092-404a-8418-8aa95095399c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T16:35:48.208280Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://54bd7937-ba2e-4cce-86e5-67bf9bb82553.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.385540Z","created_at":"2023-11-07T15:49:53.385540Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54bd7937-ba2e-4cce-86e5-67bf9bb82553.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T15:49:55.337543Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1520"
+      - "1475"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -271,7 +271,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f417f411-9182-4251-acba-46b46aee4e01
+      - 66c2ef32-2918-4567-acce-ce9b5b2a97da
     status: 200 OK
     code: 200
     duration: ""
@@ -282,19 +282,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8e5066b6-c900-4851-8e01-76feb9e34acd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8e5066b6-c900-4851-8e01-76feb9e34acd.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:46.197356Z","created_at":"2023-10-18T16:35:46.197356Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8e5066b6-c900-4851-8e01-76feb9e34acd.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8e5066b6-c900-4851-8e01-76feb9e34acd","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c20560a7-d092-404a-8418-8aa95095399c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T16:35:48.208280Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://54bd7937-ba2e-4cce-86e5-67bf9bb82553.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.385540Z","created_at":"2023-11-07T15:49:53.385540Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54bd7937-ba2e-4cce-86e5-67bf9bb82553.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T15:49:55.337543Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1520"
+      - "1475"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -304,7 +304,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5029a9d6-4492-442c-9d0e-af2a36387b72
+      - 5f3566b0-068c-4db7-844a-998683ed65dc
     status: 200 OK
     code: 200
     duration: ""
@@ -315,19 +315,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8e5066b6-c900-4851-8e01-76feb9e34acd/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXByaXZhdGUtbmV0d29yayIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVeVRYcFZNRTR4YjFoRVZFMTZUVlJCZUU1NlJUSk5lbFV3VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTbTR5Q2toelNsTTFXbWxpTjI1cE9XWjRla0UyYUU5TVMxbHZiR2RSTHpsM2JuRjZjamhZVDJjcmJuUXlabU5CYVRscU9EQnZkamhUZUVwRE9WZG1Rek5YWjNjS1dXSnRWVVVyU0RNNFNUSTNPVEpGWjBObmVqRTBZbmwzWlRaUGNFeFBSemR3U0ZZeGExbENUSEZJU0cwNFRYWmxZa3d6WVZobk9XaEZhbkZ1WjBkNE9RcHdSV0pQVFdSRFFUVmFUMjQyVVVoVFozWjBNbFpETHpCMVRGVTRVV2x4ZVRocU5TdGtWV0o0WWxaNFdqVnBRblphV1VJeFZ5dGtSMDh6TnpJNWFYSXdDbXR2TWxOVFlVaDFTVFZXV2tsWGVVd3pOVlZGVWtGVmFUaGFTMjgzT1dWdWFUVlVhRzF0VTB4eGRXRkhXalJTT1RZM1psRldVVkpoZUhFMVJXVjVZVmdLYkVaWk1sbGlLM0ptYkVWUU5IWkVTR3hET0hRMGJsRmpTRFkwZW5ONVdsUk5WaXR3TkVWMk1uYzJNbTFXVDBZdmRrOVdObVF4UTNrNGVuUmtWM2xQWkFwV1dHWTJMMlpwUm5GYVRrYzNMeXRQV25oelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ1pGaDFXRWd4WXk5d1pXMVFWRTE2UVhadmIxQldVR1pIYlZKTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1lqZ3pOWEp1Tmpkd2NqTjVOazR4YVVWdmVuSlZSRWRTY0M5bGFHVXZPVlZXVG5OdGJHeFZjWGh1T1cxSk5qQkNid3A0VkRSYVNEZG1OVUppWkM5bWJFOTBOR0ozU0hjemVqbGlkRVpzVjFSUFFXVlFlVmhGT1VkNlV6Snlka3MwUjBSb1pFUTRNMDFUU21SVk5HRndVVzQ1Q21SQ1ZtbGhjRVp2TVRkRFRXRlJSWGhHUldoeGRrY3JhMXB6VkRKb1pYZHZUM1psWldoNlJUWkdWV1F2WWtreWNYVllTRUUzYUZSTk1EZEdZV3AzZUd3S1QzVTViWGxLYkdKbWJqRkhSSG8xY0RScmRsQm9jRUV4V0dJeWVrbGFaMXBhWVVGNFVFb3lXVVV2WlVsUlRGUlZOaTgwWjBVdmJWaGpSazVHYTJoQmRncHRUelJFU1RKVk9XSjJSSEJNTDFVekwyeEJUM05PUjA1cWQxWlZUVnBpVG14d1ZXdEtkR3Q1WkUxbGVUQnVZbmwxVVRsS01VWjBWVmt3VTJOTFZXWlZDbWs0UWxWblV6RnJlVEJ0YW5CWVZYazVZbGhFVTJObFdYcHNUVU01V0RSamVHTTJXUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOGU1MDY2YjYtYzkwMC00ODUxLThlMDEtNzZmZWI5ZTM0YWNkLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXByaXZhdGUtbmV0d29yawogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrIgogICAgdXNlcjogdGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB3REJPM3pYZE1oV3YxakNySm85NEt2TlZZYncxZTBLS3M1RGpGYUs0TE8zSjlKeEczNFRnNlVwWA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXByaXZhdGUtbmV0d29yayIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeFRrUnJNVTVHYjFoRVZFMTZUVlJGZDA1cVJURk9SR3N4VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV2xUQ2pKTVdUTjRRVTFDTW1KQ1lVWjZOV3ByUW5WVk56bFdhMU12Y0dsdVREWk5SRkoxVDJrMlZ6TmlXblpRVkV4V1JUSlpka2cyV1N0bldYVktUV3BxYzBVS2VqUlJSM2hqTWt4NVlXRkdTR3BJV1RSM2FteGtlRUUwYzJaT2REVnlURlZGV2t3d01XcFBkR012U1d4dGJXTXJabkZOWjJsV2ExbDBSMVpxVEhKdWJncFhWR0ZsZG1wemMzaE9WRWxMZW5aaVpGRm9ObEU1WTFOR1JXVnhRakEyU1RnMU9HOUNXVTFFVmpWdFRUWlRVVFEwT0RFemIwTjBVWFpYTTJwb09GcHVDbmhuVm5oaVEzcEJZbGx3TVdrclRVWmpObEpDVG1wb2JERTVNRFJSVTBSb2JGbEVXRzFLZERGdWVqWmFNV1pVZEN0UVdIbEtRMUkzUlRGM1QwczNURUlLTlVOS2JIQjNPR3BOTTFacGMzRlRaM0ZWTUVOcmFYZGlhekI0TTJOeEwwdE9SVXNyY25aRU9XUXdaMjFQUzFFM1JWVm1XVXRFUkZSUU9EZHhhRFJXWkFwVFZWUjJWamRzZERaa1FuY3hORTUwV1hrd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTWNUbHBWM2d4YjI0d1JWRlJUR3BFVnpoaFNuQkxVVzFvYWtwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlprMDBjRzVYTjBOUVFqUkVkeTlRU1Zwc1FscDFNR2RoT1VwU1JtazRUbFZLWTNwRWNtSTNSVkpWWkhGTVkxQmhkUW8wY1doVFIwOW9SRzVRVms1eGVUQldZV3hhVFV0VmFXcGhTMDk1WmpOMFZTOURiMHRwTUZsamNWZHFaWEpaWkZoQ2NGcFhMMmhCVVVNNFNWUlZUWE5rQ21kMlUwVnZNMjV2YW5Gd1pWaEtRMXBwUlRsaE5HeHdaWFpXYVdvNVJVdGhkR2x1UzI5Qlp6QlJSR1JqY1cxWVZreDJWekZ1Tms1dE5UQTJVeXRNV0hNS2VYUlBiMlozYjBsNFNFcG5TR0pIT0dkV1Z5OU1XalZRTW1KS01GSklTMlZSUVU5RlpVNTZLeTlsZFUwNVdWUXpZemR0Y2pKa0swUm5XbEV4Um1aVU1Rb3lRek5yZG5OT2F6WkRkR3hDUm1KM1owdGlTeTltVEdReE5saHBNVlZsZG1aM1JtNXVTamx5VGt4Q1FuQk9jVWRJVEU1SmRrbFZUVVJoT1VKTGJqRjVDblo1VnpKVFZYcG5jU3RFUVVJekt5OVBNREZYZFdkM1FsRlRjRGhXT1U0MEx6WndSUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTRiZDc5MzctYmEyZS00Y2NlLTg2ZTUtNjdiZjliYjgyNTUzLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXByaXZhdGUtbmV0d29yawogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrIgogICAgdXNlcjogdGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBSSFM1MkRLWTBkQVE5Wkd0V1lPcUd3SkZKRTNFNjkyRU5GV2E4Vkh1UDJBUUNsU0lrWTFtNE44Mg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2686"
+      - "2684"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -337,7 +337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e795483-88cb-407c-a464-4d7cb28a0a9b
+      - 34d5cf80-1996-44f7-8129-b2cb5491219d
     status: 200 OK
     code: 200
     duration: ""
@@ -348,19 +348,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8e5066b6-c900-4851-8e01-76feb9e34acd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8e5066b6-c900-4851-8e01-76feb9e34acd.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:46.197356Z","created_at":"2023-10-18T16:35:46.197356Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8e5066b6-c900-4851-8e01-76feb9e34acd.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8e5066b6-c900-4851-8e01-76feb9e34acd","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c20560a7-d092-404a-8418-8aa95095399c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T16:35:48.208280Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://54bd7937-ba2e-4cce-86e5-67bf9bb82553.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.385540Z","created_at":"2023-11-07T15:49:53.385540Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54bd7937-ba2e-4cce-86e5-67bf9bb82553.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T15:49:55.337543Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1520"
+      - "1475"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -370,12 +370,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1fc64037-84e4-401b-9dac-5cd5b2857178
+      - bc593085-2e93-41a5-b0fa-342d42eea0c1
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"pool","node_type":"gp1_xs","placement_group_id":null,"autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":true,"tags":null,"kubelet_args":{},"upgrade_policy":null,"zone":"fr-par-1","root_volume_type":"default_volume_type","root_volume_size":null,"public_ip_disabled":false}'
+    body: '{"name":"pool","node_type":"gp1_xs","autoscaling":false,"size":2,"min_size":1,"max_size":2,"container_runtime":"containerd","autohealing":true,"tags":null,"kubelet_args":{},"zone":"fr-par-1","root_volume_type":"default_volume_type","public_ip_disabled":false}'
     form: {}
     headers:
       Content-Type:
@@ -383,19 +383,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8e5066b6-c900-4851-8e01-76feb9e34acd/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621826793Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246372Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "618"
+      - "595"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 15:49:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -405,7 +405,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a016787-f7bc-4965-8d4c-80ae6784543e
+      - 64d85293-9fcc-449f-a3ff-d8d593e94466
     status: 200 OK
     code: 200
     duration: ""
@@ -416,19 +416,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:53 GMT
+      - Tue, 07 Nov 2023 15:49:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -438,7 +438,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0b567fd1-27bc-4f1d-9ed7-1281827bb5ee
+      - cd27bdd4-1e13-4107-80ba-bd1d0815059c
     status: 200 OK
     code: 200
     duration: ""
@@ -449,19 +449,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:58 GMT
+      - Tue, 07 Nov 2023 15:50:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -471,7 +471,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8634c51a-479b-4a37-9fef-fb71b2758e94
+      - 709f039f-ed93-4bcd-b16e-206f51242348
     status: 200 OK
     code: 200
     duration: ""
@@ -482,19 +482,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:03 GMT
+      - Tue, 07 Nov 2023 15:50:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -504,7 +504,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce63d0c9-75ac-4eb4-8881-a671fcf98f5c
+      - d3efc8e9-4a9e-4294-bd74-7d8680594e4b
     status: 200 OK
     code: 200
     duration: ""
@@ -515,19 +515,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:09 GMT
+      - Tue, 07 Nov 2023 15:50:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -537,7 +537,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b5dcb59-1d11-4f0c-9c24-4fa09c77eb30
+      - 9bb15e2e-cdf6-4f17-8406-5abb7496bff2
     status: 200 OK
     code: 200
     duration: ""
@@ -548,19 +548,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:14 GMT
+      - Tue, 07 Nov 2023 15:50:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -570,7 +570,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b27760ac-6539-46e4-b262-73c9b11cef52
+      - 175b6662-7b0d-4f6e-96ae-efbf9fb12b2b
     status: 200 OK
     code: 200
     duration: ""
@@ -581,19 +581,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:19 GMT
+      - Tue, 07 Nov 2023 15:50:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -603,7 +603,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 988f7eb5-6fee-48dd-84a7-6c17d8642a09
+      - 173b7a42-09d0-4989-b615-99a643708958
     status: 200 OK
     code: 200
     duration: ""
@@ -614,19 +614,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:24 GMT
+      - Tue, 07 Nov 2023 15:50:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -636,7 +636,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50caa719-fcee-4274-92dc-575c187b8064
+      - fe57be04-7c06-4ca2-8a0a-4ff19ca7cb53
     status: 200 OK
     code: 200
     duration: ""
@@ -647,19 +647,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:30 GMT
+      - Tue, 07 Nov 2023 15:50:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -669,7 +669,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09c54814-4831-496d-afd2-4fc93f6fdec1
+      - 78b47eb7-3454-4d9f-ad0c-0b2e3783c079
     status: 200 OK
     code: 200
     duration: ""
@@ -680,19 +680,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:35 GMT
+      - Tue, 07 Nov 2023 15:50:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -702,7 +702,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14ef828f-29b6-49c8-a236-214065a53017
+      - 4cb288fa-d49f-4f06-9376-51c64b51b4dd
     status: 200 OK
     code: 200
     duration: ""
@@ -713,19 +713,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:40 GMT
+      - Tue, 07 Nov 2023 15:50:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -735,7 +735,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5476de24-ff48-4684-becd-f0dddbe7c689
+      - 59684003-a0fc-43dc-a557-0d957f73e863
     status: 200 OK
     code: 200
     duration: ""
@@ -746,19 +746,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:45 GMT
+      - Tue, 07 Nov 2023 15:50:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -768,7 +768,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ecfb3cae-4ca8-4e4d-a373-ad47a6fa5bf7
+      - 66569817-6cc4-40b2-877c-86724a85a97a
     status: 200 OK
     code: 200
     duration: ""
@@ -779,19 +779,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:50 GMT
+      - Tue, 07 Nov 2023 15:50:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -801,7 +801,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bebafe93-2336-4bd5-9650-e008024ce1e2
+      - 9877e95f-6627-4ef4-bb8c-41f13d9890de
     status: 200 OK
     code: 200
     duration: ""
@@ -812,19 +812,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:55 GMT
+      - Tue, 07 Nov 2023 15:51:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -834,7 +834,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91039fe7-5bd4-47fb-a291-ded4cd7572d0
+      - 3b8161c5-f693-4e7f-89d4-9f0691bd9319
     status: 200 OK
     code: 200
     duration: ""
@@ -845,19 +845,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:00 GMT
+      - Tue, 07 Nov 2023 15:51:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -867,7 +867,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bd7f2f2-9c84-459f-b70e-4b6c828a611d
+      - 2c19c6cc-9ded-4ab0-b7e1-96b34339ed4f
     status: 200 OK
     code: 200
     duration: ""
@@ -878,19 +878,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:05 GMT
+      - Tue, 07 Nov 2023 15:51:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -900,7 +900,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9aeb3ee-7fe8-43e8-8d45-6d59fa79928e
+      - 99dbd641-989e-42d7-8ed0-c5d4fa2036f7
     status: 200 OK
     code: 200
     duration: ""
@@ -911,19 +911,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:10 GMT
+      - Tue, 07 Nov 2023 15:51:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -933,7 +933,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4d9dd4b-005b-453f-8b3b-f11a7d3a9e82
+      - ef23c23c-0382-42fb-a0c2-ade88f660dc6
     status: 200 OK
     code: 200
     duration: ""
@@ -944,19 +944,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:15 GMT
+      - Tue, 07 Nov 2023 15:51:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -966,7 +966,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dfd4c1dc-9651-434e-b0e0-404abd04c98e
+      - bd7dee32-1e64-41dd-88e9-41c712a2af62
     status: 200 OK
     code: 200
     duration: ""
@@ -977,19 +977,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:20 GMT
+      - Tue, 07 Nov 2023 15:51:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -999,7 +999,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5f91d61-83a8-467c-97e3-c52120e0eeca
+      - 6e958f21-3edd-43dd-9a68-703df0176f41
     status: 200 OK
     code: 200
     duration: ""
@@ -1010,19 +1010,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:25 GMT
+      - Tue, 07 Nov 2023 15:51:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1032,7 +1032,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60bfe05f-165d-469c-a265-01585362f018
+      - 8492bb7f-2b74-4fdc-82af-36bf54013b92
     status: 200 OK
     code: 200
     duration: ""
@@ -1043,19 +1043,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:30 GMT
+      - Tue, 07 Nov 2023 15:51:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1065,7 +1065,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 919cddb9-ea5d-4a15-8495-d9d5850a61ac
+      - adcb368e-1e52-4fda-849b-6be9b3c98564
     status: 200 OK
     code: 200
     duration: ""
@@ -1076,19 +1076,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:35 GMT
+      - Tue, 07 Nov 2023 15:51:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1098,7 +1098,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1411672-4f3e-4975-a00a-2a6892e1e9ea
+      - a3f09a49-2346-4668-9ff6-b548e5380a58
     status: 200 OK
     code: 200
     duration: ""
@@ -1109,19 +1109,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:40 GMT
+      - Tue, 07 Nov 2023 15:51:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1131,7 +1131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd29a11e-59df-412e-a677-0190722f5e10
+      - 22fb128e-02ae-4b39-92b5-c5c11e9b2761
     status: 200 OK
     code: 200
     duration: ""
@@ -1142,19 +1142,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:45 GMT
+      - Tue, 07 Nov 2023 15:51:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1164,7 +1164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7cc0684b-1d08-43c1-a4da-dc593780a880
+      - 337fdbfd-8136-4e6d-aaba-a485be4b542c
     status: 200 OK
     code: 200
     duration: ""
@@ -1175,19 +1175,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:50 GMT
+      - Tue, 07 Nov 2023 15:51:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1197,7 +1197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab89929b-1f8b-4811-8121-0cfac7696189
+      - 3b25893c-7782-4a22-b3fc-f825b13059e9
     status: 200 OK
     code: 200
     duration: ""
@@ -1208,19 +1208,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:55 GMT
+      - Tue, 07 Nov 2023 15:52:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1230,7 +1230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0052550e-4901-4682-9793-18e4a41f0ec3
+      - 646c7b41-ddc6-48fb-896a-30e4495833c2
     status: 200 OK
     code: 200
     duration: ""
@@ -1241,19 +1241,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:00 GMT
+      - Tue, 07 Nov 2023 15:52:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1263,7 +1263,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3c8cb6e-1f16-486b-bcfd-de4ebecaa1fb
+      - 92e2986f-a86c-48d8-acaf-b1318ab20401
     status: 200 OK
     code: 200
     duration: ""
@@ -1274,19 +1274,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:05 GMT
+      - Tue, 07 Nov 2023 15:52:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1296,7 +1296,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fb819a5-11f9-4384-807a-049edfd275a4
+      - ef413512-59c5-41cb-9b93-58bf4ffd70fd
     status: 200 OK
     code: 200
     duration: ""
@@ -1307,19 +1307,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:10 GMT
+      - Tue, 07 Nov 2023 15:52:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1329,7 +1329,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5f3a89e-b45a-451d-8e97-e02f6a3bf0c8
+      - 3088236e-c051-4f8f-99d1-a7132d2a033b
     status: 200 OK
     code: 200
     duration: ""
@@ -1340,19 +1340,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:16 GMT
+      - Tue, 07 Nov 2023 15:52:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1362,7 +1362,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c0ad9aa-6cc9-4c5f-8a5c-50ef99b19f5d
+      - 0d726092-b3e4-4295-a059-f7d7e9e5b21b
     status: 200 OK
     code: 200
     duration: ""
@@ -1373,19 +1373,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:21 GMT
+      - Tue, 07 Nov 2023 15:52:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1395,7 +1395,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71494736-1a48-444a-8963-a9873dfedf62
+      - a6f76ba6-2b4e-44f8-9b8e-385a6d17a334
     status: 200 OK
     code: 200
     duration: ""
@@ -1406,19 +1406,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:26 GMT
+      - Tue, 07 Nov 2023 15:52:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1428,7 +1428,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a017a3f1-5a67-44d1-8aaf-882638e9f03c
+      - c2b98e20-32ce-4182-83fc-325cf9e8a1d0
     status: 200 OK
     code: 200
     duration: ""
@@ -1439,19 +1439,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:31 GMT
+      - Tue, 07 Nov 2023 15:52:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1461,7 +1461,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 622fa1b5-4419-4c6b-ac06-3d27b651f680
+      - fe097abc-76bd-4ed3-bee6-3e62f46d6bac
     status: 200 OK
     code: 200
     duration: ""
@@ -1472,19 +1472,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:36 GMT
+      - Tue, 07 Nov 2023 15:52:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1494,7 +1494,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81b3c274-d824-470b-a4d9-9eb9d33feb2e
+      - c4c473a6-72e4-48cb-86f3-81e66f9b256c
     status: 200 OK
     code: 200
     duration: ""
@@ -1505,19 +1505,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:41 GMT
+      - Tue, 07 Nov 2023 15:52:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1527,7 +1527,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a61b2da-848f-49de-a244-2ef566be1e70
+      - f6e6fc52-dfc8-432b-81cf-797d629a5cef
     status: 200 OK
     code: 200
     duration: ""
@@ -1538,19 +1538,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:46 GMT
+      - Tue, 07 Nov 2023 15:52:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1560,7 +1560,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89676d87-0e41-4505-b5c6-7d3f9a3a0fcb
+      - fcb987e2-03d2-4eb2-a99c-240e7dc543d8
     status: 200 OK
     code: 200
     duration: ""
@@ -1571,19 +1571,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:51 GMT
+      - Tue, 07 Nov 2023 15:52:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1593,7 +1593,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67ac1082-97fa-4e64-bba8-793b69cbedfa
+      - d164dec9-387f-44bc-ab52-e54f21467355
     status: 200 OK
     code: 200
     duration: ""
@@ -1604,19 +1604,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:56 GMT
+      - Tue, 07 Nov 2023 15:53:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1626,7 +1626,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be27d99e-36dc-475f-9830-ac8324f07a91
+      - 6c6b7b82-02cb-4ba8-b2f7-9b9da0403d95
     status: 200 OK
     code: 200
     duration: ""
@@ -1637,19 +1637,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:01 GMT
+      - Tue, 07 Nov 2023 15:53:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1659,7 +1659,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d44fbaff-2479-4a8e-bdcf-6c9c74da8f79
+      - 75e5c642-56d9-4efb-924e-3cca274d9684
     status: 200 OK
     code: 200
     duration: ""
@@ -1670,19 +1670,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:06 GMT
+      - Tue, 07 Nov 2023 15:53:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1692,7 +1692,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c224916-e135-432b-a84e-432253215a6d
+      - ec22621c-cdd6-4d48-8ae4-16ee795bdb98
     status: 200 OK
     code: 200
     duration: ""
@@ -1703,19 +1703,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:12 GMT
+      - Tue, 07 Nov 2023 15:53:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1725,7 +1725,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3a4cfa4-e5e7-460c-9f77-169d2d13e9ed
+      - 31b02129-5a47-4e8b-b727-a93365f2bec9
     status: 200 OK
     code: 200
     duration: ""
@@ -1736,19 +1736,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:17 GMT
+      - Tue, 07 Nov 2023 15:53:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1758,7 +1758,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d9ea40a-f865-463c-9ffc-0c4e7622b9c5
+      - 0481f8d1-7ce8-4685-8b7e-90cd0f2fcb51
     status: 200 OK
     code: 200
     duration: ""
@@ -1769,19 +1769,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:22 GMT
+      - Tue, 07 Nov 2023 15:53:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1791,7 +1791,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 690de7e4-48f9-4a4a-b52a-73ede66e8ee7
+      - a5afbeda-a38c-4e40-845b-6dd127df5f6c
     status: 200 OK
     code: 200
     duration: ""
@@ -1802,19 +1802,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:27 GMT
+      - Tue, 07 Nov 2023 15:53:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1824,7 +1824,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3fba92c-8109-446b-a97a-75f4590604ee
+      - a4b81d57-f77e-4f6a-a76c-0df96823bd54
     status: 200 OK
     code: 200
     duration: ""
@@ -1835,19 +1835,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:32 GMT
+      - Tue, 07 Nov 2023 15:53:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1857,7 +1857,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f2ea16e-00eb-4bb8-95e9-f7c340da43c4
+      - 799cf412-564e-498e-98c5-87ff245cfea2
     status: 200 OK
     code: 200
     duration: ""
@@ -1868,19 +1868,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:37 GMT
+      - Tue, 07 Nov 2023 15:53:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1890,7 +1890,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80e00c94-08db-4e0d-8499-e22e955dafce
+      - 013e800a-cd38-409d-bba3-d16a92db8b02
     status: 200 OK
     code: 200
     duration: ""
@@ -1901,19 +1901,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:42 GMT
+      - Tue, 07 Nov 2023 15:53:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1923,7 +1923,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56cf203b-cb5b-427e-89bb-1b4372fbf92f
+      - d672eaf6-9e5d-45ea-93f5-c16af1c0c9e7
     status: 200 OK
     code: 200
     duration: ""
@@ -1934,19 +1934,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:47 GMT
+      - Tue, 07 Nov 2023 15:53:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1956,7 +1956,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 859dfd83-6117-42dc-8030-b99d7430ac76
+      - cd366f94-b72f-4e99-b381-abd9f617119d
     status: 200 OK
     code: 200
     duration: ""
@@ -1967,19 +1967,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:52 GMT
+      - Tue, 07 Nov 2023 15:53:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1989,7 +1989,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 441d9726-9c99-4bdd-ab18-5b91d4e750cd
+      - 589e1a3f-45e7-43c8-90a6-55f85cc9151a
     status: 200 OK
     code: 200
     duration: ""
@@ -2000,19 +2000,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:57 GMT
+      - Tue, 07 Nov 2023 15:54:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2022,7 +2022,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a217077-ed42-4724-8e57-f339948f245a
+      - 29797c0e-0970-4ff0-9dbc-66099b47acca
     status: 200 OK
     code: 200
     duration: ""
@@ -2033,19 +2033,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:02 GMT
+      - Tue, 07 Nov 2023 15:54:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2055,7 +2055,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de86e186-8787-40f9-ae22-f95d41aba434
+      - 6c2fbbe6-2942-416a-90cc-a2c006e12c63
     status: 200 OK
     code: 200
     duration: ""
@@ -2066,19 +2066,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:07 GMT
+      - Tue, 07 Nov 2023 15:54:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2088,7 +2088,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b683b53-e280-42fc-8b75-97bb308bea21
+      - af528f9a-ea47-4350-adea-d61fbe00488a
     status: 200 OK
     code: 200
     duration: ""
@@ -2099,19 +2099,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:12 GMT
+      - Tue, 07 Nov 2023 15:54:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2121,7 +2121,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6bcf776a-40fc-4c5b-87e7-5fdb57ab1f66
+      - 5db8eedc-2faa-4ac0-96e2-cc81d9bca8f8
     status: 200 OK
     code: 200
     duration: ""
@@ -2132,19 +2132,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:17 GMT
+      - Tue, 07 Nov 2023 15:54:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2154,7 +2154,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2cdb2b8e-8bec-46b0-bc80-f8b99c7a16d7
+      - 7f670894-5c27-4d52-a2ef-56e0063daa1d
     status: 200 OK
     code: 200
     duration: ""
@@ -2165,19 +2165,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:22 GMT
+      - Tue, 07 Nov 2023 15:54:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2187,7 +2187,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd85e133-d586-4f51-90b5-8621ff7013d4
+      - f6ae8243-8aa9-4a63-855b-169f6b0343cf
     status: 200 OK
     code: 200
     duration: ""
@@ -2198,19 +2198,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:27 GMT
+      - Tue, 07 Nov 2023 15:54:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2220,7 +2220,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a702151b-6243-44cf-b94a-e4c7b4ecda7e
+      - 89797b1a-562f-434e-a69b-a0a1ffe277d3
     status: 200 OK
     code: 200
     duration: ""
@@ -2231,19 +2231,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:32 GMT
+      - Tue, 07 Nov 2023 15:54:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2253,7 +2253,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 743a6c57-6c46-4c52-a78d-7195b441ebe1
+      - 444fa5c0-4805-4975-8c73-ea9247569a06
     status: 200 OK
     code: 200
     duration: ""
@@ -2264,19 +2264,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:38 GMT
+      - Tue, 07 Nov 2023 15:54:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2286,7 +2286,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0530dc58-0eaf-448e-b891-546c840d0827
+      - 4e644944-e05e-464a-a9f0-b11d1416357c
     status: 200 OK
     code: 200
     duration: ""
@@ -2297,19 +2297,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:43 GMT
+      - Tue, 07 Nov 2023 15:54:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2319,7 +2319,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c78f18c2-f400-4543-9477-9dbc3bdc7173
+      - 2aabbc22-b5a7-49af-a1dd-f7f3ec06e161
     status: 200 OK
     code: 200
     duration: ""
@@ -2330,19 +2330,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:48 GMT
+      - Tue, 07 Nov 2023 15:54:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2352,7 +2352,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66278999-5b9e-4130-8339-1bfa487a0ac3
+      - e47263fb-261e-4729-ad63-a4b01beed65e
     status: 200 OK
     code: 200
     duration: ""
@@ -2363,19 +2363,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:53 GMT
+      - Tue, 07 Nov 2023 15:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2385,7 +2385,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29d43962-8a32-4fe4-9c6f-04cbaeb61d24
+      - 3782d3a9-f82d-4e86-803b-9881815f32e7
     status: 200 OK
     code: 200
     duration: ""
@@ -2396,19 +2396,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:58 GMT
+      - Tue, 07 Nov 2023 15:55:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2418,7 +2418,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 339e0f6a-4c0c-48d5-aedd-e2dcfc503315
+      - 9b422672-c784-44a0-91f7-3e34182d238a
     status: 200 OK
     code: 200
     duration: ""
@@ -2429,19 +2429,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:03 GMT
+      - Tue, 07 Nov 2023 15:55:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2451,7 +2451,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e079ed7b-5e29-4dc6-b8d3-6ba3791e536a
+      - 7890c272-9254-418f-bf06-96751f7f30eb
     status: 200 OK
     code: 200
     duration: ""
@@ -2462,19 +2462,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:08 GMT
+      - Tue, 07 Nov 2023 15:55:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2484,7 +2484,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ad555d0-e198-4368-aec8-9b7a789cab66
+      - 51902418-b210-4c1f-b374-5f8a0a1c3888
     status: 200 OK
     code: 200
     duration: ""
@@ -2495,19 +2495,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:13 GMT
+      - Tue, 07 Nov 2023 15:55:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2517,7 +2517,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f00c44ed-9510-4dd2-b8d8-525aff0cc21c
+      - 57c4c443-0e68-4a18-8346-f4d16481f6d0
     status: 200 OK
     code: 200
     duration: ""
@@ -2528,19 +2528,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:18 GMT
+      - Tue, 07 Nov 2023 15:55:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2550,7 +2550,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd8bf8c2-59cd-4039-aa73-487bb878b3e2
+      - 15f7bb86-b624-438b-a316-28405a8fa04c
     status: 200 OK
     code: 200
     duration: ""
@@ -2561,19 +2561,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:23 GMT
+      - Tue, 07 Nov 2023 15:55:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2583,7 +2583,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0775f953-0524-4059-b32c-8512b41d844d
+      - 272d6bf7-b449-447c-bf29-d61c56189cab
     status: 200 OK
     code: 200
     duration: ""
@@ -2594,19 +2594,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:28 GMT
+      - Tue, 07 Nov 2023 15:55:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2616,7 +2616,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f3d7697-b24a-4a23-b537-ab7bb029338b
+      - dde9e8c8-82d7-4971-ba1b-5fc0610166b4
     status: 200 OK
     code: 200
     duration: ""
@@ -2627,19 +2627,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:33 GMT
+      - Tue, 07 Nov 2023 15:55:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2649,7 +2649,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7fbc6abc-d250-4a89-b391-59f6d770eeeb
+      - f68de61e-d7df-4baf-96c4-5cdd8f3aa1d0
     status: 200 OK
     code: 200
     duration: ""
@@ -2660,19 +2660,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:38 GMT
+      - Tue, 07 Nov 2023 15:55:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2682,7 +2682,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 173c04bd-6166-47e0-928f-e29badadaccc
+      - b99f9acb-5d27-4b3d-98d9-7ee6620c90e8
     status: 200 OK
     code: 200
     duration: ""
@@ -2693,19 +2693,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:43 GMT
+      - Tue, 07 Nov 2023 15:55:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2715,7 +2715,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 670d8466-931a-4f22-9f31-1f52630bcb6c
+      - 8f7ad3c1-79fe-4672-9e07-8aa23c36ae01
     status: 200 OK
     code: 200
     duration: ""
@@ -2726,19 +2726,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:48 GMT
+      - Tue, 07 Nov 2023 15:55:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2748,7 +2748,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b99b74d4-0217-4561-aaaa-820dd331fce5
+      - 5d9c0b92-18e9-4377-8cec-483f13046bc9
     status: 200 OK
     code: 200
     duration: ""
@@ -2759,19 +2759,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:54 GMT
+      - Tue, 07 Nov 2023 15:55:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2781,7 +2781,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2378dc35-b6d9-4109-9d8b-1931d91604e3
+      - cdec75fc-b72a-403c-b261-42b7ec7dc98e
     status: 200 OK
     code: 200
     duration: ""
@@ -2792,19 +2792,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:59 GMT
+      - Tue, 07 Nov 2023 15:56:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2814,7 +2814,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2ccb708-5da2-4cb8-b7db-5d1acc0daa92
+      - b64457aa-b007-4150-8b17-da46c7f0a748
     status: 200 OK
     code: 200
     duration: ""
@@ -2825,19 +2825,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:04 GMT
+      - Tue, 07 Nov 2023 15:56:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2847,7 +2847,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8fd2c19d-bfaf-433c-9294-1a5ac0f182f6
+      - 9af2c9aa-e71a-489a-b531-ee6672883660
     status: 200 OK
     code: 200
     duration: ""
@@ -2858,19 +2858,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:09 GMT
+      - Tue, 07 Nov 2023 15:56:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2880,7 +2880,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d998d9a4-014d-46f9-902c-809e78f27c33
+      - 1f5c54d6-86b7-48ac-b9d8-76f6c49b854b
     status: 200 OK
     code: 200
     duration: ""
@@ -2891,19 +2891,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:14 GMT
+      - Tue, 07 Nov 2023 15:56:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2913,7 +2913,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0c2a9b9-9b50-4b72-9202-76f4ba5b78f4
+      - 4f17177c-72ef-4e92-a435-e3c6811727f1
     status: 200 OK
     code: 200
     duration: ""
@@ -2924,19 +2924,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:19 GMT
+      - Tue, 07 Nov 2023 15:56:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2946,7 +2946,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ee30207-a858-40d0-86ee-f58484712bfe
+      - 3b5d6fa9-8c6b-4e52-bc57-542ee9aeb7cd
     status: 200 OK
     code: 200
     duration: ""
@@ -2957,19 +2957,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:24 GMT
+      - Tue, 07 Nov 2023 15:56:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2979,7 +2979,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ffe90ff1-42cd-4b3a-8872-ea0306c852a4
+      - 231a7487-426d-4520-8c15-917b37fb4fc5
     status: 200 OK
     code: 200
     duration: ""
@@ -2990,19 +2990,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:29 GMT
+      - Tue, 07 Nov 2023 15:56:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3012,7 +3012,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1787ae50-ced4-478c-9341-5b2be8582597
+      - 7f16a760-c4a9-41ab-ae09-120bf75062f1
     status: 200 OK
     code: 200
     duration: ""
@@ -3023,19 +3023,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:34 GMT
+      - Tue, 07 Nov 2023 15:56:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3045,7 +3045,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d47da4c-6292-4062-8b9f-b1809acd442d
+      - 05d88af3-63f3-4405-b14e-51ec03e1afcb
     status: 200 OK
     code: 200
     duration: ""
@@ -3056,19 +3056,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:39 GMT
+      - Tue, 07 Nov 2023 15:56:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3078,7 +3078,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - efe2e5e6-79a1-4606-ad7a-16889b7040ca
+      - 83c0ae87-87ca-44aa-846c-2d4d799f3564
     status: 200 OK
     code: 200
     duration: ""
@@ -3089,19 +3089,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:44 GMT
+      - Tue, 07 Nov 2023 15:56:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3111,7 +3111,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2dd72e7-4c6a-4cfd-89c4-1a7f898dc748
+      - 09bd49a4-7ec7-42da-b09f-d5f8f1b0addb
     status: 200 OK
     code: 200
     duration: ""
@@ -3122,19 +3122,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:49 GMT
+      - Tue, 07 Nov 2023 15:56:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3144,7 +3144,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d5a5dd8-08be-4d19-ba74-1b04622aea32
+      - 50d37572-ca8e-4d02-b7c3-af84328a0b8c
     status: 200 OK
     code: 200
     duration: ""
@@ -3155,19 +3155,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:54 GMT
+      - Tue, 07 Nov 2023 15:57:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3177,7 +3177,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 829d298d-1714-41e2-ba84-e905d5aae4f0
+      - 825bd2d2-fd23-4423-aeaf-e4bd5d140481
     status: 200 OK
     code: 200
     duration: ""
@@ -3188,19 +3188,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:59 GMT
+      - Tue, 07 Nov 2023 15:57:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3210,7 +3210,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75d70850-3733-49a3-b664-0669872f2ca9
+      - 2a740842-79aa-4f00-a8e5-ef5eda900601
     status: 200 OK
     code: 200
     duration: ""
@@ -3221,19 +3221,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:51.621827Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:04 GMT
+      - Tue, 07 Nov 2023 15:57:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3243,7 +3243,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75fa07e4-e674-4098-ad2c-c2f2cd887744
+      - 94be632b-c2e1-44e8-ae6d-b0d26434b92b
     status: 200 OK
     code: 200
     duration: ""
@@ -3254,19 +3254,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-10-18T16:43:08.656484Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "613"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:10 GMT
+      - Tue, 07 Nov 2023 15:57:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3276,7 +3276,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2399593-4e58-44cb-86e6-5ef53a09a741
+      - 9d7eba0f-9cd9-4bfd-a7cb-75fadbe6e592
     status: 200 OK
     code: 200
     duration: ""
@@ -3287,19 +3287,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8e5066b6-c900-4851-8e01-76feb9e34acd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8e5066b6-c900-4851-8e01-76feb9e34acd.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:46.197356Z","created_at":"2023-10-18T16:35:46.197356Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8e5066b6-c900-4851-8e01-76feb9e34acd.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8e5066b6-c900-4851-8e01-76feb9e34acd","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c20560a7-d092-404a-8418-8aa95095399c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T16:37:27.996002Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1512"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:10 GMT
+      - Tue, 07 Nov 2023 15:57:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3309,7 +3309,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bf9bdce-d7fd-4efc-9134-275607d2de72
+      - 56ee87c5-937a-4f6b-98c9-8101f836a7d2
     status: 200 OK
     code: 200
     duration: ""
@@ -3320,19 +3320,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-10-18T16:43:08.656484Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "613"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:10 GMT
+      - Tue, 07 Nov 2023 15:57:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3342,7 +3342,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de12a0fc-62ba-4489-be57-bbc392d65461
+      - c95172fe-165b-48e9-b15c-173dc3d6a5fa
     status: 200 OK
     code: 200
     duration: ""
@@ -3353,19 +3353,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8e5066b6-c900-4851-8e01-76feb9e34acd/nodes?order_by=created_at_asc&page=1&pool_id=33ebe8a5-5a0e-434c-b810-8ca79b112bb2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:37:44.552790Z","error_message":null,"id":"1b3de83f-72e3-4d31-8872-7f367b6538f0","name":"scw-test-k8s-private-network-pool-1b3de83f72e3","pool_id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","provider_id":"scaleway://instance/fr-par-1/a6263eb5-6438-45bb-8837-77372945bfbb","public_ip_v4":"51.15.230.101","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:43:08.622910Z"},{"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:37:48.635392Z","error_message":null,"id":"e275788d-a03d-41c2-8da2-64bee196e618","name":"scw-test-k8s-private-network-pool-e275788da03d","pool_id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","provider_id":"scaleway://instance/fr-par-1/0a195f8b-16c4-44be-bf92-20f9dbe96b7a","public_ip_v4":"51.15.143.114","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:43:08.642932Z"}],"total_count":2}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.833246Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1319"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:10 GMT
+      - Tue, 07 Nov 2023 15:57:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3375,7 +3375,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c92b2bb-7e13-47ac-b160-c6a916d617b8
+      - 81455ae5-342f-4788-9260-824cce84ec0c
     status: 200 OK
     code: 200
     duration: ""
@@ -3386,19 +3386,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8e5066b6-c900-4851-8e01-76feb9e34acd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8e5066b6-c900-4851-8e01-76feb9e34acd.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:46.197356Z","created_at":"2023-10-18T16:35:46.197356Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8e5066b6-c900-4851-8e01-76feb9e34acd.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8e5066b6-c900-4851-8e01-76feb9e34acd","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c20560a7-d092-404a-8418-8aa95095399c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T16:37:27.996002Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-07T15:57:35.296164Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1512"
+      - "590"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:10 GMT
+      - Tue, 07 Nov 2023 15:57:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3408,7 +3408,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 534266f0-c31a-41fc-843b-47758222ee21
+      - ffc7a864-08e7-492c-86c2-27fe04f5ed0a
     status: 200 OK
     code: 200
     duration: ""
@@ -3419,19 +3419,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c20560a7-d092-404a-8418-8aa95095399c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:35:45.258962Z","dhcp_enabled":true,"id":"c20560a7-d092-404a-8418-8aa95095399c","name":"test-k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:35:45.258962Z","id":"d146def6-a138-4e37-9ef7-f074dadbd5e5","subnet":"172.16.20.0/22","updated_at":"2023-10-18T16:35:45.258962Z"},{"created_at":"2023-10-18T16:35:45.258962Z","id":"eafe12c9-2714-4f1c-a76f-2ad3b9be8208","subnet":"fd63:256c:45f7:4f62::/64","updated_at":"2023-10-18T16:35:45.258962Z"}],"tags":[],"updated_at":"2023-10-18T16:35:45.258962Z","vpc_id":"89dac298-df98-45a1-8871-4b918eb86a0c"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://54bd7937-ba2e-4cce-86e5-67bf9bb82553.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.385540Z","created_at":"2023-11-07T15:49:53.385540Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54bd7937-ba2e-4cce-86e5-67bf9bb82553.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T15:51:02.709881Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "725"
+      - "1467"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:10 GMT
+      - Tue, 07 Nov 2023 15:57:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3441,7 +3441,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8bb15225-d620-4855-ab46-c11ca2505304
+      - 105ac38e-6236-47d4-bb4d-ec3ffe102bfc
     status: 200 OK
     code: 200
     duration: ""
@@ -3452,19 +3452,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-10-18T16:43:08.656484Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-07T15:57:35.296164Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "613"
+      - "590"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:10 GMT
+      - Tue, 07 Nov 2023 15:57:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3474,7 +3474,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 58c194d9-d611-4e86-a7bc-e4b34a048e0c
+      - 33d5f74f-5c52-4d46-bc24-2931f128ca7e
     status: 200 OK
     code: 200
     duration: ""
@@ -3485,19 +3485,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8e5066b6-c900-4851-8e01-76feb9e34acd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553/nodes?order_by=created_at_asc&page=1&pool_id=7d41f060-d78c-497d-8412-77dcd41e5073&status=unknown
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8e5066b6-c900-4851-8e01-76feb9e34acd.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:46.197356Z","created_at":"2023-10-18T16:35:46.197356Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8e5066b6-c900-4851-8e01-76feb9e34acd.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8e5066b6-c900-4851-8e01-76feb9e34acd","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c20560a7-d092-404a-8418-8aa95095399c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T16:37:27.996002Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"nodes":[{"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:55:02.943504Z","error_message":null,"id":"1254a3f8-7ee7-4310-95dc-be2e6cea124b","name":"scw-test-k8s-private-network-pool-1254a3f87ee7","pool_id":"7d41f060-d78c-497d-8412-77dcd41e5073","provider_id":"scaleway://instance/fr-par-1/f39671eb-2054-4775-848e-780dec2c4f52","public_ip_v4":"163.172.138.73","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:57:35.282753Z"},{"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:55:07.024645Z","error_message":null,"id":"0a574723-3b4a-4a67-a239-5dd1cf6a3655","name":"scw-test-k8s-private-network-pool-0a5747233b4a","pool_id":"7d41f060-d78c-497d-8412-77dcd41e5073","provider_id":"scaleway://instance/fr-par-1/b5b8cd51-72c2-461d-b62b-97e97ca383a4","public_ip_v4":"163.172.177.183","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:57:35.265437Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1512"
+      - "1258"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:10 GMT
+      - Tue, 07 Nov 2023 15:57:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3507,7 +3507,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3579ca77-ed96-4009-867e-543edf79cce9
+      - 70c07760-69ae-4453-830c-63949da2f1af
     status: 200 OK
     code: 200
     duration: ""
@@ -3518,19 +3518,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8e5066b6-c900-4851-8e01-76feb9e34acd/nodes?order_by=created_at_asc&pool_id=33ebe8a5-5a0e-434c-b810-8ca79b112bb2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:37:44.552790Z","error_message":null,"id":"1b3de83f-72e3-4d31-8872-7f367b6538f0","name":"scw-test-k8s-private-network-pool-1b3de83f72e3","pool_id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","provider_id":"scaleway://instance/fr-par-1/a6263eb5-6438-45bb-8837-77372945bfbb","public_ip_v4":"51.15.230.101","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:43:08.622910Z"},{"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:37:48.635392Z","error_message":null,"id":"e275788d-a03d-41c2-8da2-64bee196e618","name":"scw-test-k8s-private-network-pool-e275788da03d","pool_id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","provider_id":"scaleway://instance/fr-par-1/0a195f8b-16c4-44be-bf92-20f9dbe96b7a","public_ip_v4":"51.15.143.114","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:43:08.642932Z"}],"total_count":2}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://54bd7937-ba2e-4cce-86e5-67bf9bb82553.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.385540Z","created_at":"2023-11-07T15:49:53.385540Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54bd7937-ba2e-4cce-86e5-67bf9bb82553.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T15:51:02.709881Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1319"
+      - "1467"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:10 GMT
+      - Tue, 07 Nov 2023 15:57:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3540,7 +3540,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c47a1de-20d2-4c60-9133-7fb1e0b62712
+      - f45bfe10-ece7-45fa-837e-ce944400632a
     status: 200 OK
     code: 200
     duration: ""
@@ -3551,23 +3551,155 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/a6263eb5-6438-45bb-8837-77372945bfbb
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6ec88d41-f0fc-4501-9810-dd9de4cbc098
+    method: GET
+  response:
+    body: '{"created_at":"2023-11-07T15:49:51.243805Z","dhcp_enabled":true,"id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","name":"test-k8s-private-network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.243805Z","id":"d26296a1-8f11-4d2b-8781-5c7cef7510f7","subnet":"172.16.68.0/22","updated_at":"2023-11-07T15:49:51.243805Z"},{"created_at":"2023-11-07T15:49:51.243805Z","id":"95bc8018-3c82-4917-a233-3066ab5210af","subnet":"fd5f:519c:6d46:ead6::/64","updated_at":"2023-11-07T15:49:51.243805Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.243805Z","vpc_id":"ca01ec19-5e6a-461a-a75b-7f1f56bcfa42"}'
+    headers:
+      Content-Length:
+      - "708"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:57:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5ca4a484-9995-4564-a7d9-2545f18f3eb7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-07T15:57:35.296164Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "590"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:57:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0662859d-05ab-4020-852b-e213f789440d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://54bd7937-ba2e-4cce-86e5-67bf9bb82553.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.385540Z","created_at":"2023-11-07T15:49:53.385540Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54bd7937-ba2e-4cce-86e5-67bf9bb82553.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T15:51:02.709881Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1467"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:57:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9ec241a9-f400-43d1-8f2d-3abe987efca6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553/nodes?order_by=created_at_asc&pool_id=7d41f060-d78c-497d-8412-77dcd41e5073&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:55:02.943504Z","error_message":null,"id":"1254a3f8-7ee7-4310-95dc-be2e6cea124b","name":"scw-test-k8s-private-network-pool-1254a3f87ee7","pool_id":"7d41f060-d78c-497d-8412-77dcd41e5073","provider_id":"scaleway://instance/fr-par-1/f39671eb-2054-4775-848e-780dec2c4f52","public_ip_v4":"163.172.138.73","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:57:35.282753Z"},{"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:55:07.024645Z","error_message":null,"id":"0a574723-3b4a-4a67-a239-5dd1cf6a3655","name":"scw-test-k8s-private-network-pool-0a5747233b4a","pool_id":"7d41f060-d78c-497d-8412-77dcd41e5073","provider_id":"scaleway://instance/fr-par-1/b5b8cd51-72c2-461d-b62b-97e97ca383a4","public_ip_v4":"163.172.177.183","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:57:35.265437Z"}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "1258"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:57:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c904eeaa-f7e4-472b-885c-95b3da61cb1a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f39671eb-2054-4775-848e-780dec2c4f52
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-10-18T16:37:45.284301+00:00","dynamic_ip_required":true,"enable_ipv6":true,"extra_networks":[],"hostname":"scw-test-k8s-private-network-pool-1b3de83f72e3","id":"a6263eb5-6438-45bb-8837-77372945bfbb","image":{"arch":"x86_64","creation_date":"2023-10-17T13:58:22.900323+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"058ec9bf-0cd8-4b2d-a68e-cb7578338a88","modification_date":"2023-10-17T14:08:43.096919+00:00","name":"k8s_base_node_2023-10-11.1","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"84ef0475-6a5a-4ab4-9acd-8e5855eee050","name":"k8s_base_node_2023-10-11.1","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":{"address":"2001:bc8:63c:2004::1","gateway":"2001:bc8:63c:2004::","netmask":"64"},"location":{"cluster_id":"29","hypervisor_id":"1701","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:5d:29","maintenances":[],"modification_date":"2023-10-18T16:38:00.912730+00:00","name":"scw-test-k8s-private-network-pool-1b3de83f72e3","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","placement_group":null,"private_ip":"10.66.82.9","private_nics":[{"creation_date":"2023-10-18T16:37:46.006952+00:00","id":"b7e614ed-9dff-47b2-9c0b-53d3bcdc4717","mac_address":"02:00:00:14:4d:27","modification_date":"2023-10-18T16:37:46.753827+00:00","private_network_id":"c20560a7-d092-404a-8418-8aa95095399c","server_id":"a6263eb5-6438-45bb-8837-77372945bfbb","state":"available","tags":[],"zone":"fr-par-1"}],"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"public_ip":{"address":"51.15.230.101","dynamic":true,"family":"inet","gateway":null,"id":"457a53e4-b04b-4487-a43a-6aedb768c100","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.230.101","dynamic":true,"family":"inet","gateway":null,"id":"457a53e4-b04b-4487-a43a-6aedb768c100","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"e67f0208-18dd-44d8-9411-360e694a1be5","name":"kubernetes
-      8e5066b6-c900-4851-8e01-76feb9e34acd"},"state":"running","state_detail":"booting
-      kernel","tags":["kapsule=8e5066b6-c900-4851-8e01-76feb9e34acd","pool=33ebe8a5-5a0e-434c-b810-8ca79b112bb2","pool-name=pool","runtime=containerd","managed=true","node=1b3de83f-72e3-4d31-8872-7f367b6538f0"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T16:37:45.284301+00:00","export_uri":null,"id":"9eb429bb-b3fd-430d-8315-70572443b0f3","modification_date":"2023-10-18T16:37:45.284301+00:00","name":"k8s_base_node_2023-10-11.1","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","server":{"id":"a6263eb5-6438-45bb-8837-77372945bfbb","name":"scw-test-k8s-private-network-pool-1b3de83f72e3"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-11-07T15:55:03.583869+00:00","dynamic_ip_required":true,"enable_ipv6":true,"extra_networks":[],"hostname":"scw-test-k8s-private-network-pool-1254a3f87ee7","id":"f39671eb-2054-4775-848e-780dec2c4f52","image":{"arch":"x86_64","creation_date":"2023-10-17T13:58:22.900323+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"058ec9bf-0cd8-4b2d-a68e-cb7578338a88","modification_date":"2023-10-17T14:08:43.096919+00:00","name":"k8s_base_node_2023-10-11.1","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"84ef0475-6a5a-4ab4-9acd-8e5855eee050","name":"k8s_base_node_2023-10-11.1","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":{"address":"2001:bc8:63c:301::1","gateway":"2001:bc8:63c:301::","netmask":"64"},"location":{"cluster_id":"29","hypervisor_id":"202","node_id":"2","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:5e:67","maintenances":[],"modification_date":"2023-11-07T15:55:19.588328+00:00","name":"scw-test-k8s-private-network-pool-1254a3f87ee7","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.66.74.195","private_nics":[{"creation_date":"2023-11-07T15:55:04.358912+00:00","id":"c234dda7-8eed-4fea-a5e3-6b469256fd2a","mac_address":"02:00:00:14:a3:f9","modification_date":"2023-11-07T15:55:05.146548+00:00","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","server_id":"f39671eb-2054-4775-848e-780dec2c4f52","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.138.73","dynamic":true,"family":"inet","gateway":null,"id":"f696e00b-1234-42a6-a328-a9ff5b25ac02","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.138.73","dynamic":true,"family":"inet","gateway":null,"id":"f696e00b-1234-42a6-a328-a9ff5b25ac02","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"e0f0232a-0b28-4673-8992-26f2e07dba55","name":"kubernetes
+      54bd7937-ba2e-4cce-86e5-67bf9bb82553"},"state":"running","state_detail":"booting
+      kernel","tags":["kapsule=54bd7937-ba2e-4cce-86e5-67bf9bb82553","pool=7d41f060-d78c-497d-8412-77dcd41e5073","pool-name=pool","runtime=containerd","managed=true","node=1254a3f8-7ee7-4310-95dc-be2e6cea124b"],"volumes":{"0":{"boot":false,"creation_date":"2023-11-07T15:55:03.583869+00:00","export_uri":null,"id":"9677b7d9-30a4-42ba-b2d0-908c6227f974","modification_date":"2023-11-07T15:55:03.583869+00:00","name":"k8s_base_node_2023-10-11.1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f39671eb-2054-4775-848e-780dec2c4f52","name":"scw-test-k8s-private-network-pool-1254a3f87ee7"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3951"
+      - "3952"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:10 GMT
+      - Tue, 07 Nov 2023 15:57:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3577,7 +3709,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b7bead0-ec70-4891-ba0e-65d812714422
+      - 3ff78021-5de3-44b8-b054-501a47931b59
     status: 200 OK
     code: 200
     duration: ""
@@ -3588,23 +3720,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a195f8b-16c4-44be-bf92-20f9dbe96b7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b5b8cd51-72c2-461d-b62b-97e97ca383a4
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-10-18T16:37:49.013800+00:00","dynamic_ip_required":true,"enable_ipv6":true,"extra_networks":[],"hostname":"scw-test-k8s-private-network-pool-e275788da03d","id":"0a195f8b-16c4-44be-bf92-20f9dbe96b7a","image":{"arch":"x86_64","creation_date":"2023-10-17T13:58:22.900323+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"058ec9bf-0cd8-4b2d-a68e-cb7578338a88","modification_date":"2023-10-17T14:08:43.096919+00:00","name":"k8s_base_node_2023-10-11.1","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"84ef0475-6a5a-4ab4-9acd-8e5855eee050","name":"k8s_base_node_2023-10-11.1","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":{"address":"2001:bc8:4748:2302::1","gateway":"2001:bc8:4748:2302::","netmask":"64"},"location":{"cluster_id":"3","hypervisor_id":"1802","node_id":"3","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:5d:2b","maintenances":[],"modification_date":"2023-10-18T16:38:09.457502+00:00","name":"scw-test-k8s-private-network-pool-e275788da03d","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","placement_group":null,"private_ip":"10.12.156.197","private_nics":[{"creation_date":"2023-10-18T16:37:50.005085+00:00","id":"23871bdb-185d-4617-af12-ea3a6b2d8e50","mac_address":"02:00:00:14:4d:28","modification_date":"2023-10-18T16:37:50.846602+00:00","private_network_id":"c20560a7-d092-404a-8418-8aa95095399c","server_id":"0a195f8b-16c4-44be-bf92-20f9dbe96b7a","state":"available","tags":[],"zone":"fr-par-1"}],"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"public_ip":{"address":"51.15.143.114","dynamic":true,"family":"inet","gateway":null,"id":"37d573b3-feb6-4fcb-b0ad-699a6299a21e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.143.114","dynamic":true,"family":"inet","gateway":null,"id":"37d573b3-feb6-4fcb-b0ad-699a6299a21e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"e67f0208-18dd-44d8-9411-360e694a1be5","name":"kubernetes
-      8e5066b6-c900-4851-8e01-76feb9e34acd"},"state":"running","state_detail":"booting
-      kernel","tags":["kapsule=8e5066b6-c900-4851-8e01-76feb9e34acd","pool=33ebe8a5-5a0e-434c-b810-8ca79b112bb2","pool-name=pool","runtime=containerd","managed=true","node=e275788d-a03d-41c2-8da2-64bee196e618"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T16:37:49.013800+00:00","export_uri":null,"id":"5f52a11d-75e8-420f-88c7-78d36fcbbd39","modification_date":"2023-10-18T16:37:49.013800+00:00","name":"k8s_base_node_2023-10-11.1","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","server":{"id":"0a195f8b-16c4-44be-bf92-20f9dbe96b7a","name":"scw-test-k8s-private-network-pool-e275788da03d"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-11-07T15:55:07.434620+00:00","dynamic_ip_required":true,"enable_ipv6":true,"extra_networks":[],"hostname":"scw-test-k8s-private-network-pool-0a5747233b4a","id":"b5b8cd51-72c2-461d-b62b-97e97ca383a4","image":{"arch":"x86_64","creation_date":"2023-10-17T13:58:22.900323+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"058ec9bf-0cd8-4b2d-a68e-cb7578338a88","modification_date":"2023-10-17T14:08:43.096919+00:00","name":"k8s_base_node_2023-10-11.1","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"84ef0475-6a5a-4ab4-9acd-8e5855eee050","name":"k8s_base_node_2023-10-11.1","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":{"address":"2001:bc8:610:8703::1","gateway":"2001:bc8:610:8703::","netmask":"64"},"location":{"cluster_id":"52","hypervisor_id":"501","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:5e:69","maintenances":[],"modification_date":"2023-11-07T15:55:22.791944+00:00","name":"scw-test-k8s-private-network-pool-0a5747233b4a","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.194.88.135","private_nics":[{"creation_date":"2023-11-07T15:55:07.977875+00:00","id":"24c79171-2295-4182-a104-fa2e44b443df","mac_address":"02:00:00:14:a3:fa","modification_date":"2023-11-07T15:55:08.801885+00:00","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","server_id":"b5b8cd51-72c2-461d-b62b-97e97ca383a4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.177.183","dynamic":true,"family":"inet","gateway":null,"id":"7fd94e15-665d-4d53-b7d1-a50f35453ced","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.177.183","dynamic":true,"family":"inet","gateway":null,"id":"7fd94e15-665d-4d53-b7d1-a50f35453ced","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"e0f0232a-0b28-4673-8992-26f2e07dba55","name":"kubernetes
+      54bd7937-ba2e-4cce-86e5-67bf9bb82553"},"state":"running","state_detail":"booting
+      kernel","tags":["kapsule=54bd7937-ba2e-4cce-86e5-67bf9bb82553","pool=7d41f060-d78c-497d-8412-77dcd41e5073","pool-name=pool","runtime=containerd","managed=true","node=0a574723-3b4a-4a67-a239-5dd1cf6a3655"],"volumes":{"0":{"boot":false,"creation_date":"2023-11-07T15:55:07.434620+00:00","export_uri":null,"id":"2740b4d4-8560-43ac-a524-4db1b4987691","modification_date":"2023-11-07T15:55:07.434620+00:00","name":"k8s_base_node_2023-10-11.1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b5b8cd51-72c2-461d-b62b-97e97ca383a4","name":"scw-test-k8s-private-network-pool-0a5747233b4a"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3955"
+      - "3957"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:10 GMT
+      - Tue, 07 Nov 2023 15:57:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3614,7 +3746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be55aefd-e857-46b9-8f00-c72e1b891100
+      - 61535e8b-dc92-4e54-8598-b704f0a34713
     status: 200 OK
     code: 200
     duration: ""
@@ -3625,19 +3757,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/89dac298-df98-45a1-8871-4b918eb86a0c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/ca01ec19-5e6a-461a-a75b-7f1f56bcfa42
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:35:44.902018Z","id":"89dac298-df98-45a1-8871-4b918eb86a0c","is_default":false,"name":"test-k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_count":1,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","tags":[],"updated_at":"2023-10-18T16:35:44.902018Z"}'
+    body: '{"created_at":"2023-11-07T15:49:50.909203Z","id":"ca01ec19-5e6a-461a-a75b-7f1f56bcfa42","is_default":false,"name":"test-k8s-private-network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2023-11-07T15:49:50.909203Z"}'
     headers:
       Content-Length:
-      - "356"
+      - "347"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:11 GMT
+      - Tue, 07 Nov 2023 15:57:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3647,7 +3779,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f10605a3-deb1-483f-9064-3e73a5fb77a1
+      - cd24f155-eeee-44db-8613-51f8b09fee7d
     status: 200 OK
     code: 200
     duration: ""
@@ -3658,19 +3790,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c20560a7-d092-404a-8418-8aa95095399c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6ec88d41-f0fc-4501-9810-dd9de4cbc098
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:35:45.258962Z","dhcp_enabled":true,"id":"c20560a7-d092-404a-8418-8aa95095399c","name":"test-k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:35:45.258962Z","id":"d146def6-a138-4e37-9ef7-f074dadbd5e5","subnet":"172.16.20.0/22","updated_at":"2023-10-18T16:35:45.258962Z"},{"created_at":"2023-10-18T16:35:45.258962Z","id":"eafe12c9-2714-4f1c-a76f-2ad3b9be8208","subnet":"fd63:256c:45f7:4f62::/64","updated_at":"2023-10-18T16:35:45.258962Z"}],"tags":[],"updated_at":"2023-10-18T16:35:45.258962Z","vpc_id":"89dac298-df98-45a1-8871-4b918eb86a0c"}'
+    body: '{"created_at":"2023-11-07T15:49:51.243805Z","dhcp_enabled":true,"id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","name":"test-k8s-private-network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.243805Z","id":"d26296a1-8f11-4d2b-8781-5c7cef7510f7","subnet":"172.16.68.0/22","updated_at":"2023-11-07T15:49:51.243805Z"},{"created_at":"2023-11-07T15:49:51.243805Z","id":"95bc8018-3c82-4917-a233-3066ab5210af","subnet":"fd5f:519c:6d46:ead6::/64","updated_at":"2023-11-07T15:49:51.243805Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.243805Z","vpc_id":"ca01ec19-5e6a-461a-a75b-7f1f56bcfa42"}'
     headers:
       Content-Length:
-      - "725"
+      - "708"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:11 GMT
+      - Tue, 07 Nov 2023 15:57:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3680,7 +3812,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c591f3d-c85f-425a-88ba-117e96cc599c
+      - c17cd4cc-d23f-455c-b861-c8676b10658b
     status: 200 OK
     code: 200
     duration: ""
@@ -3691,19 +3823,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8e5066b6-c900-4851-8e01-76feb9e34acd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8e5066b6-c900-4851-8e01-76feb9e34acd.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:46.197356Z","created_at":"2023-10-18T16:35:46.197356Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8e5066b6-c900-4851-8e01-76feb9e34acd.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8e5066b6-c900-4851-8e01-76feb9e34acd","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c20560a7-d092-404a-8418-8aa95095399c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T16:37:27.996002Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://54bd7937-ba2e-4cce-86e5-67bf9bb82553.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.385540Z","created_at":"2023-11-07T15:49:53.385540Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54bd7937-ba2e-4cce-86e5-67bf9bb82553.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T15:51:02.709881Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1512"
+      - "1467"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:11 GMT
+      - Tue, 07 Nov 2023 15:57:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3713,7 +3845,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b08e52c5-6021-4599-b61a-6d751df778b6
+      - ed35fc78-9163-41be-be8b-4ab46c132f3e
     status: 200 OK
     code: 200
     duration: ""
@@ -3724,19 +3856,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8e5066b6-c900-4851-8e01-76feb9e34acd/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXByaXZhdGUtbmV0d29yayIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVeVRYcFZNRTR4YjFoRVZFMTZUVlJCZUU1NlJUSk5lbFV3VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTbTR5Q2toelNsTTFXbWxpTjI1cE9XWjRla0UyYUU5TVMxbHZiR2RSTHpsM2JuRjZjamhZVDJjcmJuUXlabU5CYVRscU9EQnZkamhUZUVwRE9WZG1Rek5YWjNjS1dXSnRWVVVyU0RNNFNUSTNPVEpGWjBObmVqRTBZbmwzWlRaUGNFeFBSemR3U0ZZeGExbENUSEZJU0cwNFRYWmxZa3d6WVZobk9XaEZhbkZ1WjBkNE9RcHdSV0pQVFdSRFFUVmFUMjQyVVVoVFozWjBNbFpETHpCMVRGVTRVV2x4ZVRocU5TdGtWV0o0WWxaNFdqVnBRblphV1VJeFZ5dGtSMDh6TnpJNWFYSXdDbXR2TWxOVFlVaDFTVFZXV2tsWGVVd3pOVlZGVWtGVmFUaGFTMjgzT1dWdWFUVlVhRzF0VTB4eGRXRkhXalJTT1RZM1psRldVVkpoZUhFMVJXVjVZVmdLYkVaWk1sbGlLM0ptYkVWUU5IWkVTR3hET0hRMGJsRmpTRFkwZW5ONVdsUk5WaXR3TkVWMk1uYzJNbTFXVDBZdmRrOVdObVF4UTNrNGVuUmtWM2xQWkFwV1dHWTJMMlpwUm5GYVRrYzNMeXRQV25oelEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ1pGaDFXRWd4WXk5d1pXMVFWRTE2UVhadmIxQldVR1pIYlZKTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1lqZ3pOWEp1Tmpkd2NqTjVOazR4YVVWdmVuSlZSRWRTY0M5bGFHVXZPVlZXVG5OdGJHeFZjWGh1T1cxSk5qQkNid3A0VkRSYVNEZG1OVUppWkM5bWJFOTBOR0ozU0hjemVqbGlkRVpzVjFSUFFXVlFlVmhGT1VkNlV6Snlka3MwUjBSb1pFUTRNMDFUU21SVk5HRndVVzQ1Q21SQ1ZtbGhjRVp2TVRkRFRXRlJSWGhHUldoeGRrY3JhMXB6VkRKb1pYZHZUM1psWldoNlJUWkdWV1F2WWtreWNYVllTRUUzYUZSTk1EZEdZV3AzZUd3S1QzVTViWGxLYkdKbWJqRkhSSG8xY0RScmRsQm9jRUV4V0dJeWVrbGFaMXBhWVVGNFVFb3lXVVV2WlVsUlRGUlZOaTgwWjBVdmJWaGpSazVHYTJoQmRncHRUelJFU1RKVk9XSjJSSEJNTDFVekwyeEJUM05PUjA1cWQxWlZUVnBpVG14d1ZXdEtkR3Q1WkUxbGVUQnVZbmwxVVRsS01VWjBWVmt3VTJOTFZXWlZDbWs0UWxWblV6RnJlVEJ0YW5CWVZYazVZbGhFVTJObFdYcHNUVU01V0RSamVHTTJXUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOGU1MDY2YjYtYzkwMC00ODUxLThlMDEtNzZmZWI5ZTM0YWNkLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXByaXZhdGUtbmV0d29yawogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrIgogICAgdXNlcjogdGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB3REJPM3pYZE1oV3YxakNySm85NEt2TlZZYncxZTBLS3M1RGpGYUs0TE8zSjlKeEczNFRnNlVwWA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXByaXZhdGUtbmV0d29yayIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeFRrUnJNVTVHYjFoRVZFMTZUVlJGZDA1cVJURk9SR3N4VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUV2xUQ2pKTVdUTjRRVTFDTW1KQ1lVWjZOV3ByUW5WVk56bFdhMU12Y0dsdVREWk5SRkoxVDJrMlZ6TmlXblpRVkV4V1JUSlpka2cyV1N0bldYVktUV3BxYzBVS2VqUlJSM2hqTWt4NVlXRkdTR3BJV1RSM2FteGtlRUUwYzJaT2REVnlURlZGV2t3d01XcFBkR012U1d4dGJXTXJabkZOWjJsV2ExbDBSMVpxVEhKdWJncFhWR0ZsZG1wemMzaE9WRWxMZW5aaVpGRm9ObEU1WTFOR1JXVnhRakEyU1RnMU9HOUNXVTFFVmpWdFRUWlRVVFEwT0RFemIwTjBVWFpYTTJwb09GcHVDbmhuVm5oaVEzcEJZbGx3TVdrclRVWmpObEpDVG1wb2JERTVNRFJSVTBSb2JGbEVXRzFLZERGdWVqWmFNV1pVZEN0UVdIbEtRMUkzUlRGM1QwczNURUlLTlVOS2JIQjNPR3BOTTFacGMzRlRaM0ZWTUVOcmFYZGlhekI0TTJOeEwwdE9SVXNyY25aRU9XUXdaMjFQUzFFM1JWVm1XVXRFUkZSUU9EZHhhRFJXWkFwVFZWUjJWamRzZERaa1FuY3hORTUwV1hrd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTWNUbHBWM2d4YjI0d1JWRlJUR3BFVnpoaFNuQkxVVzFvYWtwTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlprMDBjRzVYTjBOUVFqUkVkeTlRU1Zwc1FscDFNR2RoT1VwU1JtazRUbFZLWTNwRWNtSTNSVkpWWkhGTVkxQmhkUW8wY1doVFIwOW9SRzVRVms1eGVUQldZV3hhVFV0VmFXcGhTMDk1WmpOMFZTOURiMHRwTUZsamNWZHFaWEpaWkZoQ2NGcFhMMmhCVVVNNFNWUlZUWE5rQ21kMlUwVnZNMjV2YW5Gd1pWaEtRMXBwUlRsaE5HeHdaWFpXYVdvNVJVdGhkR2x1UzI5Qlp6QlJSR1JqY1cxWVZreDJWekZ1Tms1dE5UQTJVeXRNV0hNS2VYUlBiMlozYjBsNFNFcG5TR0pIT0dkV1Z5OU1XalZRTW1KS01GSklTMlZSUVU5RlpVNTZLeTlsZFUwNVdWUXpZemR0Y2pKa0swUm5XbEV4Um1aVU1Rb3lRek5yZG5OT2F6WkRkR3hDUm1KM1owdGlTeTltVEdReE5saHBNVlZsZG1aM1JtNXVTamx5VGt4Q1FuQk9jVWRJVEU1SmRrbFZUVVJoT1VKTGJqRjVDblo1VnpKVFZYcG5jU3RFUVVJekt5OVBNREZYZFdkM1FsRlRjRGhXT1U0MEx6WndSUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTRiZDc5MzctYmEyZS00Y2NlLTg2ZTUtNjdiZjliYjgyNTUzLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXByaXZhdGUtbmV0d29yawogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrIgogICAgdXNlcjogdGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHJpdmF0ZS1uZXR3b3JrLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBSSFM1MkRLWTBkQVE5Wkd0V1lPcUd3SkZKRTNFNjkyRU5GV2E4Vkh1UDJBUUNsU0lrWTFtNE44Mg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2686"
+      - "2684"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:11 GMT
+      - Tue, 07 Nov 2023 15:57:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3746,7 +3878,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 457b56bc-0911-4757-8d0b-b881f514a9cc
+      - d114deeb-b31e-4c5a-815e-7b8d1b4168d1
     status: 200 OK
     code: 200
     duration: ""
@@ -3757,19 +3889,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-10-18T16:43:08.656484Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-07T15:57:35.296164Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "613"
+      - "590"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:11 GMT
+      - Tue, 07 Nov 2023 15:57:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3779,7 +3911,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9fa998b0-cb69-411b-a079-82e8b021e0f1
+      - 2d00a1c4-1437-4c88-bf8f-dd845eb1241a
     status: 200 OK
     code: 200
     duration: ""
@@ -3790,19 +3922,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8e5066b6-c900-4851-8e01-76feb9e34acd/nodes?order_by=created_at_asc&page=1&pool_id=33ebe8a5-5a0e-434c-b810-8ca79b112bb2&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553/nodes?order_by=created_at_asc&page=1&pool_id=7d41f060-d78c-497d-8412-77dcd41e5073&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:37:44.552790Z","error_message":null,"id":"1b3de83f-72e3-4d31-8872-7f367b6538f0","name":"scw-test-k8s-private-network-pool-1b3de83f72e3","pool_id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","provider_id":"scaleway://instance/fr-par-1/a6263eb5-6438-45bb-8837-77372945bfbb","public_ip_v4":"51.15.230.101","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:43:08.622910Z"},{"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:37:48.635392Z","error_message":null,"id":"e275788d-a03d-41c2-8da2-64bee196e618","name":"scw-test-k8s-private-network-pool-e275788da03d","pool_id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","provider_id":"scaleway://instance/fr-par-1/0a195f8b-16c4-44be-bf92-20f9dbe96b7a","public_ip_v4":"51.15.143.114","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:43:08.642932Z"}],"total_count":2}'
+    body: '{"nodes":[{"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:55:02.943504Z","error_message":null,"id":"1254a3f8-7ee7-4310-95dc-be2e6cea124b","name":"scw-test-k8s-private-network-pool-1254a3f87ee7","pool_id":"7d41f060-d78c-497d-8412-77dcd41e5073","provider_id":"scaleway://instance/fr-par-1/f39671eb-2054-4775-848e-780dec2c4f52","public_ip_v4":"163.172.138.73","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:57:35.282753Z"},{"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:55:07.024645Z","error_message":null,"id":"0a574723-3b4a-4a67-a239-5dd1cf6a3655","name":"scw-test-k8s-private-network-pool-0a5747233b4a","pool_id":"7d41f060-d78c-497d-8412-77dcd41e5073","provider_id":"scaleway://instance/fr-par-1/b5b8cd51-72c2-461d-b62b-97e97ca383a4","public_ip_v4":"163.172.177.183","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:57:35.265437Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1319"
+      - "1258"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:11 GMT
+      - Tue, 07 Nov 2023 15:57:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3812,7 +3944,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3cef031d-18e1-49ef-91d2-b9c036c0929c
+      - 58bc94ec-8969-46b3-977c-91fefddada2a
     status: 200 OK
     code: 200
     duration: ""
@@ -3823,19 +3955,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/33ebe8a5-5a0e-434c-b810-8ca79b112bb2
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.613769Z","id":"33ebe8a5-5a0e-434c-b810-8ca79b112bb2","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"deleting","tags":[],"updated_at":"2023-10-18T16:43:12.830499629Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:57:38.239436596Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "619"
+      - "596"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:12 GMT
+      - Tue, 07 Nov 2023 15:57:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3845,7 +3977,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bfc1c7ab-cb14-4c51-b6b5-c104b0682257
+      - a0071ae2-4f02-4b1f-9f49-e54086d8e99b
     status: 200 OK
     code: 200
     duration: ""
@@ -3856,19 +3988,184 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8e5066b6-c900-4851-8e01-76feb9e34acd?with_additional_resources=true
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:57:38.239437Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "593"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:57:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 00a6bfd0-f7db-4463-bc14-e278993747e1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:57:38.239437Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "593"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:57:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 02eedc09-fe6c-41d9-addc-492765079b64
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:57:38.239437Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "593"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:57:48 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e895c1cf-5412-4666-b6bc-6f9033fcfe6d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.825752Z","id":"7d41f060-d78c-497d-8412-77dcd41e5073","kubelet_args":{},"max_size":2,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:57:38.239437Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "593"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:57:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1779474e-52cc-45b0-89dc-65c479d3a2b4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7d41f060-d78c-497d-8412-77dcd41e5073
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"7d41f060-d78c-497d-8412-77dcd41e5073","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "125"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:57:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dc1142a5-8ae0-43e1-b656-e9153307e8f8
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8e5066b6-c900-4851-8e01-76feb9e34acd.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:46.197356Z","created_at":"2023-10-18T16:35:46.197356Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8e5066b6-c900-4851-8e01-76feb9e34acd.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8e5066b6-c900-4851-8e01-76feb9e34acd","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c20560a7-d092-404a-8418-8aa95095399c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T16:43:12.903497784Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://54bd7937-ba2e-4cce-86e5-67bf9bb82553.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.385540Z","created_at":"2023-11-07T15:49:53.385540Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54bd7937-ba2e-4cce-86e5-67bf9bb82553.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T15:57:58.542055337Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1518"
+      - "1473"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:12 GMT
+      - Tue, 07 Nov 2023 15:57:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3878,7 +4175,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f1e8894-cd4f-4039-a11b-5fe2c8f68a7d
+      - 7c8841df-7e98-41e1-b1c4-bc0efb3cd824
     status: 200 OK
     code: 200
     duration: ""
@@ -3889,19 +4186,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8e5066b6-c900-4851-8e01-76feb9e34acd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8e5066b6-c900-4851-8e01-76feb9e34acd.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:46.197356Z","created_at":"2023-10-18T16:35:46.197356Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8e5066b6-c900-4851-8e01-76feb9e34acd.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8e5066b6-c900-4851-8e01-76feb9e34acd","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c20560a7-d092-404a-8418-8aa95095399c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T16:43:12.903498Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://54bd7937-ba2e-4cce-86e5-67bf9bb82553.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.385540Z","created_at":"2023-11-07T15:49:53.385540Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54bd7937-ba2e-4cce-86e5-67bf9bb82553.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T15:57:58.542055Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:13 GMT
+      - Tue, 07 Nov 2023 15:57:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3911,7 +4208,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4bad264f-9c68-4068-98ab-a3c44845c8cd
+      - 3a8386be-22b8-41a8-b151-ec4466edc33a
     status: 200 OK
     code: 200
     duration: ""
@@ -3922,19 +4219,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8e5066b6-c900-4851-8e01-76feb9e34acd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8e5066b6-c900-4851-8e01-76feb9e34acd.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:46.197356Z","created_at":"2023-10-18T16:35:46.197356Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8e5066b6-c900-4851-8e01-76feb9e34acd.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8e5066b6-c900-4851-8e01-76feb9e34acd","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c20560a7-d092-404a-8418-8aa95095399c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T16:43:12.903498Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://54bd7937-ba2e-4cce-86e5-67bf9bb82553.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.385540Z","created_at":"2023-11-07T15:49:53.385540Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.54bd7937-ba2e-4cce-86e5-67bf9bb82553.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T15:57:58.542055Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:18 GMT
+      - Tue, 07 Nov 2023 15:58:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3944,7 +4241,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1009f2d0-0ce3-4944-9db3-f746307ca74b
+      - cb814ed3-a405-4642-8141-1a2e178e3c09
     status: 200 OK
     code: 200
     duration: ""
@@ -3955,142 +4252,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8e5066b6-c900-4851-8e01-76feb9e34acd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8e5066b6-c900-4851-8e01-76feb9e34acd.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:46.197356Z","created_at":"2023-10-18T16:35:46.197356Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8e5066b6-c900-4851-8e01-76feb9e34acd.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8e5066b6-c900-4851-8e01-76feb9e34acd","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c20560a7-d092-404a-8418-8aa95095399c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T16:43:12.903498Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:23 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ddaa6e9c-4784-40d5-9029-402071373f9a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8e5066b6-c900-4851-8e01-76feb9e34acd
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8e5066b6-c900-4851-8e01-76feb9e34acd.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:46.197356Z","created_at":"2023-10-18T16:35:46.197356Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8e5066b6-c900-4851-8e01-76feb9e34acd.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8e5066b6-c900-4851-8e01-76feb9e34acd","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c20560a7-d092-404a-8418-8aa95095399c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T16:43:12.903498Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 58a07b77-d466-4e4e-9d07-6cbba024324e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8e5066b6-c900-4851-8e01-76feb9e34acd
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8e5066b6-c900-4851-8e01-76feb9e34acd.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:46.197356Z","created_at":"2023-10-18T16:35:46.197356Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8e5066b6-c900-4851-8e01-76feb9e34acd.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8e5066b6-c900-4851-8e01-76feb9e34acd","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c20560a7-d092-404a-8418-8aa95095399c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T16:43:12.903498Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - aa58a1bc-496b-4c5d-8ff4-d7a9e86aedb4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8e5066b6-c900-4851-8e01-76feb9e34acd
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8e5066b6-c900-4851-8e01-76feb9e34acd.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:46.197356Z","created_at":"2023-10-18T16:35:46.197356Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8e5066b6-c900-4851-8e01-76feb9e34acd.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8e5066b6-c900-4851-8e01-76feb9e34acd","ingress":"none","name":"test-k8s-private-network","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c20560a7-d092-404a-8418-8aa95095399c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T16:43:12.903498Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1515"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f3f423c5-1f76-4c69-b0fd-c98063c975c7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8e5066b6-c900-4851-8e01-76feb9e34acd
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -4099,7 +4264,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:43 GMT
+      - Tue, 07 Nov 2023 15:58:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4109,7 +4274,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 778fb3d8-7ae5-4745-9a41-2111d5b0c1bf
+      - eee372b2-5cca-4d87-b5ec-d9d10d370930
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4120,10 +4285,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c20560a7-d092-404a-8418-8aa95095399c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6ec88d41-f0fc-4501-9810-dd9de4cbc098
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"c20560a7-d092-404a-8418-8aa95095399c","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"6ec88d41-f0fc-4501-9810-dd9de4cbc098","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -4132,7 +4297,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:43 GMT
+      - Tue, 07 Nov 2023 15:58:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4142,7 +4307,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 842f6bbb-71c6-4450-9292-4efe7d316b89
+      - 5b31d5c5-33d1-4ef8-8e60-d36340419171
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4153,7 +4318,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/89dac298-df98-45a1-8871-4b918eb86a0c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/ca01ec19-5e6a-461a-a75b-7f1f56bcfa42
     method: DELETE
   response:
     body: ""
@@ -4163,7 +4328,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:43 GMT
+      - Tue, 07 Nov 2023 15:58:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4173,7 +4338,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c660d94b-5430-4cfc-9909-a15b39fbaa7e
+      - fba17d2f-fb7f-4b22-850a-0c87b4a3b339
     status: 204 No Content
     code: 204
     duration: ""
@@ -4184,10 +4349,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8e5066b6-c900-4851-8e01-76feb9e34acd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/54bd7937-ba2e-4cce-86e5-67bf9bb82553
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"8e5066b6-c900-4851-8e01-76feb9e34acd","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"54bd7937-ba2e-4cce-86e5-67bf9bb82553","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -4196,7 +4361,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:43 GMT
+      - Tue, 07 Nov 2023 15:58:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4206,7 +4371,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 382c22bd-da1b-4f9c-bd9d-f31c5f921550
+      - 4de9daa4-bd35-4ab1-aa33-dd27655a7f27
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-public-ip-disabled.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-public-ip-disabled.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:05:38 GMT
+      - Tue, 07 Nov 2023 16:05:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,12 +34,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ecd5d24-6060-4627-bd39-496dfaddc5e2
+      - 419c7efb-c087-4d54-9450-3d3fc6ba1505
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-k8s-public-ip","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"test-k8s-public-ip","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-18T17:05:38.963133Z","dhcp_enabled":true,"id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T17:05:38.963133Z","id":"b6f618ae-5f6f-4745-acbc-66e1cba782d7","subnet":"172.16.16.0/22","updated_at":"2023-10-18T17:05:38.963133Z"},{"created_at":"2023-10-18T17:05:38.963133Z","id":"385347c4-de12-4c0f-ab0e-d6fc33b70b07","subnet":"fd63:256c:45f7:2b74::/64","updated_at":"2023-10-18T17:05:38.963133Z"}],"tags":[],"updated_at":"2023-10-18T17:05:38.963133Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:05:40.803436Z","dhcp_enabled":true,"id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:05:40.803436Z","id":"593394e2-e265-4d2d-8acd-a46de571baa7","subnet":"172.16.20.0/22","updated_at":"2023-11-07T16:05:40.803436Z"},{"created_at":"2023-11-07T16:05:40.803436Z","id":"f1c14d0f-4e1b-4c61-ac26-67402c6a15ed","subnet":"fd5f:519c:6d46:63f8::/64","updated_at":"2023-11-07T16:05:40.803436Z"}],"tags":[],"updated_at":"2023-11-07T16:05:40.803436Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "719"
+      - "702"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:05:39 GMT
+      - Tue, 07 Nov 2023 16:05:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7cedf7c1-2395-444d-b0c8-2a4e21eeab57
+      - ce62c3de-9fb2-4de3-859b-89a6a5152101
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b27b50b7-86ff-406e-b08b-de82de78fe7a
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3161b3a1-c691-4566-aeb8-03eb610ff2ee
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T17:05:38.963133Z","dhcp_enabled":true,"id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T17:05:38.963133Z","id":"b6f618ae-5f6f-4745-acbc-66e1cba782d7","subnet":"172.16.16.0/22","updated_at":"2023-10-18T17:05:38.963133Z"},{"created_at":"2023-10-18T17:05:38.963133Z","id":"385347c4-de12-4c0f-ab0e-d6fc33b70b07","subnet":"fd63:256c:45f7:2b74::/64","updated_at":"2023-10-18T17:05:38.963133Z"}],"tags":[],"updated_at":"2023-10-18T17:05:38.963133Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:05:40.803436Z","dhcp_enabled":true,"id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:05:40.803436Z","id":"593394e2-e265-4d2d-8acd-a46de571baa7","subnet":"172.16.20.0/22","updated_at":"2023-11-07T16:05:40.803436Z"},{"created_at":"2023-11-07T16:05:40.803436Z","id":"f1c14d0f-4e1b-4c61-ac26-67402c6a15ed","subnet":"fd5f:519c:6d46:63f8::/64","updated_at":"2023-11-07T16:05:40.803436Z"}],"tags":[],"updated_at":"2023-11-07T16:05:40.803436Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "719"
+      - "702"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:05:40 GMT
+      - Tue, 07 Nov 2023 16:05:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aeb1b729-415a-472b-82fe-f6ae96fd802c
+      - e5a6fb9c-3dc0-458f-af92-b9256b9e6b1b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-k8s-public-ip","description":"","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a"}'
+    body: '{"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","type":"","name":"test-k8s-public-ip","description":"","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee"}'
     form: {}
     headers:
       Content-Type:
@@ -118,16 +118,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f82f936-189f-46c3-b063-e7b2af051c79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T17:05:41.115898375Z","created_at":"2023-10-18T17:05:41.115898375Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f82f936-189f-46c3-b063-e7b2af051c79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f82f936-189f-46c3-b063-e7b2af051c79","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-18T17:05:41.140239460Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253477Z","created_at":"2023-11-07T16:05:42.404253477Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:05:42.416427990Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1512"
+      - "1467"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:05:41 GMT
+      - Tue, 07 Nov 2023 16:05:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e102854-6489-4137-8bd8-441ece73279d
+      - e8e600fd-4e08-4d6d-b26e-53c7db3ccd75
     status: 200 OK
     code: 200
     duration: ""
@@ -148,19 +148,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f82f936-189f-46c3-b063-e7b2af051c79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T17:05:41.115898Z","created_at":"2023-10-18T17:05:41.115898Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f82f936-189f-46c3-b063-e7b2af051c79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f82f936-189f-46c3-b063-e7b2af051c79","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-18T17:05:41.140239Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:05:42.416428Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1503"
+      - "1458"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:05:41 GMT
+      - Tue, 07 Nov 2023 16:05:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6628d45e-d04f-4b5a-9fad-b896f8072c99
+      - 8d289b0a-05a0-4330-b399-010019e87d82
     status: 200 OK
     code: 200
     duration: ""
@@ -181,19 +181,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f82f936-189f-46c3-b063-e7b2af051c79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T17:05:41.115898Z","created_at":"2023-10-18T17:05:41.115898Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f82f936-189f-46c3-b063-e7b2af051c79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f82f936-189f-46c3-b063-e7b2af051c79","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-18T17:05:42.599796Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:05:44.188247Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1508"
+      - "1463"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:05:46 GMT
+      - Tue, 07 Nov 2023 16:05:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb75c4b6-1f4c-48d0-94be-f7d6f3945f35
+      - 1c394447-1584-45ea-bb9b-dbdaf705de30
     status: 200 OK
     code: 200
     duration: ""
@@ -214,19 +214,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f82f936-189f-46c3-b063-e7b2af051c79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T17:05:41.115898Z","created_at":"2023-10-18T17:05:41.115898Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f82f936-189f-46c3-b063-e7b2af051c79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f82f936-189f-46c3-b063-e7b2af051c79","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-18T17:05:42.599796Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:05:44.188247Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1508"
+      - "1463"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:05:46 GMT
+      - Tue, 07 Nov 2023 16:05:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb431f16-fb90-443c-a6c9-05b6e2b2ba59
+      - 5eac8c67-8da4-4b54-9c1b-16bb1171613e
     status: 200 OK
     code: 200
     duration: ""
@@ -247,19 +247,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVelRVUlZNRTFzYjFoRVZFMTZUVlJCZUU1NlJUTk5SRlV3VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUMjl4Q2xrNFNIaDRhR3M1UkVreE56TjNZMGd4ZVRnemMzcFhiWFpFZDJ0d2FrOVhVRXhxTDFwa05scEZjSE5FWlRoalpVMVNOVUZYUWxwNVExWjFaRUpXVUhrS1VXWlFUVXRQUTNkRGQwRjFaekJpVldFelIwZE1UREZoVldkWFUwd3dlbkZRY0dsTGRtMUxTRXhtTkV4cVVHcE1VRGxaZUdKTFYyMWFPRGRXVjBVelRncEJRM3B0VTNGQk9VYzJNa1U1UjFGNVJYWkhRbHBJWW1sWksza3lkV0pLVVhWQmJHbFpSMG94ZUZNMVVWbGxhRTFSU25GSFJIQXhSMDg1ZDJSeU5VZHlDbmc1TDJKdmVqQmpPR3Q2TmxoT1NucFZSblJOZUU0NFpEQXZaVlZwUjBNMmFTdHBSMU5GVFU0eWEwUkhjVW8yTW1NMU4yaDJXbk40UTJZek1HUTFVbXNLWjB0NFQwRXpaVWhLVFVwNFQyMXpabEJLUjNoUVFubDJVR1FyU2tkaVJuUlZkME5SVkhkbVluTnFTSGRuSzFOYVJXczRSVkl2U0RsdlJVbHRWa3hyZUFwbFFtazNTMUUwSzIxRmVVWTVNelU0WVZjd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUGJUWTRTbUZsWm1GclZWUm9SMDR2UkhFMVIwNUtWVXBNV1VoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmNFeDBaVnBFWm1veFMyeDVkV3hIV1U5SmJrbDNlRlpDZVhFM1RYQnRZa3gyUVRkeFNFcFNTaTg1YUV4emRWSkpWd3ByUVRaUVVVZHBhemRVYzJGdFQwUlVOU3Q0ZDBRck1rY3daRzB5Vm5KSlkyRkdSVzAyYjJJNVpHeDNiRkJ2WjFwRU1rZFBTVFo1UVVWcVdWZFdiWFpqQ20xeGEweEpaRGR6UkRWb01EbHVURmhoVGt4aFZUbHRZblYyT1d3MGFXbExPVmw0VFcxQk1WQlJUbUptUjBOTGJYbHVPREpoYVVsTU9XMTBiRkFyYUVnS1VIcFZNbVp5TmxkemNTOU9ibEo1VkZOaWIyZ3haVkJ5TmpOV2JGazVkazk2YkROTWVVUnlaMnR1UldnNFFVaHpVVGxvYlRaVUx6aFBXR2xTUzBjNGNRbzRiV2xMVHk5eFprMW5NWFZzZVRJMmNuZFBiV1ZVVmk5TVdITktNbmRCUldJeU5rTndXR3hMZEdWWVYyc3phRGxDVUVSYVlYcG1TMGh2WTNWNWFWbHVDbFZJU1ROdVIzTTNUQzlvWVhaeVF6QkhUVkYwZVdzNFIydFBkbU5vVDJOQk4zQjZVd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNGY4MmY5MzYtMTg5Zi00NmMzLWIwNjMtZTdiMmFmMDUxYzc5LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHVibGljLWlwIgogICAgdXNlcjogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBDT2FQVE5idURiSFpYY3pBbDhKWTN6R29UeTZFeXlWWjNPMkE3YXBpWE1TVm9MclhFaThkdmR5SA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRVUlZNRTB4YjFoRVZFMTZUVlJGZDA1cVJUSk5SRlV3VFRGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURkJUQ2tReEwxcG5TMVF2TW5oT2MyaDVlVVU1YlVWNlQwTktTRGgwUWs4MksyOWxiSEZJU2pSMU1YcDNjRGRLSzFjeWNYQnBNMEprVUhwMFJYSlJkMlpTYXpZS1NWbHBhV00yT0dvNFkzQTFlR2x2T1dGU1FURnRhbmxFWlZGamNXMUJUVzlJT1hwVWVISlJXWE5hVVVablEyUlhZMUpGT0VselYycEtPR3BYYlN0SFNncFVSUzh2VFVaa2N5dDNiblZoU2pFMllrZHdValpxTUZobVJXUkZPVlZoZDFvMk5WVjZjRFF4YUZReVREY3pRVTQ0TkdJck5XUmlVRXB6Wmk5Wk0yaElDa28wYjNWaU1WbFFXa0pXT0ZGTFpsSjNTMGhzU0hVeVlqQlZiak14WjNWbVVsSk9TM0l2WVd0TFNsYzFZVUpCY2pJeU9XZG1VbVJWVkdscFJrOXZTSFFLUzA5V1NGSXJNRmM1YVhkU2JYRmtkMFp6TTNkQ1JrTTRPV3BvWkRSSlFtZFJhME0yYW5WU1JHVTBWRk16VEhjMU1IRkVSM2s0Ym04MVJqaFBVamhXVFFwRlVGWnhRWHB0T0RWUVNtMW1jVlZFWTBKVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaT1kwZEVNbTl6TlZaaGVHNWFVMEptUmtSS09XUjRSbG8zTDNsTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2JVRkpiVWhVV1M5TVdUSmlXREFyVTJSSU0zQXZXVGRqVmtKbk5XWTVkRU0zVERsUlFqSnFlV1o1YVhoUFZGUktWQXB6YlVGTUwzSkhia1pNZVU1d2JsSmlUMmNyVW1STVpDdEZUVlJoVERJNFJuSXZkRXRxU25OU2FGTnRVbTFZVmxWS1NtVllibWxtYjBGMVpUQnhZMVl4Q21Wc2NsRkJReXMxZGtOM2FDOW5lbGhFY2xGVVZtdzVZMk42UVUwMGJGUTJOell6Wm5SbmVFMHJUMDVSSzFwcVoxWlplRlEwZW1WaFMwUlFaWGd2ZUZNS1VIaGxUekJCWldNNVV6aHZiRzlZWkRjcloycGpXWHBKWjFCSk1VSm1VRmhQTmxvMGFWcHBjVVJyU0VVMlZISlZla3RyZGxwaE1XNDNOV3hLUzBoa1l3b3dUMUpHY1VOT01UazRlaTh3VVZkclVWbDRkQzlSVUZaUWRrdE1TbWhqZHpsTVZIWnNOR2RSVXpkR1Z6SlNVV0p5YlhsMlNFVlZabGxIVVRkeldXcE9Da1pKWkUxRU5rMXRhMnBsTURSQ055dDZTbU5ZYVc1b2MyTnFPREZDUW1WQ05qZGxkZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMzlkOWYxNDUtMDJlYS00ZTRlLWE1ZGEtZjE0NjYzMGM2MzJiLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHVibGljLWlwIgogICAgdXNlcjogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpaVEzZlhGSHBDWWI2bUxkdjZkOEVkNnJwd1dTT3c2TmJHWFhPcDRjTWxUY0xaazN4VEx1YTR0MA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2638"
+      - "2636"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:05:46 GMT
+      - Tue, 07 Nov 2023 16:05:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a21e120f-94ba-4de0-b665-f6d6a75955d1
+      - 9368fb0b-159b-4ee0-8f92-a9db635fec30
     status: 200 OK
     code: 200
     duration: ""
@@ -280,19 +280,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f82f936-189f-46c3-b063-e7b2af051c79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T17:05:41.115898Z","created_at":"2023-10-18T17:05:41.115898Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f82f936-189f-46c3-b063-e7b2af051c79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f82f936-189f-46c3-b063-e7b2af051c79","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-18T17:05:42.599796Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:05:44.188247Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1508"
+      - "1463"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:05:46 GMT
+      - Tue, 07 Nov 2023 16:05:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,12 +302,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6fd375f8-90ef-4eb8-897b-437436be0f73
+      - 4998cac5-58b4-4ab0-ae38-e18f94241588
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"pool","node_type":"gp1_xs","placement_group_id":null,"autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":null,"kubelet_args":{},"upgrade_policy":null,"zone":"fr-par-1","root_volume_type":"default_volume_type","root_volume_size":null,"public_ip_disabled":false}'
+    body: '{"name":"test-k8s-public-ip","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":null,"kubelet_args":{},"zone":"fr-par-1","root_volume_type":"default_volume_type","public_ip_disabled":false}'
     form: {}
     headers:
       Content-Type:
@@ -315,19 +315,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023240Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919131802Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "618"
+      - "609"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:05:46 GMT
+      - Tue, 07 Nov 2023 16:05:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -337,7 +337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a55d4c98-0bdc-41e4-98d3-9c3d0df3bd35
+      - 50ce8b58-2752-49ef-9e41-892a3783627d
     status: 200 OK
     code: 200
     duration: ""
@@ -348,19 +348,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:05:47 GMT
+      - Tue, 07 Nov 2023 16:05:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -370,7 +370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4bb11c14-e36c-478b-8cdf-49149636ace9
+      - ee569efb-ed11-4186-a408-c79baf07ae6f
     status: 200 OK
     code: 200
     duration: ""
@@ -381,19 +381,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:05:52 GMT
+      - Tue, 07 Nov 2023 16:05:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -403,7 +403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd6b6da3-f207-4ae3-8d0f-0a4b1417d0b0
+      - 0e626049-7c2d-4516-8cff-27a3b43507dc
     status: 200 OK
     code: 200
     duration: ""
@@ -414,19 +414,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:05:57 GMT
+      - Tue, 07 Nov 2023 16:05:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -436,7 +436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ebc7b7da-4980-4067-b703-a0a7278acd00
+      - e532aada-68c9-46b0-b7de-c73b409a1235
     status: 200 OK
     code: 200
     duration: ""
@@ -447,19 +447,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:06:02 GMT
+      - Tue, 07 Nov 2023 16:06:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -469,7 +469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27a24607-2270-410a-8fc5-829d1905e084
+      - e9821010-7a1d-4fc7-ab9b-7835ac52c823
     status: 200 OK
     code: 200
     duration: ""
@@ -480,19 +480,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:06:07 GMT
+      - Tue, 07 Nov 2023 16:06:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8489fb2-21be-4bf9-a936-6bdaa88b88a2
+      - bb6ebc1f-c2c7-41c4-8fb2-e81709027b11
     status: 200 OK
     code: 200
     duration: ""
@@ -513,19 +513,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:06:12 GMT
+      - Tue, 07 Nov 2023 16:06:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef50bc70-3d79-4f4a-b015-d3119b019331
+      - 686427e0-8ade-467e-baec-6377bc6b3119
     status: 200 OK
     code: 200
     duration: ""
@@ -546,19 +546,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:06:17 GMT
+      - Tue, 07 Nov 2023 16:06:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc5126d5-11a8-4654-9175-bede62c08b30
+      - 0d7048a3-3aec-4890-862f-cf466734aaee
     status: 200 OK
     code: 200
     duration: ""
@@ -579,19 +579,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:06:22 GMT
+      - Tue, 07 Nov 2023 16:06:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46ae4210-0429-4838-809a-8e505aebbc1b
+      - 0ca4f690-d18d-44c1-94c2-126c38c93cfe
     status: 200 OK
     code: 200
     duration: ""
@@ -612,19 +612,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:06:27 GMT
+      - Tue, 07 Nov 2023 16:06:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1cd877d9-c801-45d5-916d-8adad45b3f3e
+      - afc0d08f-873f-4b8a-8b82-e3072c7cc71e
     status: 200 OK
     code: 200
     duration: ""
@@ -645,19 +645,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:06:32 GMT
+      - Tue, 07 Nov 2023 16:06:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8016693-c84a-4c0e-bbf1-06d0cdfa1881
+      - b4a782f4-ec24-477e-9b20-5f1d2638056f
     status: 200 OK
     code: 200
     duration: ""
@@ -678,19 +678,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:06:37 GMT
+      - Tue, 07 Nov 2023 16:06:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b574c48d-ae8d-4ac2-973b-cdbb1ea3dc2d
+      - d3735b6b-6219-4451-a4bc-4fdf5677a88b
     status: 200 OK
     code: 200
     duration: ""
@@ -711,19 +711,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:06:42 GMT
+      - Tue, 07 Nov 2023 16:06:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2827d773-8f46-414e-868b-9643cc8e0c4b
+      - 2ae7c87b-b9bf-453d-b237-f39d9048228c
     status: 200 OK
     code: 200
     duration: ""
@@ -744,19 +744,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:06:47 GMT
+      - Tue, 07 Nov 2023 16:06:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea5a9fb0-13ce-4222-a083-3b4c0f53735d
+      - 0dc4c0eb-4613-41b7-8868-7abc4ff2d350
     status: 200 OK
     code: 200
     duration: ""
@@ -777,19 +777,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:06:52 GMT
+      - Tue, 07 Nov 2023 16:06:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 558eaadb-c601-4d59-980d-b031b47fad8d
+      - b9b6a47d-f2c9-44b0-bc30-785b8d90959b
     status: 200 OK
     code: 200
     duration: ""
@@ -810,19 +810,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:06:57 GMT
+      - Tue, 07 Nov 2023 16:06:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19715e64-a203-4b24-9f1b-7d84fd4480db
+      - 08688e99-999c-44ae-8297-dbba4794c854
     status: 200 OK
     code: 200
     duration: ""
@@ -843,19 +843,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:07:02 GMT
+      - Tue, 07 Nov 2023 16:07:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 868dd098-9cd8-4a6c-a9e6-4211b2068e7a
+      - 7f273a62-0f0e-47ee-aee3-087b9e2ea632
     status: 200 OK
     code: 200
     duration: ""
@@ -876,19 +876,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:07:07 GMT
+      - Tue, 07 Nov 2023 16:07:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11ac4ddc-3b2d-4e7b-8cfc-52ff3a15d331
+      - e2c8aa19-b4f2-4264-bc3f-7c9b408fee38
     status: 200 OK
     code: 200
     duration: ""
@@ -909,19 +909,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:07:12 GMT
+      - Tue, 07 Nov 2023 16:07:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec54dc1a-f734-418e-ba1c-929bb0a1e4f3
+      - 89cf4418-17d8-4a8e-9f59-310fa75c3429
     status: 200 OK
     code: 200
     duration: ""
@@ -942,19 +942,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:07:17 GMT
+      - Tue, 07 Nov 2023 16:07:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18324213-21c6-4ccb-b682-533a3b34d634
+      - 882b5857-896d-4069-97f2-6c5da3891e95
     status: 200 OK
     code: 200
     duration: ""
@@ -975,19 +975,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:07:22 GMT
+      - Tue, 07 Nov 2023 16:07:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5bf95a41-23aa-45ba-ba41-218e2e9f1f5f
+      - fb06b0c6-96b9-4376-ada4-0364357a3280
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,19 +1008,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:07:28 GMT
+      - Tue, 07 Nov 2023 16:07:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a27de1a2-e448-40cc-abad-37db10e02b50
+      - 6461a01a-0ce5-4dbf-a62f-87f8496ba3fb
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,19 +1041,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:07:33 GMT
+      - Tue, 07 Nov 2023 16:07:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a6efe89-5e9f-40c3-9fb7-b1113ff4d7ad
+      - 65c18ba0-545b-4773-8cd7-902ed1d0a4d3
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,19 +1074,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:07:38 GMT
+      - Tue, 07 Nov 2023 16:07:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b34b9c2-4bf6-43e9-bea3-9d2d65233fb5
+      - 9aac2ae7-a2bb-483b-bd62-273a9e3279ac
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,19 +1107,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:07:43 GMT
+      - Tue, 07 Nov 2023 16:07:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1129,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89c7f824-6b61-4fc5-9bd3-8efb5ff3feaa
+      - ff39c7d2-2873-4019-a284-46906b933599
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,19 +1140,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:07:48 GMT
+      - Tue, 07 Nov 2023 16:07:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f2635aa-71f9-492c-a6c9-b58c009bb22c
+      - 0f1f9576-67f8-417b-b3a1-603021b0a4af
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,19 +1173,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:07:53 GMT
+      - Tue, 07 Nov 2023 16:07:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4b65398-82ba-4e92-a553-bb95d64b2139
+      - 8f5252fc-fbf7-4382-932e-307037f83bc1
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,19 +1206,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:07:58 GMT
+      - Tue, 07 Nov 2023 16:07:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7aac0461-2a0b-40bc-b861-88441c8664d1
+      - b56e58c6-bf9a-4737-938e-9be23e43bdff
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,19 +1239,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:08:03 GMT
+      - Tue, 07 Nov 2023 16:08:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6af2a62f-c35a-4774-bad6-3bdb98f69688
+      - b3b201aa-0c9e-44b1-843f-252fc9b2b426
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,19 +1272,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:08:08 GMT
+      - Tue, 07 Nov 2023 16:08:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e335d4f-7aa4-45e1-929d-51ef1e790587
+      - 12721ffa-0ffe-4eb7-8bd2-0b7b86442746
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,19 +1305,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:08:13 GMT
+      - Tue, 07 Nov 2023 16:08:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6c28c26-6719-4c0c-a716-9e49ae8f8fbc
+      - 442332ab-e637-4c74-92dd-65802f525579
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,19 +1338,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:08:18 GMT
+      - Tue, 07 Nov 2023 16:08:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1360,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2503d640-1a58-4275-93ed-de07572c003b
+      - 01325b43-3e44-4693-ac3e-45b8fd3cf714
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,19 +1371,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:08:23 GMT
+      - Tue, 07 Nov 2023 16:08:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1393,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cccc9d5f-eb85-4dbe-a2bb-d5278e698b07
+      - 2ced4d1c-7749-43fd-a4da-0ddda148ce59
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,19 +1404,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:08:28 GMT
+      - Tue, 07 Nov 2023 16:08:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1426,7 +1426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0dd433d-a5dd-4a4b-ab93-858f6033e30b
+      - 2c036390-7137-4903-ac27-1f0548070c86
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,19 +1437,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:08:33 GMT
+      - Tue, 07 Nov 2023 16:08:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1459,7 +1459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 051abe80-5c90-4676-9cbf-1193f2e697dd
+      - b34523af-2c02-4e31-abf4-00b3ecced3a4
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,19 +1470,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:08:38 GMT
+      - Tue, 07 Nov 2023 16:08:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1492,7 +1492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72122f67-9729-47a6-bc83-fd5d17404c31
+      - 1043c599-9ff2-49db-a86b-5f31ead794f7
     status: 200 OK
     code: 200
     duration: ""
@@ -1503,19 +1503,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:08:43 GMT
+      - Tue, 07 Nov 2023 16:08:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67a3b502-c1b4-401e-813a-52fcad781165
+      - 0639b04a-e2ea-4d81-948f-587cccc9ddd7
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,19 +1536,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:08:48 GMT
+      - Tue, 07 Nov 2023 16:08:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1558,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cacc7880-414b-4154-8a22-ac08c58a59a7
+      - fec78855-2c3f-4f88-b08b-ad24e6553b41
     status: 200 OK
     code: 200
     duration: ""
@@ -1569,19 +1569,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:08:53 GMT
+      - Tue, 07 Nov 2023 16:08:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1591,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ee74077-ddaa-4d66-8d5f-8f89d081e98d
+      - 583369e5-b89e-4f17-b370-c11655647b97
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,19 +1602,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:08:58 GMT
+      - Tue, 07 Nov 2023 16:09:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0c48f15-fde2-48a6-bfe0-97d82c90da0a
+      - 4de9c88f-21ed-44d8-825d-6a1d09a548fb
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,19 +1635,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:09:04 GMT
+      - Tue, 07 Nov 2023 16:09:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1657,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c93439e-54cd-461a-a22a-6dbd18f105f8
+      - af32c4e3-6b48-4ee5-9981-8863d0b69a5b
     status: 200 OK
     code: 200
     duration: ""
@@ -1668,19 +1668,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:09:09 GMT
+      - Tue, 07 Nov 2023 16:09:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1690,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7fcbbe9e-b2b3-479a-86aa-4ceb4cfceabe
+      - 1ed7b6d8-dddd-4c3b-8f17-d089f393588d
     status: 200 OK
     code: 200
     duration: ""
@@ -1701,19 +1701,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:09:14 GMT
+      - Tue, 07 Nov 2023 16:09:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1723,7 +1723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a43bada0-ac98-4fab-94ff-02f4e957c5de
+      - 9bcc7e55-8e54-4ce8-8308-78b67a809e2e
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,19 +1734,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:09:19 GMT
+      - Tue, 07 Nov 2023 16:09:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1756,7 +1756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e9c5fc4-17d3-4b60-8bae-8b2bc88aad37
+      - d7997062-7402-4d07-bc96-6ce3c1f4b084
     status: 200 OK
     code: 200
     duration: ""
@@ -1767,19 +1767,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:09:24 GMT
+      - Tue, 07 Nov 2023 16:09:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1789,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd903c57-0442-4554-aef5-9441f3f75faa
+      - 50225391-7431-4710-b6ff-0b6f6c6247ff
     status: 200 OK
     code: 200
     duration: ""
@@ -1800,19 +1800,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:09:29 GMT
+      - Tue, 07 Nov 2023 16:09:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1822,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 487f231d-42d1-4cda-8935-4e9f6d00ea10
+      - bc632d8c-76a9-4d83-9420-26501850f689
     status: 200 OK
     code: 200
     duration: ""
@@ -1833,19 +1833,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:09:34 GMT
+      - Tue, 07 Nov 2023 16:09:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1855,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01e9cc8d-b560-4edf-9b89-d4fbd77ee0dc
+      - 62ad9813-5ee6-4c86-8863-36c564a4c5e8
     status: 200 OK
     code: 200
     duration: ""
@@ -1866,19 +1866,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:09:39 GMT
+      - Tue, 07 Nov 2023 16:09:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1888,7 +1888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90a8e22b-519a-4b87-afb6-b191b717bd72
+      - 4741bfba-6756-4070-8ac8-82b8748ce7e0
     status: 200 OK
     code: 200
     duration: ""
@@ -1899,19 +1899,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:09:44 GMT
+      - Tue, 07 Nov 2023 16:09:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1921,7 +1921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 697b6e77-ff08-459c-908c-2be713b27d0f
+      - c36f0110-c266-4658-86fa-1dbfa97c128e
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,19 +1932,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:09:49 GMT
+      - Tue, 07 Nov 2023 16:09:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1954,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3015b73d-fe3e-4308-874d-dd1ea23f4edc
+      - b02a8c8b-bf64-4da4-9938-88bf2b27723c
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,19 +1965,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:09:54 GMT
+      - Tue, 07 Nov 2023 16:09:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1987,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5588f131-576e-4af5-938d-9c4fb832741e
+      - f072905b-ce72-42b5-ba2e-f7d8d7891183
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,19 +1998,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:09:59 GMT
+      - Tue, 07 Nov 2023 16:10:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2020,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef7d52f7-8b54-43e2-abe2-b2dc01d3ae46
+      - ad6c1e93-09d4-4596-a79e-e5ff08c5c279
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,19 +2031,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:10:04 GMT
+      - Tue, 07 Nov 2023 16:10:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2053,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42a25927-9c88-47cc-b051-d1eb966a9af4
+      - 1872be2d-376e-49d0-9a93-254874a43471
     status: 200 OK
     code: 200
     duration: ""
@@ -2064,19 +2064,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:10:09 GMT
+      - Tue, 07 Nov 2023 16:10:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2086,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57b79431-ebc0-4ebe-b180-2ff2bc33eab1
+      - c83f929e-cc44-4835-9800-8ee242680dea
     status: 200 OK
     code: 200
     duration: ""
@@ -2097,19 +2097,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:10:14 GMT
+      - Tue, 07 Nov 2023 16:10:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2119,7 +2119,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0849fff-3e62-4e00-b92d-c6155f03b0c3
+      - dd43fe4a-a0bc-45db-bc8c-b5f876a39045
     status: 200 OK
     code: 200
     duration: ""
@@ -2130,19 +2130,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:10:19 GMT
+      - Tue, 07 Nov 2023 16:10:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2152,7 +2152,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eea3d03f-87ff-41ee-a522-f337ca676d99
+      - 929c8305-25f2-4b80-ab51-6f3f0e301eac
     status: 200 OK
     code: 200
     duration: ""
@@ -2163,19 +2163,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:10:24 GMT
+      - Tue, 07 Nov 2023 16:10:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2185,7 +2185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba8674e8-dfb6-44f3-94d5-3d8b2d29699e
+      - 454776bd-c45e-4fcd-9d63-9ddb6087d4d3
     status: 200 OK
     code: 200
     duration: ""
@@ -2196,19 +2196,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:10:29 GMT
+      - Tue, 07 Nov 2023 16:10:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2218,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 447e1d8e-d6a4-498b-a682-98e5cc4aa53f
+      - 58df8d93-e7ef-4091-abb4-bf16040235d4
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,19 +2229,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:10:34 GMT
+      - Tue, 07 Nov 2023 16:10:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2251,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 002e9974-23fb-4d39-826f-4c2d3edfca93
+      - dc79e582-6b03-4deb-8a2d-7bc9c61ba234
     status: 200 OK
     code: 200
     duration: ""
@@ -2262,19 +2262,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:10:40 GMT
+      - Tue, 07 Nov 2023 16:10:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2284,7 +2284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe872541-374e-4c2e-91fa-fb3f1bd62965
+      - a638b7fb-538f-4c73-8025-85bdfc774be5
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,19 +2295,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:10:45 GMT
+      - Tue, 07 Nov 2023 16:10:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2317,7 +2317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d39c940-10af-474f-8625-6d6773449be9
+      - 0733fa4e-091b-4b3b-acd1-ce523827016b
     status: 200 OK
     code: 200
     duration: ""
@@ -2328,19 +2328,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:10:50 GMT
+      - Tue, 07 Nov 2023 16:10:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2350,7 +2350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 379a81eb-3330-444f-bfba-f33567cf97a4
+      - 4f87fd29-a1ef-4e29-9327-be91114d0e03
     status: 200 OK
     code: 200
     duration: ""
@@ -2361,19 +2361,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:10:55 GMT
+      - Tue, 07 Nov 2023 16:10:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2383,7 +2383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82959f0c-024a-4140-b4d9-8e21e5837fd4
+      - 2666aa81-748f-4762-b8c5-c94fd3a86629
     status: 200 OK
     code: 200
     duration: ""
@@ -2394,19 +2394,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:11:00 GMT
+      - Tue, 07 Nov 2023 16:11:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2416,7 +2416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89acc903-f7b8-4f47-a75e-3e3876b3d237
+      - b57e9abb-22b0-481f-b7c9-798d94d438e4
     status: 200 OK
     code: 200
     duration: ""
@@ -2427,19 +2427,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:11:05 GMT
+      - Tue, 07 Nov 2023 16:11:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2449,7 +2449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1a70c69-b69e-4858-89b9-6170af1eea2f
+      - 5671bb23-7ed8-4aa4-b37d-98577dcbb478
     status: 200 OK
     code: 200
     duration: ""
@@ -2460,19 +2460,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:11:10 GMT
+      - Tue, 07 Nov 2023 16:11:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2482,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 133cfb91-fc1d-468e-ad4a-c55c08a49d2f
+      - 93af2303-2881-4394-a2ee-795b1463d6d5
     status: 200 OK
     code: 200
     duration: ""
@@ -2493,19 +2493,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:11:15 GMT
+      - Tue, 07 Nov 2023 16:11:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2515,7 +2515,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b2650e8-419b-4a26-8de5-19493abe0a65
+      - 713a2e49-0794-41db-9171-379cb172f84a
     status: 200 OK
     code: 200
     duration: ""
@@ -2526,19 +2526,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:11:20 GMT
+      - Tue, 07 Nov 2023 16:11:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2548,7 +2548,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 250a0bbc-8f77-411e-8753-9927a176b08e
+      - d255cd9c-19f7-4fb4-b9dc-db76f9a16105
     status: 200 OK
     code: 200
     duration: ""
@@ -2559,19 +2559,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:11:25 GMT
+      - Tue, 07 Nov 2023 16:11:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2581,7 +2581,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4f79433-e93e-401e-80f9-eaeeb4c5b849
+      - 413da506-6774-43bf-8378-0c802ba45e5f
     status: 200 OK
     code: 200
     duration: ""
@@ -2592,19 +2592,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:11:30 GMT
+      - Tue, 07 Nov 2023 16:11:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2614,7 +2614,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ec934a7-3257-4cc9-8fdb-59522f85c5ac
+      - cee15cbe-acd6-4b4f-9d86-598740766dbf
     status: 200 OK
     code: 200
     duration: ""
@@ -2625,19 +2625,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:05:47.919132Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:11:35 GMT
+      - Tue, 07 Nov 2023 16:11:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2647,7 +2647,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b20e7845-b9b0-4d99-9cf1-9de4f7792933
+      - 9445b578-7275-48ca-a0db-167989ada726
     status: 200 OK
     code: 200
     duration: ""
@@ -2658,19 +2658,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:11:40.540303Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:11:40 GMT
+      - Tue, 07 Nov 2023 16:11:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2680,7 +2680,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2aad2cf9-da0b-46f4-88d2-39acfb459389
+      - 3598f41b-c956-4879-bf4e-d45d919c98b8
     status: 200 OK
     code: 200
     duration: ""
@@ -2691,19 +2691,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:06:52.761677Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "615"
+      - "1455"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:11:45 GMT
+      - Tue, 07 Nov 2023 16:11:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2713,7 +2713,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a173dbf3-4ae5-45dd-a2ac-2580475436ba
+      - b8c6f9ff-c380-42e5-96be-e0373441cf32
     status: 200 OK
     code: 200
     duration: ""
@@ -2724,19 +2724,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:11:40.540303Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:11:50 GMT
+      - Tue, 07 Nov 2023 16:11:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2746,7 +2746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4a4b916-b5e7-4e61-a7bd-937b1a66ef6f
+      - c9ddd4cb-e284-4702-b1c8-b8b0e44c6b20
     status: 200 OK
     code: 200
     duration: ""
@@ -2757,19 +2757,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/nodes?order_by=created_at_asc&page=1&pool_id=308c7294-01ad-4afe-9a9c-1feac3e1a142&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T16:08:28.132162Z","error_message":null,"id":"06c62993-3874-4d90-99f2-3aac9161cce9","name":"scw-test-k8s-public-i-test-k8s-public-i-06c629","pool_id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","provider_id":"scaleway://instance/fr-par-1/be05aa69-3d5f-45ec-8ea4-cd0d3d455712","public_ip_v4":"51.15.215.100","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:11:40.519424Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "615"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:11:55 GMT
+      - Tue, 07 Nov 2023 16:11:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2779,7 +2779,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4579059b-d6ba-42f2-9bfb-9ded83895cc1
+      - a301c240-321e-4781-8517-4d554d4665b7
     status: 200 OK
     code: 200
     duration: ""
@@ -2790,19 +2790,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:06:52.761677Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "615"
+      - "1455"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:00 GMT
+      - Tue, 07 Nov 2023 16:11:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2812,7 +2812,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b83caeca-7661-4788-97d2-91255fb87bc0
+      - 311371ce-c74a-453a-a5ae-b0a2aeaea4ee
     status: 200 OK
     code: 200
     duration: ""
@@ -2823,19 +2823,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3161b3a1-c691-4566-aeb8-03eb610ff2ee
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-07T16:05:40.803436Z","dhcp_enabled":true,"id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:05:40.803436Z","id":"593394e2-e265-4d2d-8acd-a46de571baa7","subnet":"172.16.20.0/22","updated_at":"2023-11-07T16:05:40.803436Z"},{"created_at":"2023-11-07T16:05:40.803436Z","id":"f1c14d0f-4e1b-4c61-ac26-67402c6a15ed","subnet":"fd5f:519c:6d46:63f8::/64","updated_at":"2023-11-07T16:05:40.803436Z"}],"tags":[],"updated_at":"2023-11-07T16:05:40.803436Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "615"
+      - "702"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:05 GMT
+      - Tue, 07 Nov 2023 16:11:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2845,7 +2845,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6d3a894-21df-422b-b380-d5211ec31a46
+      - 6afda5f1-9a32-4c5e-ad28-0825ee95f44b
     status: 200 OK
     code: 200
     duration: ""
@@ -2856,19 +2856,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:05:46.657023Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:11:40.540303Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:11 GMT
+      - Tue, 07 Nov 2023 16:11:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2878,7 +2878,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7aaf3f8f-7dd2-453a-9ed4-4406d58449fc
+      - 6d466e66-0279-4fcf-8a5e-0eee6b88783a
     status: 200 OK
     code: 200
     duration: ""
@@ -2889,19 +2889,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/nodes?order_by=created_at_asc&pool_id=308c7294-01ad-4afe-9a9c-1feac3e1a142&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-18T17:12:11.121274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T16:08:28.132162Z","error_message":null,"id":"06c62993-3874-4d90-99f2-3aac9161cce9","name":"scw-test-k8s-public-i-test-k8s-public-i-06c629","pool_id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","provider_id":"scaleway://instance/fr-par-1/be05aa69-3d5f-45ec-8ea4-cd0d3d455712","public_ip_v4":"51.15.215.100","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:11:40.519424Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "613"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:16 GMT
+      - Tue, 07 Nov 2023 16:11:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2911,7 +2911,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d66997db-155c-4b02-8a67-b1415e64f50d
+      - 48a7c261-5745-47fb-8337-8e9dec98c04b
     status: 200 OK
     code: 200
     duration: ""
@@ -2922,254 +2922,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f82f936-189f-46c3-b063-e7b2af051c79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T17:05:41.115898Z","created_at":"2023-10-18T17:05:41.115898Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f82f936-189f-46c3-b063-e7b2af051c79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f82f936-189f-46c3-b063-e7b2af051c79","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-18T17:07:10.949789Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1500"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 17:12:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 765925c4-fe0b-4c49-9466-db4b10805c92
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-18T17:12:11.121274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "613"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 17:12:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6bb25aca-6133-49ce-bdd7-e68ae365e26d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79/nodes?order_by=created_at_asc&page=1&pool_id=d38eed5f-356c-45cc-b081-fdca496aa995&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T17:07:15.323103Z","error_message":null,"id":"b5cb9457-0865-4b0d-ac1f-b375f9e513d5","name":"scw-test-k8s-public-ip-pool-b5cb945708654b0dac","pool_id":"d38eed5f-356c-45cc-b081-fdca496aa995","provider_id":"scaleway://instance/fr-par-1/ff62c988-07a5-4aa8-bf13-690a11baad87","public_ip_v4":"51.15.143.114","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T17:12:11.109867Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "658"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 17:12:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 487d94e5-3145-4ca0-9f98-92d441614266
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f82f936-189f-46c3-b063-e7b2af051c79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T17:05:41.115898Z","created_at":"2023-10-18T17:05:41.115898Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f82f936-189f-46c3-b063-e7b2af051c79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f82f936-189f-46c3-b063-e7b2af051c79","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-18T17:07:10.949789Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1500"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 17:12:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 46cb5ad1-8f8f-4264-8199-f7722da712bd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b27b50b7-86ff-406e-b08b-de82de78fe7a
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-18T17:05:38.963133Z","dhcp_enabled":true,"id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T17:05:38.963133Z","id":"b6f618ae-5f6f-4745-acbc-66e1cba782d7","subnet":"172.16.16.0/22","updated_at":"2023-10-18T17:05:38.963133Z"},{"created_at":"2023-10-18T17:05:38.963133Z","id":"385347c4-de12-4c0f-ab0e-d6fc33b70b07","subnet":"fd63:256c:45f7:2b74::/64","updated_at":"2023-10-18T17:05:38.963133Z"}],"tags":[],"updated_at":"2023-10-18T17:05:38.963133Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "719"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 17:12:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8d201f05-1451-46b1-baf8-243a1e3bf74b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-18T17:12:11.121274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "613"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 17:12:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 691b96d7-5ee4-4432-a746-a0e7435de59c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79/nodes?order_by=created_at_asc&pool_id=d38eed5f-356c-45cc-b081-fdca496aa995&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T17:07:15.323103Z","error_message":null,"id":"b5cb9457-0865-4b0d-ac1f-b375f9e513d5","name":"scw-test-k8s-public-ip-pool-b5cb945708654b0dac","pool_id":"d38eed5f-356c-45cc-b081-fdca496aa995","provider_id":"scaleway://instance/fr-par-1/ff62c988-07a5-4aa8-bf13-690a11baad87","public_ip_v4":"51.15.143.114","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T17:12:11.109867Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "658"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 17:12:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - af73701c-690a-4b14-a033-ea09b01f706a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ff62c988-07a5-4aa8-bf13-690a11baad87
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/be05aa69-3d5f-45ec-8ea4-cd0d3d455712
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-10-18T17:07:16.269554+00:00","dynamic_ip_required":true,"enable_ipv6":true,"extra_networks":[],"hostname":"scw-test-k8s-public-ip-pool-b5cb945708654b0dac","id":"ff62c988-07a5-4aa8-bf13-690a11baad87","image":{"arch":"x86_64","creation_date":"2023-10-17T13:58:22.900323+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"058ec9bf-0cd8-4b2d-a68e-cb7578338a88","modification_date":"2023-10-17T14:08:43.096919+00:00","name":"k8s_base_node_2023-10-11.1","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"84ef0475-6a5a-4ab4-9acd-8e5855eee050","name":"k8s_base_node_2023-10-11.1","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":{"address":"2001:bc8:474c:1901::1","gateway":"2001:bc8:474c:1901::","netmask":"64"},"location":{"cluster_id":"4","hypervisor_id":"1302","node_id":"2","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:5e:33","maintenances":[],"modification_date":"2023-10-18T17:07:32.646805+00:00","name":"scw-test-k8s-public-ip-pool-b5cb945708654b0dac","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","placement_group":null,"private_ip":"10.12.164.67","private_nics":[{"creation_date":"2023-10-18T17:07:16.831824+00:00","id":"55ab2295-4836-40ed-abda-33478ae451c4","mac_address":"02:00:00:14:4d:51","modification_date":"2023-10-18T17:07:17.610875+00:00","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","server_id":"ff62c988-07a5-4aa8-bf13-690a11baad87","state":"available","tags":[],"zone":"fr-par-1"}],"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"public_ip":{"address":"51.15.143.114","dynamic":true,"family":"inet","gateway":null,"id":"37d573b3-feb6-4fcb-b0ad-699a6299a21e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.143.114","dynamic":true,"family":"inet","gateway":null,"id":"37d573b3-feb6-4fcb-b0ad-699a6299a21e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"92e3a255-acd6-4ef5-bc55-ba14ba229683","name":"kubernetes
-      4f82f936-189f-46c3-b063-e7b2af051c79"},"state":"running","state_detail":"booting
-      kernel","tags":["kapsule=4f82f936-189f-46c3-b063-e7b2af051c79","pool=d38eed5f-356c-45cc-b081-fdca496aa995","pool-name=pool","runtime=containerd","managed=true","node=b5cb9457-0865-4b0d-ac1f-b375f9e513d5"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T17:07:16.269554+00:00","export_uri":null,"id":"a15d625e-c6ce-4054-9dee-575634f80667","modification_date":"2023-10-18T17:07:16.269554+00:00","name":"k8s_base_node_2023-10-11.1","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","server":{"id":"ff62c988-07a5-4aa8-bf13-690a11baad87","name":"scw-test-k8s-public-ip-pool-b5cb945708654b0dac"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-11-07T16:08:28.600272+00:00","dynamic_ip_required":true,"enable_ipv6":true,"extra_networks":[],"hostname":"scw-test-k8s-public-i-test-k8s-public-i-06c629","id":"be05aa69-3d5f-45ec-8ea4-cd0d3d455712","image":{"arch":"x86_64","creation_date":"2023-10-17T13:58:22.900323+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"058ec9bf-0cd8-4b2d-a68e-cb7578338a88","modification_date":"2023-10-17T14:08:43.096919+00:00","name":"k8s_base_node_2023-10-11.1","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"84ef0475-6a5a-4ab4-9acd-8e5855eee050","name":"k8s_base_node_2023-10-11.1","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":{"address":"2001:bc8:610:2a07::1","gateway":"2001:bc8:610:2a07::","netmask":"64"},"location":{"cluster_id":"47","hypervisor_id":"102","node_id":"8","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:5e:fb","maintenances":[],"modification_date":"2023-11-07T16:08:45.102071+00:00","name":"scw-test-k8s-public-i-test-k8s-public-i-06c629","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.194.65.79","private_nics":[{"creation_date":"2023-11-07T16:08:29.262776+00:00","id":"e2d355bb-c296-4b6d-9d43-cda00caf50e9","mac_address":"02:00:00:14:a4:11","modification_date":"2023-11-07T16:08:30.156714+00:00","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","server_id":"be05aa69-3d5f-45ec-8ea4-cd0d3d455712","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.215.100","dynamic":true,"family":"inet","gateway":null,"id":"4c16f5eb-f338-4fae-8f22-8b0d12d83ec7","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.215.100","dynamic":true,"family":"inet","gateway":null,"id":"4c16f5eb-f338-4fae-8f22-8b0d12d83ec7","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"8ee2862c-bbf8-44af-82cf-9ec4d2265dd9","name":"kubernetes
+      39d9f145-02ea-4e4e-a5da-f146630c632b"},"state":"running","state_detail":"booting
+      kernel","tags":["kapsule=39d9f145-02ea-4e4e-a5da-f146630c632b","pool=308c7294-01ad-4afe-9a9c-1feac3e1a142","pool-name=test-k8s-public-ip","runtime=containerd","managed=true","node=06c62993-3874-4d90-99f2-3aac9161cce9"],"volumes":{"0":{"boot":false,"creation_date":"2023-11-07T16:08:28.600272+00:00","export_uri":null,"id":"c97beb96-de3c-4387-bcb0-fec23e8602a5","modification_date":"2023-11-07T16:08:28.600272+00:00","name":"k8s_base_node_2023-10-11.1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"be05aa69-3d5f-45ec-8ea4-cd0d3d455712","name":"scw-test-k8s-public-i-test-k8s-public-i-06c629"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3954"
+      - "3966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:16 GMT
+      - Tue, 07 Nov 2023 16:11:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3179,7 +2948,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - feffed05-00aa-40d7-afb9-8632f1807bdf
+      - bab0a722-aa22-4b46-b8a9-1ca09b8c0e2d
     status: 200 OK
     code: 200
     duration: ""
@@ -3190,19 +2959,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b27b50b7-86ff-406e-b08b-de82de78fe7a
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3161b3a1-c691-4566-aeb8-03eb610ff2ee
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T17:05:38.963133Z","dhcp_enabled":true,"id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T17:05:38.963133Z","id":"b6f618ae-5f6f-4745-acbc-66e1cba782d7","subnet":"172.16.16.0/22","updated_at":"2023-10-18T17:05:38.963133Z"},{"created_at":"2023-10-18T17:05:38.963133Z","id":"385347c4-de12-4c0f-ab0e-d6fc33b70b07","subnet":"fd63:256c:45f7:2b74::/64","updated_at":"2023-10-18T17:05:38.963133Z"}],"tags":[],"updated_at":"2023-10-18T17:05:38.963133Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:05:40.803436Z","dhcp_enabled":true,"id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:05:40.803436Z","id":"593394e2-e265-4d2d-8acd-a46de571baa7","subnet":"172.16.20.0/22","updated_at":"2023-11-07T16:05:40.803436Z"},{"created_at":"2023-11-07T16:05:40.803436Z","id":"f1c14d0f-4e1b-4c61-ac26-67402c6a15ed","subnet":"fd5f:519c:6d46:63f8::/64","updated_at":"2023-11-07T16:05:40.803436Z"}],"tags":[],"updated_at":"2023-11-07T16:05:40.803436Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "719"
+      - "702"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:17 GMT
+      - Tue, 07 Nov 2023 16:11:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3212,7 +2981,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01aea095-ebf8-4d57-9431-a3207d550747
+      - 273741cc-63c8-467b-8bf4-24a3b4591ecc
     status: 200 OK
     code: 200
     duration: ""
@@ -3223,19 +2992,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f82f936-189f-46c3-b063-e7b2af051c79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T17:05:41.115898Z","created_at":"2023-10-18T17:05:41.115898Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f82f936-189f-46c3-b063-e7b2af051c79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f82f936-189f-46c3-b063-e7b2af051c79","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-18T17:07:10.949789Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:06:52.761677Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1500"
+      - "1455"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:17 GMT
+      - Tue, 07 Nov 2023 16:11:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3245,7 +3014,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d0a01eb-8a2f-44df-9ff1-fd733332e611
+      - 71b1111a-5f08-44d9-a04f-bd5d8b70d364
     status: 200 OK
     code: 200
     duration: ""
@@ -3256,19 +3025,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVelRVUlZNRTFzYjFoRVZFMTZUVlJCZUU1NlJUTk5SRlV3VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUMjl4Q2xrNFNIaDRhR3M1UkVreE56TjNZMGd4ZVRnemMzcFhiWFpFZDJ0d2FrOVhVRXhxTDFwa05scEZjSE5FWlRoalpVMVNOVUZYUWxwNVExWjFaRUpXVUhrS1VXWlFUVXRQUTNkRGQwRjFaekJpVldFelIwZE1UREZoVldkWFUwd3dlbkZRY0dsTGRtMUxTRXhtTkV4cVVHcE1VRGxaZUdKTFYyMWFPRGRXVjBVelRncEJRM3B0VTNGQk9VYzJNa1U1UjFGNVJYWkhRbHBJWW1sWksza3lkV0pLVVhWQmJHbFpSMG94ZUZNMVVWbGxhRTFSU25GSFJIQXhSMDg1ZDJSeU5VZHlDbmc1TDJKdmVqQmpPR3Q2TmxoT1NucFZSblJOZUU0NFpEQXZaVlZwUjBNMmFTdHBSMU5GVFU0eWEwUkhjVW8yTW1NMU4yaDJXbk40UTJZek1HUTFVbXNLWjB0NFQwRXpaVWhLVFVwNFQyMXpabEJLUjNoUVFubDJVR1FyU2tkaVJuUlZkME5SVkhkbVluTnFTSGRuSzFOYVJXczRSVkl2U0RsdlJVbHRWa3hyZUFwbFFtazNTMUUwSzIxRmVVWTVNelU0WVZjd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUGJUWTRTbUZsWm1GclZWUm9SMDR2UkhFMVIwNUtWVXBNV1VoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmNFeDBaVnBFWm1veFMyeDVkV3hIV1U5SmJrbDNlRlpDZVhFM1RYQnRZa3gyUVRkeFNFcFNTaTg1YUV4emRWSkpWd3ByUVRaUVVVZHBhemRVYzJGdFQwUlVOU3Q0ZDBRck1rY3daRzB5Vm5KSlkyRkdSVzAyYjJJNVpHeDNiRkJ2WjFwRU1rZFBTVFo1UVVWcVdWZFdiWFpqQ20xeGEweEpaRGR6UkRWb01EbHVURmhoVGt4aFZUbHRZblYyT1d3MGFXbExPVmw0VFcxQk1WQlJUbUptUjBOTGJYbHVPREpoYVVsTU9XMTBiRkFyYUVnS1VIcFZNbVp5TmxkemNTOU9ibEo1VkZOaWIyZ3haVkJ5TmpOV2JGazVkazk2YkROTWVVUnlaMnR1UldnNFFVaHpVVGxvYlRaVUx6aFBXR2xTUzBjNGNRbzRiV2xMVHk5eFprMW5NWFZzZVRJMmNuZFBiV1ZVVmk5TVdITktNbmRCUldJeU5rTndXR3hMZEdWWVYyc3phRGxDVUVSYVlYcG1TMGh2WTNWNWFWbHVDbFZJU1ROdVIzTTNUQzlvWVhaeVF6QkhUVkYwZVdzNFIydFBkbU5vVDJOQk4zQjZVd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNGY4MmY5MzYtMTg5Zi00NmMzLWIwNjMtZTdiMmFmMDUxYzc5LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHVibGljLWlwIgogICAgdXNlcjogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBDT2FQVE5idURiSFpYY3pBbDhKWTN6R29UeTZFeXlWWjNPMkE3YXBpWE1TVm9MclhFaThkdmR5SA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRVUlZNRTB4YjFoRVZFMTZUVlJGZDA1cVJUSk5SRlV3VFRGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURkJUQ2tReEwxcG5TMVF2TW5oT2MyaDVlVVU1YlVWNlQwTktTRGgwUWs4MksyOWxiSEZJU2pSMU1YcDNjRGRLSzFjeWNYQnBNMEprVUhwMFJYSlJkMlpTYXpZS1NWbHBhV00yT0dvNFkzQTFlR2x2T1dGU1FURnRhbmxFWlZGamNXMUJUVzlJT1hwVWVISlJXWE5hVVVablEyUlhZMUpGT0VselYycEtPR3BYYlN0SFNncFVSUzh2VFVaa2N5dDNiblZoU2pFMllrZHdValpxTUZobVJXUkZPVlZoZDFvMk5WVjZjRFF4YUZReVREY3pRVTQ0TkdJck5XUmlVRXB6Wmk5Wk0yaElDa28wYjNWaU1WbFFXa0pXT0ZGTFpsSjNTMGhzU0hVeVlqQlZiak14WjNWbVVsSk9TM0l2WVd0TFNsYzFZVUpCY2pJeU9XZG1VbVJWVkdscFJrOXZTSFFLUzA5V1NGSXJNRmM1YVhkU2JYRmtkMFp6TTNkQ1JrTTRPV3BvWkRSSlFtZFJhME0yYW5WU1JHVTBWRk16VEhjMU1IRkVSM2s0Ym04MVJqaFBVamhXVFFwRlVGWnhRWHB0T0RWUVNtMW1jVlZFWTBKVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaT1kwZEVNbTl6TlZaaGVHNWFVMEptUmtSS09XUjRSbG8zTDNsTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2JVRkpiVWhVV1M5TVdUSmlXREFyVTJSSU0zQXZXVGRqVmtKbk5XWTVkRU0zVERsUlFqSnFlV1o1YVhoUFZGUktWQXB6YlVGTUwzSkhia1pNZVU1d2JsSmlUMmNyVW1STVpDdEZUVlJoVERJNFJuSXZkRXRxU25OU2FGTnRVbTFZVmxWS1NtVllibWxtYjBGMVpUQnhZMVl4Q21Wc2NsRkJReXMxZGtOM2FDOW5lbGhFY2xGVVZtdzVZMk42UVUwMGJGUTJOell6Wm5SbmVFMHJUMDVSSzFwcVoxWlplRlEwZW1WaFMwUlFaWGd2ZUZNS1VIaGxUekJCWldNNVV6aHZiRzlZWkRjcloycGpXWHBKWjFCSk1VSm1VRmhQTmxvMGFWcHBjVVJyU0VVMlZISlZla3RyZGxwaE1XNDNOV3hLUzBoa1l3b3dUMUpHY1VOT01UazRlaTh3VVZkclVWbDRkQzlSVUZaUWRrdE1TbWhqZHpsTVZIWnNOR2RSVXpkR1Z6SlNVV0p5YlhsMlNFVlZabGxIVVRkeldXcE9Da1pKWkUxRU5rMXRhMnBsTURSQ055dDZTbU5ZYVc1b2MyTnFPREZDUW1WQ05qZGxkZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMzlkOWYxNDUtMDJlYS00ZTRlLWE1ZGEtZjE0NjYzMGM2MzJiLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHVibGljLWlwIgogICAgdXNlcjogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpaVEzZlhGSHBDWWI2bUxkdjZkOEVkNnJwd1dTT3c2TmJHWFhPcDRjTWxUY0xaazN4VEx1YTR0MA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2638"
+      - "2636"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:17 GMT
+      - Tue, 07 Nov 2023 16:11:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3278,7 +3047,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42872d85-b2e5-4be6-a5f5-13e21f01d4a8
+      - 6114f374-ab41-48e7-b8e8-5c7beacc39a8
     status: 200 OK
     code: 200
     duration: ""
@@ -3289,19 +3058,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-18T17:12:11.121274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:11:40.540303Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "613"
+      - "604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:17 GMT
+      - Tue, 07 Nov 2023 16:11:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3311,7 +3080,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a4a3a95-a0a6-435d-84e3-416be0ec7d7e
+      - ce1fadc0-7d07-4e3b-915a-9bccbc37da66
     status: 200 OK
     code: 200
     duration: ""
@@ -3322,19 +3091,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79/nodes?order_by=created_at_asc&page=1&pool_id=d38eed5f-356c-45cc-b081-fdca496aa995&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/nodes?order_by=created_at_asc&page=1&pool_id=308c7294-01ad-4afe-9a9c-1feac3e1a142&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T17:07:15.323103Z","error_message":null,"id":"b5cb9457-0865-4b0d-ac1f-b375f9e513d5","name":"scw-test-k8s-public-ip-pool-b5cb945708654b0dac","pool_id":"d38eed5f-356c-45cc-b081-fdca496aa995","provider_id":"scaleway://instance/fr-par-1/ff62c988-07a5-4aa8-bf13-690a11baad87","public_ip_v4":"51.15.143.114","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T17:12:11.109867Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T16:08:28.132162Z","error_message":null,"id":"06c62993-3874-4d90-99f2-3aac9161cce9","name":"scw-test-k8s-public-i-test-k8s-public-i-06c629","pool_id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","provider_id":"scaleway://instance/fr-par-1/be05aa69-3d5f-45ec-8ea4-cd0d3d455712","public_ip_v4":"51.15.215.100","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:11:40.519424Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "658"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:17 GMT
+      - Tue, 07 Nov 2023 16:11:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3344,7 +3113,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a30ebffc-8d89-45e9-9763-77df05d98b47
+      - b4abcae5-e586-42fb-b3c3-8bbf903dd38f
     status: 200 OK
     code: 200
     duration: ""
@@ -3355,19 +3124,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b27b50b7-86ff-406e-b08b-de82de78fe7a
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3161b3a1-c691-4566-aeb8-03eb610ff2ee
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T17:05:38.963133Z","dhcp_enabled":true,"id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T17:05:38.963133Z","id":"b6f618ae-5f6f-4745-acbc-66e1cba782d7","subnet":"172.16.16.0/22","updated_at":"2023-10-18T17:05:38.963133Z"},{"created_at":"2023-10-18T17:05:38.963133Z","id":"385347c4-de12-4c0f-ab0e-d6fc33b70b07","subnet":"fd63:256c:45f7:2b74::/64","updated_at":"2023-10-18T17:05:38.963133Z"}],"tags":[],"updated_at":"2023-10-18T17:05:38.963133Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:05:40.803436Z","dhcp_enabled":true,"id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:05:40.803436Z","id":"593394e2-e265-4d2d-8acd-a46de571baa7","subnet":"172.16.20.0/22","updated_at":"2023-11-07T16:05:40.803436Z"},{"created_at":"2023-11-07T16:05:40.803436Z","id":"f1c14d0f-4e1b-4c61-ac26-67402c6a15ed","subnet":"fd5f:519c:6d46:63f8::/64","updated_at":"2023-11-07T16:05:40.803436Z"}],"tags":[],"updated_at":"2023-11-07T16:05:40.803436Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "719"
+      - "702"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:18 GMT
+      - Tue, 07 Nov 2023 16:11:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3377,7 +3146,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 112ceb70-3080-4fc9-8601-4c7fc8ccb9c0
+      - 1b477b57-194a-459e-80d5-c3ecd581af2b
     status: 200 OK
     code: 200
     duration: ""
@@ -3388,19 +3157,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f82f936-189f-46c3-b063-e7b2af051c79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T17:05:41.115898Z","created_at":"2023-10-18T17:05:41.115898Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f82f936-189f-46c3-b063-e7b2af051c79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f82f936-189f-46c3-b063-e7b2af051c79","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-18T17:07:10.949789Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:06:52.761677Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1500"
+      - "1455"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:18 GMT
+      - Tue, 07 Nov 2023 16:11:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3410,7 +3179,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9bd74f4-adeb-40fc-ad1f-d48b34f4469c
+      - 7abf2383-e84d-4e8d-969e-7ef1f490b5c8
     status: 200 OK
     code: 200
     duration: ""
@@ -3421,19 +3190,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVelRVUlZNRTFzYjFoRVZFMTZUVlJCZUU1NlJUTk5SRlV3VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUMjl4Q2xrNFNIaDRhR3M1UkVreE56TjNZMGd4ZVRnemMzcFhiWFpFZDJ0d2FrOVhVRXhxTDFwa05scEZjSE5FWlRoalpVMVNOVUZYUWxwNVExWjFaRUpXVUhrS1VXWlFUVXRQUTNkRGQwRjFaekJpVldFelIwZE1UREZoVldkWFUwd3dlbkZRY0dsTGRtMUxTRXhtTkV4cVVHcE1VRGxaZUdKTFYyMWFPRGRXVjBVelRncEJRM3B0VTNGQk9VYzJNa1U1UjFGNVJYWkhRbHBJWW1sWksza3lkV0pLVVhWQmJHbFpSMG94ZUZNMVVWbGxhRTFSU25GSFJIQXhSMDg1ZDJSeU5VZHlDbmc1TDJKdmVqQmpPR3Q2TmxoT1NucFZSblJOZUU0NFpEQXZaVlZwUjBNMmFTdHBSMU5GVFU0eWEwUkhjVW8yTW1NMU4yaDJXbk40UTJZek1HUTFVbXNLWjB0NFQwRXpaVWhLVFVwNFQyMXpabEJLUjNoUVFubDJVR1FyU2tkaVJuUlZkME5SVkhkbVluTnFTSGRuSzFOYVJXczRSVkl2U0RsdlJVbHRWa3hyZUFwbFFtazNTMUUwSzIxRmVVWTVNelU0WVZjd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUGJUWTRTbUZsWm1GclZWUm9SMDR2UkhFMVIwNUtWVXBNV1VoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmNFeDBaVnBFWm1veFMyeDVkV3hIV1U5SmJrbDNlRlpDZVhFM1RYQnRZa3gyUVRkeFNFcFNTaTg1YUV4emRWSkpWd3ByUVRaUVVVZHBhemRVYzJGdFQwUlVOU3Q0ZDBRck1rY3daRzB5Vm5KSlkyRkdSVzAyYjJJNVpHeDNiRkJ2WjFwRU1rZFBTVFo1UVVWcVdWZFdiWFpqQ20xeGEweEpaRGR6UkRWb01EbHVURmhoVGt4aFZUbHRZblYyT1d3MGFXbExPVmw0VFcxQk1WQlJUbUptUjBOTGJYbHVPREpoYVVsTU9XMTBiRkFyYUVnS1VIcFZNbVp5TmxkemNTOU9ibEo1VkZOaWIyZ3haVkJ5TmpOV2JGazVkazk2YkROTWVVUnlaMnR1UldnNFFVaHpVVGxvYlRaVUx6aFBXR2xTUzBjNGNRbzRiV2xMVHk5eFprMW5NWFZzZVRJMmNuZFBiV1ZVVmk5TVdITktNbmRCUldJeU5rTndXR3hMZEdWWVYyc3phRGxDVUVSYVlYcG1TMGh2WTNWNWFWbHVDbFZJU1ROdVIzTTNUQzlvWVhaeVF6QkhUVkYwZVdzNFIydFBkbU5vVDJOQk4zQjZVd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNGY4MmY5MzYtMTg5Zi00NmMzLWIwNjMtZTdiMmFmMDUxYzc5LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHVibGljLWlwIgogICAgdXNlcjogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBDT2FQVE5idURiSFpYY3pBbDhKWTN6R29UeTZFeXlWWjNPMkE3YXBpWE1TVm9MclhFaThkdmR5SA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRVUlZNRTB4YjFoRVZFMTZUVlJGZDA1cVJUSk5SRlV3VFRGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURkJUQ2tReEwxcG5TMVF2TW5oT2MyaDVlVVU1YlVWNlQwTktTRGgwUWs4MksyOWxiSEZJU2pSMU1YcDNjRGRLSzFjeWNYQnBNMEprVUhwMFJYSlJkMlpTYXpZS1NWbHBhV00yT0dvNFkzQTFlR2x2T1dGU1FURnRhbmxFWlZGamNXMUJUVzlJT1hwVWVISlJXWE5hVVVablEyUlhZMUpGT0VselYycEtPR3BYYlN0SFNncFVSUzh2VFVaa2N5dDNiblZoU2pFMllrZHdValpxTUZobVJXUkZPVlZoZDFvMk5WVjZjRFF4YUZReVREY3pRVTQ0TkdJck5XUmlVRXB6Wmk5Wk0yaElDa28wYjNWaU1WbFFXa0pXT0ZGTFpsSjNTMGhzU0hVeVlqQlZiak14WjNWbVVsSk9TM0l2WVd0TFNsYzFZVUpCY2pJeU9XZG1VbVJWVkdscFJrOXZTSFFLUzA5V1NGSXJNRmM1YVhkU2JYRmtkMFp6TTNkQ1JrTTRPV3BvWkRSSlFtZFJhME0yYW5WU1JHVTBWRk16VEhjMU1IRkVSM2s0Ym04MVJqaFBVamhXVFFwRlVGWnhRWHB0T0RWUVNtMW1jVlZFWTBKVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaT1kwZEVNbTl6TlZaaGVHNWFVMEptUmtSS09XUjRSbG8zTDNsTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2JVRkpiVWhVV1M5TVdUSmlXREFyVTJSSU0zQXZXVGRqVmtKbk5XWTVkRU0zVERsUlFqSnFlV1o1YVhoUFZGUktWQXB6YlVGTUwzSkhia1pNZVU1d2JsSmlUMmNyVW1STVpDdEZUVlJoVERJNFJuSXZkRXRxU25OU2FGTnRVbTFZVmxWS1NtVllibWxtYjBGMVpUQnhZMVl4Q21Wc2NsRkJReXMxZGtOM2FDOW5lbGhFY2xGVVZtdzVZMk42UVUwMGJGUTJOell6Wm5SbmVFMHJUMDVSSzFwcVoxWlplRlEwZW1WaFMwUlFaWGd2ZUZNS1VIaGxUekJCWldNNVV6aHZiRzlZWkRjcloycGpXWHBKWjFCSk1VSm1VRmhQTmxvMGFWcHBjVVJyU0VVMlZISlZla3RyZGxwaE1XNDNOV3hLUzBoa1l3b3dUMUpHY1VOT01UazRlaTh3VVZkclVWbDRkQzlSVUZaUWRrdE1TbWhqZHpsTVZIWnNOR2RSVXpkR1Z6SlNVV0p5YlhsMlNFVlZabGxIVVRkeldXcE9Da1pKWkUxRU5rMXRhMnBsTURSQ055dDZTbU5ZYVc1b2MyTnFPREZDUW1WQ05qZGxkZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMzlkOWYxNDUtMDJlYS00ZTRlLWE1ZGEtZjE0NjYzMGM2MzJiLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHVibGljLWlwIgogICAgdXNlcjogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpaVEzZlhGSHBDWWI2bUxkdjZkOEVkNnJwd1dTT3c2TmJHWFhPcDRjTWxUY0xaazN4VEx1YTR0MA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2638"
+      - "2636"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:18 GMT
+      - Tue, 07 Nov 2023 16:11:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3443,7 +3212,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97895d42-b1b1-4a26-a019-c04437100939
+      - a2b7afff-ddb1-4e74-8a48-078489093b19
     status: 200 OK
     code: 200
     duration: ""
@@ -3454,19 +3223,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-18T17:12:11.121274Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:11:40.540303Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "613"
+      - "604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:18 GMT
+      - Tue, 07 Nov 2023 16:11:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3476,7 +3245,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b4e1792-894f-423a-ba69-e9b55ebc6b36
+      - bb0534fc-2c50-4c3d-b94a-56f7ccf25b63
     status: 200 OK
     code: 200
     duration: ""
@@ -3487,19 +3256,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79/nodes?order_by=created_at_asc&page=1&pool_id=d38eed5f-356c-45cc-b081-fdca496aa995&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/nodes?order_by=created_at_asc&page=1&pool_id=308c7294-01ad-4afe-9a9c-1feac3e1a142&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T17:07:15.323103Z","error_message":null,"id":"b5cb9457-0865-4b0d-ac1f-b375f9e513d5","name":"scw-test-k8s-public-ip-pool-b5cb945708654b0dac","pool_id":"d38eed5f-356c-45cc-b081-fdca496aa995","provider_id":"scaleway://instance/fr-par-1/ff62c988-07a5-4aa8-bf13-690a11baad87","public_ip_v4":"51.15.143.114","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T17:12:11.109867Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T16:08:28.132162Z","error_message":null,"id":"06c62993-3874-4d90-99f2-3aac9161cce9","name":"scw-test-k8s-public-i-test-k8s-public-i-06c629","pool_id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","provider_id":"scaleway://instance/fr-par-1/be05aa69-3d5f-45ec-8ea4-cd0d3d455712","public_ip_v4":"51.15.215.100","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:11:40.519424Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "658"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:18 GMT
+      - Tue, 07 Nov 2023 16:11:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3509,7 +3278,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 119a83c0-705f-40dc-93d5-51f3d90e71fa
+      - 4c036a62-0f77-41cd-834d-ea5cfc633fbb
     status: 200 OK
     code: 200
     duration: ""
@@ -3520,19 +3289,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d38eed5f-356c-45cc-b081-fdca496aa995
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:05:46.645102Z","id":"d38eed5f-356c-45cc-b081-fdca496aa995","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-10-18T17:12:19.425900905Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608334Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "619"
+      - "610"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:19 GMT
+      - Tue, 07 Nov 2023 16:11:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3542,12 +3311,837 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a5df83a-9ec0-496d-9283-8d298c2dbdab
+      - 455dee2c-3178-45f4-815e-2610b8cc6f2d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"192.168.0.0/22","address":null,"pool_low":null,"pool_high":null,"enable_dynamic":null,"valid_lifetime":null,"renew_timer":null,"rebind_timer":null,"push_default_route":true,"push_dns_server":null,"dns_servers_override":null,"dns_search":null,"dns_local_name":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:11:47 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cc0c4c31-b67a-4d46-973c-fae6350064a4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:11:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 026b8aae-cb2a-42ca-8dec-e4cbb257f630
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:11:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 60516772-523f-4512-89c5-ed5778468c85
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:12:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 88683df0-807e-492b-8ecf-337356b9533f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:12:07 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e0cc5af5-06e6-4a79-aafa-fb3458e563df
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:12:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d5e5f7ab-8743-4c1d-bd0f-e8d103d28ad5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:12:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a42ad51f-ac6d-4d12-915c-66606b12a052
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:12:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ea6e24f4-9e48-4602-bd92-b52527d9e145
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:12:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - af9c3332-f40a-4165-9a30-a9241d9da26f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:12:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 342d6262-a3ed-4974-b47d-af0cd25e1832
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:12:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c9e159cc-9ffd-43de-b0fa-15894f1a474e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:12:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9f81aa7e-3e36-4f41-b4be-b07a6d0d9d45
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:12:48 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 758ae1b4-b28f-452d-a088-a6e104e6c7b0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:12:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5094cbf3-637c-4a0e-b6cb-1ccb6671bba3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:12:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 28ce6e43-4310-4755-981e-83dc128a4a73
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:13:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9ef89433-d3d4-4af4-bb8e-c828d702901b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:13:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - db33fd23-e509-4449-8b8a-4d5374d2a536
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:13:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4e402f52-aa68-4234-a63a-52d48b62bd87
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:13:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e90fcdef-e4da-4cbc-9827-ba117dcfe51e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:13:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cfd4556a-7f3c-41f6-992c-35bdfb2dc264
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:13:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e1428c60-ade5-46b0-b0f4-1fe4618c9d0b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:13:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 25492f8a-912d-45e4-ac04-0da37be1fe47
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:13:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ffab148c-b8b8-43c2-b5ca-9e9dcec84c75
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    method: GET
+  response:
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:05:47.912242Z","id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:11:47.626608Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:13:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 932e750a-9140-49db-a69c-2bd8a9a773ef
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/308c7294-01ad-4afe-9a9c-1feac3e1a142
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"308c7294-01ad-4afe-9a9c-1feac3e1a142","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "125"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:13:48 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e32ca357-3694-4c1f-b9bb-aa4432fe2377
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.0.0/22","push_default_route":true}'
     form: {}
     headers:
       Content-Type:
@@ -3558,16 +4152,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
     method: POST
   response:
-    body: '{"address":"192.168.0.1","created_at":"2023-10-18T17:12:19.486701Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8488fefa-e9b0-4874-9796-d69f72ea632b","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-18T17:12:19.486701Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "586"
+      - "568"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:19 GMT
+      - Tue, 07 Nov 2023 16:13:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3577,7 +4171,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aacc1059-8880-48e7-9bb4-c1a3deda5e18
+      - 4b7f27b7-13d4-4f78-a98c-a42b1d3c3443
     status: 200 OK
     code: 200
     duration: ""
@@ -3588,19 +4182,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/8488fefa-e9b0-4874-9796-d69f72ea632b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/9a11d235-abb0-476b-aefe-580f5054044b
     method: GET
   response:
-    body: '{"address":"192.168.0.1","created_at":"2023-10-18T17:12:19.486701Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8488fefa-e9b0-4874-9796-d69f72ea632b","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-18T17:12:19.486701Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "586"
+      - "568"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:19 GMT
+      - Tue, 07 Nov 2023 16:13:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3610,12 +4204,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f9f3cfa-3f30-41ad-b84b-5a120e164724
+      - fc45b97a-cdb0-4b6b-89f6-7e83f37bbab2
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-k8s-public-ip","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":null,"enable_smtp":false,"enable_bastion":false,"bastion_port":null}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-k8s-public-ip","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"enable_smtp":false,"enable_bastion":false}'
     form: {}
     headers:
       Content-Type:
@@ -3626,16 +4220,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
     method: POST
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-18T17:12:20.078194Z","gateway_networks":[],"id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","ip":{"address":"51.15.224.248","created_at":"2023-10-18T17:12:20.064132Z","gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","id":"349cc528-45f1-4aac-a1ad-65ea6a66aa50","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"248-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-18T17:12:20.064132Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-18T17:12:20.078194Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:13:49.690251Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "981"
+      - "954"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:20 GMT
+      - Tue, 07 Nov 2023 16:13:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3645,7 +4239,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a925546d-bceb-4a97-8e6d-5b8913e8eded
+      - 709dc931-5ad1-4368-9884-8c38ecc176b9
     status: 200 OK
     code: 200
     duration: ""
@@ -3656,19 +4250,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/5b346518-375f-4ecb-95ec-0e48b3b50d54
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-18T17:12:20.078194Z","gateway_networks":[],"id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","ip":{"address":"51.15.224.248","created_at":"2023-10-18T17:12:20.064132Z","gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","id":"349cc528-45f1-4aac-a1ad-65ea6a66aa50","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"248-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-18T17:12:20.064132Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-18T17:12:20.111352Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:13:49.753152Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "984"
+      - "957"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:20 GMT
+      - Tue, 07 Nov 2023 16:13:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3678,7 +4272,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5aa75e88-e8f9-42a9-9bf0-b8a3a2b7eadb
+      - a462b85e-2fb4-4a73-ad94-f8ed62788622
     status: 200 OK
     code: 200
     duration: ""
@@ -3689,19 +4283,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/5b346518-375f-4ecb-95ec-0e48b3b50d54
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-18T17:12:20.078194Z","gateway_networks":[],"id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","ip":{"address":"51.15.224.248","created_at":"2023-10-18T17:12:20.064132Z","gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","id":"349cc528-45f1-4aac-a1ad-65ea6a66aa50","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"248-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-18T17:12:20.064132Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-18T17:12:20.729258Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:13:50.334905Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "981"
+      - "954"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:25 GMT
+      - Tue, 07 Nov 2023 16:13:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3711,7 +4305,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1527b41a-9f70-42bb-9638-7017bdbb8ff7
+      - 765c4aeb-e703-4034-b86a-665e0f9dd99f
     status: 200 OK
     code: 200
     duration: ""
@@ -3722,19 +4316,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/5b346518-375f-4ecb-95ec-0e48b3b50d54
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-18T17:12:20.078194Z","gateway_networks":[],"id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","ip":{"address":"51.15.224.248","created_at":"2023-10-18T17:12:20.064132Z","gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","id":"349cc528-45f1-4aac-a1ad-65ea6a66aa50","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"248-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-18T17:12:20.064132Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-18T17:12:20.729258Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:13:50.334905Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "981"
+      - "954"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:25 GMT
+      - Tue, 07 Nov 2023 16:13:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3744,7 +4338,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9886ca2b-bc2e-47ed-9567-2341321ec4a4
+      - 355b0973-863f-47b6-b239-87611d15851a
     status: 200 OK
     code: 200
     duration: ""
@@ -3755,19 +4349,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/5b346518-375f-4ecb-95ec-0e48b3b50d54
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-18T17:12:20.078194Z","gateway_networks":[],"id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","ip":{"address":"51.15.224.248","created_at":"2023-10-18T17:12:20.064132Z","gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","id":"349cc528-45f1-4aac-a1ad-65ea6a66aa50","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"248-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-18T17:12:20.064132Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-18T17:12:20.729258Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":false,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:13:50.334905Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "981"
+      - "954"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:25 GMT
+      - Tue, 07 Nov 2023 16:13:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3777,12 +4371,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c4407a3-1b0c-4c65-b73a-fc0733bdf35d
+      - f27884e0-f075-4e22-b083-6009c5ab623f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"8488fefa-e9b0-4874-9796-d69f72ea632b"}'
+    body: '{"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"9a11d235-abb0-476b-aefe-580f5054044b"}'
     form: {}
     headers:
       Content-Type:
@@ -3793,16 +4387,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
     method: POST
   response:
-    body: '{"address":null,"created_at":"2023-10-18T17:12:26.924175Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-18T17:12:19.486701Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8488fefa-e9b0-4874-9796-d69f72ea632b","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-18T17:12:19.486701Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","id":"9bec2bc2-3cd3-475d-aa88-056cc9a6d7a4","ipam_config":null,"mac_address":null,"private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","status":"created","updated_at":"2023-10-18T17:12:26.924175Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":null,"private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"created","updated_at":"2023-11-07T16:13:55.899920Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "983"
+      - "953"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:27 GMT
+      - Tue, 07 Nov 2023 16:13:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3812,7 +4406,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 389ba295-d07c-43d3-bd37-caf97fcca45b
+      - 76700c43-ee3c-486c-8dce-48c4269280f5
     status: 200 OK
     code: 200
     duration: ""
@@ -3823,19 +4417,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/5b346518-375f-4ecb-95ec-0e48b3b50d54
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-18T17:12:20.078194Z","gateway_networks":[{"address":null,"created_at":"2023-10-18T17:12:26.924175Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-18T17:12:19.486701Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8488fefa-e9b0-4874-9796-d69f72ea632b","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-18T17:12:19.486701Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","id":"9bec2bc2-3cd3-475d-aa88-056cc9a6d7a4","ipam_config":null,"mac_address":null,"private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","status":"created","updated_at":"2023-10-18T17:12:26.924175Z","zone":"fr-par-1"}],"id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","ip":{"address":"51.15.224.248","created_at":"2023-10-18T17:12:20.064132Z","gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","id":"349cc528-45f1-4aac-a1ad-65ea6a66aa50","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"248-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-18T17:12:20.064132Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-18T17:12:27.089433Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":null,"private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"created","updated_at":"2023-11-07T16:13:55.899920Z","zone":"fr-par-1"}],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:13:56.085179Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1967"
+      - "1910"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:27 GMT
+      - Tue, 07 Nov 2023 16:13:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3845,7 +4439,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c40f57ae-c023-43d1-b1df-81e2948fb97d
+      - 52a8a573-c63b-45ce-9b7f-60dae99b5af9
     status: 200 OK
     code: 200
     duration: ""
@@ -3856,19 +4450,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/5b346518-375f-4ecb-95ec-0e48b3b50d54
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-18T17:12:20.078194Z","gateway_networks":[{"address":null,"created_at":"2023-10-18T17:12:26.924175Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-18T17:12:19.486701Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8488fefa-e9b0-4874-9796-d69f72ea632b","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-18T17:12:19.486701Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","id":"9bec2bc2-3cd3-475d-aa88-056cc9a6d7a4","ipam_config":null,"mac_address":"02:00:00:14:4D:5A","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","status":"ready","updated_at":"2023-10-18T17:12:29.107374Z","zone":"fr-par-1"}],"id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","ip":{"address":"51.15.224.248","created_at":"2023-10-18T17:12:20.064132Z","gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","id":"349cc528-45f1-4aac-a1ad-65ea6a66aa50","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"248-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-18T17:12:20.064132Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-18T17:12:29.202280Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":"02:00:00:14:A4:17","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"ready","updated_at":"2023-11-07T16:14:00.919968Z","zone":"fr-par-1"}],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:14:01.031794Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1976"
+      - "1919"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:32 GMT
+      - Tue, 07 Nov 2023 16:14:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3878,7 +4472,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9d17481-3a1c-4416-8eea-41bee71d720b
+      - 4dfe645c-e944-4223-90be-d5055f8e3c5e
     status: 200 OK
     code: 200
     duration: ""
@@ -3889,19 +4483,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/9bec2bc2-3cd3-475d-aa88-056cc9a6d7a4
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cb4961bb-038a-4b42-842b-4cf377d6b06f
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-18T17:12:26.924175Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-18T17:12:19.486701Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8488fefa-e9b0-4874-9796-d69f72ea632b","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-18T17:12:19.486701Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","id":"9bec2bc2-3cd3-475d-aa88-056cc9a6d7a4","ipam_config":null,"mac_address":"02:00:00:14:4D:5A","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","status":"ready","updated_at":"2023-10-18T17:12:29.107374Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":"02:00:00:14:A4:17","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"ready","updated_at":"2023-11-07T16:14:00.919968Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "996"
+      - "966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:32 GMT
+      - Tue, 07 Nov 2023 16:14:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3911,7 +4505,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb9af5a8-100b-4b8b-b677-b832c633d0c7
+      - 45554bad-bd6d-4cb5-89bd-aab256fce6fb
     status: 200 OK
     code: 200
     duration: ""
@@ -3922,19 +4516,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/9bec2bc2-3cd3-475d-aa88-056cc9a6d7a4
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cb4961bb-038a-4b42-842b-4cf377d6b06f
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-18T17:12:26.924175Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-18T17:12:19.486701Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8488fefa-e9b0-4874-9796-d69f72ea632b","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-18T17:12:19.486701Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","id":"9bec2bc2-3cd3-475d-aa88-056cc9a6d7a4","ipam_config":null,"mac_address":"02:00:00:14:4D:5A","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","status":"ready","updated_at":"2023-10-18T17:12:29.107374Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":"02:00:00:14:A4:17","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"ready","updated_at":"2023-11-07T16:14:00.919968Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "996"
+      - "966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:32 GMT
+      - Tue, 07 Nov 2023 16:14:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3944,7 +4538,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0b481cf8-5a35-474a-bc0e-324a8534d9b4
+      - c18d0ff2-a66c-407a-99cb-2184dc2a0e32
     status: 200 OK
     code: 200
     duration: ""
@@ -3955,19 +4549,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/5b346518-375f-4ecb-95ec-0e48b3b50d54
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-18T17:12:20.078194Z","gateway_networks":[{"address":null,"created_at":"2023-10-18T17:12:26.924175Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-18T17:12:19.486701Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8488fefa-e9b0-4874-9796-d69f72ea632b","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-18T17:12:19.486701Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","id":"9bec2bc2-3cd3-475d-aa88-056cc9a6d7a4","ipam_config":null,"mac_address":"02:00:00:14:4D:5A","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","status":"ready","updated_at":"2023-10-18T17:12:29.107374Z","zone":"fr-par-1"}],"id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","ip":{"address":"51.15.224.248","created_at":"2023-10-18T17:12:20.064132Z","gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","id":"349cc528-45f1-4aac-a1ad-65ea6a66aa50","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"248-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-18T17:12:20.064132Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-18T17:12:29.202280Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":"02:00:00:14:A4:17","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"ready","updated_at":"2023-11-07T16:14:00.919968Z","zone":"fr-par-1"}],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:14:01.031794Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1976"
+      - "1919"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:32 GMT
+      - Tue, 07 Nov 2023 16:14:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3977,7 +4571,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1cc95bec-b707-4af4-add3-fde2da3a2c81
+      - 382e7b44-01bf-462b-8983-e04115259661
     status: 200 OK
     code: 200
     duration: ""
@@ -3988,19 +4582,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/9bec2bc2-3cd3-475d-aa88-056cc9a6d7a4
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cb4961bb-038a-4b42-842b-4cf377d6b06f
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-18T17:12:26.924175Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-18T17:12:19.486701Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8488fefa-e9b0-4874-9796-d69f72ea632b","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-18T17:12:19.486701Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","id":"9bec2bc2-3cd3-475d-aa88-056cc9a6d7a4","ipam_config":null,"mac_address":"02:00:00:14:4D:5A","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","status":"ready","updated_at":"2023-10-18T17:12:29.107374Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":"02:00:00:14:A4:17","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"ready","updated_at":"2023-11-07T16:14:00.919968Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "996"
+      - "966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:32 GMT
+      - Tue, 07 Nov 2023 16:14:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4010,7 +4604,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85f4e1f6-34c6-49d2-923d-f58dfcb1f075
+      - d8ec3766-1e6f-4729-9ea5-ae7ce2410462
     status: 200 OK
     code: 200
     duration: ""
@@ -4021,19 +4615,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f82f936-189f-46c3-b063-e7b2af051c79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T17:05:41.115898Z","created_at":"2023-10-18T17:05:41.115898Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f82f936-189f-46c3-b063-e7b2af051c79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f82f936-189f-46c3-b063-e7b2af051c79","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-18T17:07:10.949789Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:13:47.945248Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1500"
+      - "1463"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:32 GMT
+      - Tue, 07 Nov 2023 16:14:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4043,12 +4637,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e16614d-95b3-4897-a9ee-b4c6073691a2
+      - 764433b8-6f2e-4871-ae7f-d7bf5a75630d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"pool","node_type":"gp1_xs","placement_group_id":null,"autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":null,"kubelet_args":{},"upgrade_policy":null,"zone":"fr-par-1","root_volume_type":"default_volume_type","root_volume_size":null,"public_ip_disabled":true}'
+    body: '{"name":"test-k8s-public-ip","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":null,"kubelet_args":{},"zone":"fr-par-1","root_volume_type":"default_volume_type","public_ip_disabled":true}'
     form: {}
     headers:
       Content-Type:
@@ -4056,19 +4650,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869213Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695285623Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "617"
+      - "608"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:32 GMT
+      - Tue, 07 Nov 2023 16:14:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4078,7 +4672,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c5dc916-792e-49b1-96ee-c50c94a30150
+      - 5f8797c5-9cd1-4aeb-aa8c-8f0b4854ce05
     status: 200 OK
     code: 200
     duration: ""
@@ -4089,19 +4683,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:33 GMT
+      - Tue, 07 Nov 2023 16:14:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4111,7 +4705,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ecab1b8e-2103-4beb-806f-d8c9cb84337b
+      - 064d2ce0-e491-46f7-9cec-5d14855a92b4
     status: 200 OK
     code: 200
     duration: ""
@@ -4122,19 +4716,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:38 GMT
+      - Tue, 07 Nov 2023 16:14:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4144,7 +4738,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c89bf176-c2f3-4aaf-a7a5-cf614f76dc2d
+      - 175feaf0-bc8d-4193-a254-aeabbf8546ed
     status: 200 OK
     code: 200
     duration: ""
@@ -4155,19 +4749,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:43 GMT
+      - Tue, 07 Nov 2023 16:14:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4177,7 +4771,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea2f4587-3031-4f76-aa54-e3b47f5e3300
+      - 1eff3741-d2d2-4a43-96bc-03aee58a75e9
     status: 200 OK
     code: 200
     duration: ""
@@ -4188,19 +4782,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:48 GMT
+      - Tue, 07 Nov 2023 16:14:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4210,7 +4804,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94dbf180-f00a-4be5-9ce4-7a05f77d7979
+      - b6913305-25f7-4fdc-bb6b-d25006333dcf
     status: 200 OK
     code: 200
     duration: ""
@@ -4221,19 +4815,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:53 GMT
+      - Tue, 07 Nov 2023 16:14:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4243,7 +4837,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a691035-c2a1-471e-bf32-bafbe93252db
+      - ee9bc802-ec52-4353-af86-db03594512d9
     status: 200 OK
     code: 200
     duration: ""
@@ -4254,19 +4848,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:12:58 GMT
+      - Tue, 07 Nov 2023 16:14:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4276,7 +4870,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6cf7dc2-cabe-41da-a8f3-b2e4e02a1b59
+      - 9d64331b-712a-4bcf-b42d-a11ccfa20219
     status: 200 OK
     code: 200
     duration: ""
@@ -4287,19 +4881,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:13:03 GMT
+      - Tue, 07 Nov 2023 16:14:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4309,7 +4903,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f317ae1-8b1e-4b7a-8438-6b89aa39f43f
+      - 25fb2df8-2d92-4b09-8e2c-ec93703d6080
     status: 200 OK
     code: 200
     duration: ""
@@ -4320,19 +4914,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:13:08 GMT
+      - Tue, 07 Nov 2023 16:14:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4342,7 +4936,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1c766c6-f220-4d00-b532-adc67198b10b
+      - a43ceaef-37a6-4df6-a2ed-96c48b174109
     status: 200 OK
     code: 200
     duration: ""
@@ -4353,19 +4947,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:13:13 GMT
+      - Tue, 07 Nov 2023 16:14:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4375,7 +4969,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ad45174-0cfe-4b39-b978-c1ed41aa8e11
+      - 5e0d7614-0ea0-4442-b12b-3a70f9d26896
     status: 200 OK
     code: 200
     duration: ""
@@ -4386,19 +4980,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:13:18 GMT
+      - Tue, 07 Nov 2023 16:14:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4408,7 +5002,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f140897-04d5-425c-8daa-464a00cae0e8
+      - ef011e27-7093-440f-af26-d6ecc4d62cd8
     status: 200 OK
     code: 200
     duration: ""
@@ -4419,19 +5013,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:13:23 GMT
+      - Tue, 07 Nov 2023 16:14:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4441,7 +5035,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21108486-d457-47d1-aa03-8d7a680e398d
+      - 1d352f80-97d0-4da5-afeb-47198d115008
     status: 200 OK
     code: 200
     duration: ""
@@ -4452,19 +5046,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:13:28 GMT
+      - Tue, 07 Nov 2023 16:14:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4474,7 +5068,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77e8bf52-2573-4d1c-9fa2-eb00868d9843
+      - 43aa6c45-1525-42b6-9188-36fcc3159974
     status: 200 OK
     code: 200
     duration: ""
@@ -4485,19 +5079,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:13:33 GMT
+      - Tue, 07 Nov 2023 16:15:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4507,7 +5101,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 055e06b3-c700-4bed-bd58-ddee8c7a9f17
+      - c7df9f74-64d4-4e1c-b21a-e0b04f1d06b7
     status: 200 OK
     code: 200
     duration: ""
@@ -4518,19 +5112,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:13:38 GMT
+      - Tue, 07 Nov 2023 16:15:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4540,7 +5134,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40da6b0e-9e0e-4763-ad7d-a327711ed937
+      - 58318f47-3248-4090-9c6b-2f29b29d3d0a
     status: 200 OK
     code: 200
     duration: ""
@@ -4551,19 +5145,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:13:43 GMT
+      - Tue, 07 Nov 2023 16:15:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4573,7 +5167,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb538e7e-7599-4266-9f12-4b01311daed0
+      - 47880554-0f62-43f8-9d6f-8fc0a3957da2
     status: 200 OK
     code: 200
     duration: ""
@@ -4584,19 +5178,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:13:48 GMT
+      - Tue, 07 Nov 2023 16:15:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4606,7 +5200,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c47bea5-b68b-4dc0-9603-203a89c42316
+      - ce208224-b387-471d-b5db-7cf28745e116
     status: 200 OK
     code: 200
     duration: ""
@@ -4617,19 +5211,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:13:53 GMT
+      - Tue, 07 Nov 2023 16:15:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4639,7 +5233,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8fbe6f09-2814-4f6a-bbf6-82e8d2c799db
+      - f62ade79-265b-43a0-90c8-d9e216f7f324
     status: 200 OK
     code: 200
     duration: ""
@@ -4650,19 +5244,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:13:58 GMT
+      - Tue, 07 Nov 2023 16:15:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4672,7 +5266,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8afef93c-b16b-466a-bcdb-ebf2d52e519c
+      - 710d5149-4792-4723-9290-7ffdf703de12
     status: 200 OK
     code: 200
     duration: ""
@@ -4683,19 +5277,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:14:03 GMT
+      - Tue, 07 Nov 2023 16:15:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4705,7 +5299,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f586d08-30dc-44a4-a4ff-be62f7aebe94
+      - 1282e51e-d9f5-4653-bcc6-641e017baba5
     status: 200 OK
     code: 200
     duration: ""
@@ -4716,19 +5310,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:14:08 GMT
+      - Tue, 07 Nov 2023 16:15:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4738,7 +5332,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83827ead-1265-4fb9-b04f-eea445d53c36
+      - ffd5d852-d47c-42f9-a6a7-fed45b8c11ea
     status: 200 OK
     code: 200
     duration: ""
@@ -4749,19 +5343,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:14:14 GMT
+      - Tue, 07 Nov 2023 16:15:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4771,7 +5365,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2140adef-97fa-4626-a8ff-6a6e246d312c
+      - f12d7dc8-1ebf-417f-bdcb-4963d86ac9ed
     status: 200 OK
     code: 200
     duration: ""
@@ -4782,19 +5376,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:14:19 GMT
+      - Tue, 07 Nov 2023 16:15:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4804,7 +5398,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0be8770-ff65-499f-b5a5-b834ff2963e2
+      - f50be189-78f9-47b2-a7b9-0feea196e819
     status: 200 OK
     code: 200
     duration: ""
@@ -4815,19 +5409,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:14:24 GMT
+      - Tue, 07 Nov 2023 16:15:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4837,7 +5431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0543178f-7825-4479-8962-87511da385aa
+      - 08c60956-f824-46b3-878a-04a96c3e2be9
     status: 200 OK
     code: 200
     duration: ""
@@ -4848,19 +5442,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:14:29 GMT
+      - Tue, 07 Nov 2023 16:15:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4870,7 +5464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19171739-f107-41ad-8514-cc5bfecfc144
+      - 694fa839-c80f-4331-832a-ad129b1459a3
     status: 200 OK
     code: 200
     duration: ""
@@ -4881,19 +5475,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:14:34 GMT
+      - Tue, 07 Nov 2023 16:16:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4903,7 +5497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec42f665-0f9a-49f8-a360-6f48540bb52d
+      - d567da5b-3d09-481c-bd3a-9995f5037558
     status: 200 OK
     code: 200
     duration: ""
@@ -4914,19 +5508,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:14:39 GMT
+      - Tue, 07 Nov 2023 16:16:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4936,7 +5530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7390cf8-09ad-4140-85cb-9683af5daf9a
+      - 05c0f23b-fcdc-4f94-942a-6a3fc8674a16
     status: 200 OK
     code: 200
     duration: ""
@@ -4947,19 +5541,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:14:44 GMT
+      - Tue, 07 Nov 2023 16:16:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4969,7 +5563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82458e3d-bb8c-4df0-9545-9c4b2c7bc004
+      - 97974cab-abc2-4e02-8d0f-a6654f2dbb72
     status: 200 OK
     code: 200
     duration: ""
@@ -4980,19 +5574,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:14:49 GMT
+      - Tue, 07 Nov 2023 16:16:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5002,7 +5596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2197de5f-07f1-4bbe-b060-a921c946ab03
+      - af070591-4b74-4af8-8cf6-f84a58141b22
     status: 200 OK
     code: 200
     duration: ""
@@ -5013,19 +5607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:14:54 GMT
+      - Tue, 07 Nov 2023 16:16:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5035,7 +5629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e13ecc19-c094-49da-ae0b-4f15fe1005cf
+      - dab8e9e1-42f2-4af5-bb97-b07e4797f0ff
     status: 200 OK
     code: 200
     duration: ""
@@ -5046,19 +5640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:15:00 GMT
+      - Tue, 07 Nov 2023 16:16:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5068,7 +5662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a476d6d-0918-42ab-9f7e-3853282869e2
+      - b52f78fe-9b31-4d19-bf52-0b9590dd7a00
     status: 200 OK
     code: 200
     duration: ""
@@ -5079,19 +5673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:15:05 GMT
+      - Tue, 07 Nov 2023 16:16:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5101,7 +5695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea9c4fa9-7e3e-4219-bdcf-4895453f72de
+      - d6c28754-7f85-403a-82b2-ae0eeffb3d4e
     status: 200 OK
     code: 200
     duration: ""
@@ -5112,19 +5706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:15:10 GMT
+      - Tue, 07 Nov 2023 16:16:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5134,7 +5728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ea7e0d2-e68c-4041-bf66-a188690f0341
+      - a097c6e6-6c05-432f-b236-35e67fec009e
     status: 200 OK
     code: 200
     duration: ""
@@ -5145,19 +5739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:15:15 GMT
+      - Tue, 07 Nov 2023 16:16:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5167,7 +5761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - acd1d320-b394-490d-9172-09c05d765904
+      - 8804848f-0abe-404a-91b5-6c842117b929
     status: 200 OK
     code: 200
     duration: ""
@@ -5178,19 +5772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:15:20 GMT
+      - Tue, 07 Nov 2023 16:16:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5200,7 +5794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14b345a1-febe-453d-b1cd-988f22cf2106
+      - b74f4834-2938-413d-a8d5-9de8ea10a74f
     status: 200 OK
     code: 200
     duration: ""
@@ -5211,19 +5805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:15:25 GMT
+      - Tue, 07 Nov 2023 16:16:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5233,7 +5827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7870ba94-6952-4b27-993f-949bc53a250a
+      - 5b68fa0d-df8e-483b-aa6c-29878d16fda3
     status: 200 OK
     code: 200
     duration: ""
@@ -5244,19 +5838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:15:30 GMT
+      - Tue, 07 Nov 2023 16:16:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5266,7 +5860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc5b84c3-a744-4696-b9e7-5be535948ff8
+      - f490686e-c0bb-432c-a46a-3f62a8031c9e
     status: 200 OK
     code: 200
     duration: ""
@@ -5277,19 +5871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:15:35 GMT
+      - Tue, 07 Nov 2023 16:17:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5299,7 +5893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4b483bd-495c-4827-bb5d-956302193e7e
+      - 37ad37dd-c281-4c7b-879c-a1eb77bfb4c3
     status: 200 OK
     code: 200
     duration: ""
@@ -5310,19 +5904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:15:40 GMT
+      - Tue, 07 Nov 2023 16:17:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5332,7 +5926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9219619-2761-477b-b365-9f1071aa924d
+      - b8b8f9a5-e91b-4baf-8f12-1c51ba7f06b6
     status: 200 OK
     code: 200
     duration: ""
@@ -5343,19 +5937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:15:45 GMT
+      - Tue, 07 Nov 2023 16:17:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5365,7 +5959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08f3d1a0-31a9-404c-97e2-3d43006eaee8
+      - 402bc26d-4d42-472c-be15-96c280e6590a
     status: 200 OK
     code: 200
     duration: ""
@@ -5376,19 +5970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:15:50 GMT
+      - Tue, 07 Nov 2023 16:17:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5398,7 +5992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b47840b4-6d84-44c9-9e64-34f9be83d4b2
+      - d3807173-088f-4363-928e-8b0f5a918fa6
     status: 200 OK
     code: 200
     duration: ""
@@ -5409,19 +6003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:15:55 GMT
+      - Tue, 07 Nov 2023 16:17:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5431,7 +6025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4aa5c32-3c16-4b7e-a730-30e6d1fecab9
+      - a2f9ea8a-3d93-41de-a119-b5a03f7cb59e
     status: 200 OK
     code: 200
     duration: ""
@@ -5442,19 +6036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:16:00 GMT
+      - Tue, 07 Nov 2023 16:17:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5464,7 +6058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e9b8ce1-27a0-420f-ba4a-7fe40cdf64a4
+      - c811b67c-f87f-4e99-8a81-0d93ddfef7d3
     status: 200 OK
     code: 200
     duration: ""
@@ -5475,19 +6069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:16:05 GMT
+      - Tue, 07 Nov 2023 16:17:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5497,7 +6091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0c0ec9c-5e83-489f-9591-18eaf2db846a
+      - 0b1ec5a8-5bbb-4922-8894-3078b516785a
     status: 200 OK
     code: 200
     duration: ""
@@ -5508,19 +6102,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:16:10 GMT
+      - Tue, 07 Nov 2023 16:17:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5530,7 +6124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 532c3050-be47-491e-bed7-3aa1f4b3f673
+      - c224bf9b-16a9-4121-a78b-121a644df834
     status: 200 OK
     code: 200
     duration: ""
@@ -5541,19 +6135,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:16:15 GMT
+      - Tue, 07 Nov 2023 16:17:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5563,7 +6157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6049e239-15f7-48cb-a70e-8c9ba2124153
+      - d4a8e6d0-d45f-4c1b-bcc7-62b9462a9451
     status: 200 OK
     code: 200
     duration: ""
@@ -5574,19 +6168,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:16:20 GMT
+      - Tue, 07 Nov 2023 16:17:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5596,7 +6190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76efb682-448f-4266-ad41-bef6e2d123b9
+      - 35b390c8-8016-48fc-94e4-7b2aac3f5b5e
     status: 200 OK
     code: 200
     duration: ""
@@ -5607,19 +6201,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:16:25 GMT
+      - Tue, 07 Nov 2023 16:17:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5629,7 +6223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c32a7c6-c4c4-450f-a541-61a93354bb55
+      - 4f3ea37c-ce7f-4403-b3b1-4bb3e13afe43
     status: 200 OK
     code: 200
     duration: ""
@@ -5640,19 +6234,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:16:31 GMT
+      - Tue, 07 Nov 2023 16:17:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5662,7 +6256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f30a7a62-3e0f-4d43-aaf5-ce4b1aed7e60
+      - 78c837f6-d8f9-43a2-8689-ab13c7e6d8a1
     status: 200 OK
     code: 200
     duration: ""
@@ -5673,19 +6267,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:16:36 GMT
+      - Tue, 07 Nov 2023 16:18:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5695,7 +6289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bae933dc-357b-49e8-8133-0d241e5dda09
+      - 1c63480b-2520-413c-aece-0ec563bf9f98
     status: 200 OK
     code: 200
     duration: ""
@@ -5706,19 +6300,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:16:41 GMT
+      - Tue, 07 Nov 2023 16:18:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5728,7 +6322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 667ee9fd-ef52-4a9f-903c-33bc43186d7a
+      - ab294d31-c3c2-4624-b65a-4105051f5575
     status: 200 OK
     code: 200
     duration: ""
@@ -5739,19 +6333,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:16:46 GMT
+      - Tue, 07 Nov 2023 16:18:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5761,7 +6355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b76704e9-ad2f-439c-8b2d-4d0992afa456
+      - 5f52bf23-e617-435f-bfda-f2eb1ac804bf
     status: 200 OK
     code: 200
     duration: ""
@@ -5772,19 +6366,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:16:51 GMT
+      - Tue, 07 Nov 2023 16:18:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5794,7 +6388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef880fe5-28bb-453e-a321-66ea6a18ed16
+      - 3454b135-382f-4ec0-aacf-062a6f687ac3
     status: 200 OK
     code: 200
     duration: ""
@@ -5805,19 +6399,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:14:01.695286Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:16:56 GMT
+      - Tue, 07 Nov 2023 16:18:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5827,7 +6421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7182e96c-ef86-4364-91ea-1992353691de
+      - 75dd730d-9d14-4875-b0d4-3a01e762b370
     status: 200 OK
     code: 200
     duration: ""
@@ -5838,19 +6432,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:18:26.750409Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:17:01 GMT
+      - Tue, 07 Nov 2023 16:18:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5860,7 +6454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e589253-2f98-4c03-8ed0-546882d8e6bd
+      - d3e2a663-36cd-4456-a99a-1a4566b2c657
     status: 200 OK
     code: 200
     duration: ""
@@ -5871,19 +6465,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:15:32.328838Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "614"
+      - "1455"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:17:06 GMT
+      - Tue, 07 Nov 2023 16:18:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5893,7 +6487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35759bab-1d31-48fe-b2c0-4c652230329e
+      - 80afccbe-45b7-41bd-8464-7a3e4f031d2f
     status: 200 OK
     code: 200
     duration: ""
@@ -5904,19 +6498,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:18:26.750409Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:17:11 GMT
+      - Tue, 07 Nov 2023 16:18:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5926,7 +6520,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0e8d7d3-075d-4af4-9e35-72cc23b607d1
+      - e3ded353-ec94-4ced-9031-8f65cdba1766
     status: 200 OK
     code: 200
     duration: ""
@@ -5937,19 +6531,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/nodes?order_by=created_at_asc&page=1&pool_id=1eac1bd9-8533-4d1b-b549-a1ef95831940&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T16:15:34.157632Z","error_message":null,"id":"6009f374-7e80-461a-9638-aa60ee66dba9","name":"scw-test-k8s-public-i-test-k8s-public-i-6009f3","pool_id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","provider_id":"scaleway://instance/fr-par-1/038043dc-93d2-40f9-8b0e-690d1f35ebbe","public_ip_v4":"","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:18:26.736312Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "614"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:17:16 GMT
+      - Tue, 07 Nov 2023 16:18:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5959,7 +6553,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e268288a-a5a6-4d69-a5bc-62668e7b27db
+      - 6bbb0a69-dae3-4d20-9648-ba946ac37b2b
     status: 200 OK
     code: 200
     duration: ""
@@ -5970,19 +6564,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:15:32.328838Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "614"
+      - "1455"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:17:21 GMT
+      - Tue, 07 Nov 2023 16:18:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5992,7 +6586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf4b3f0e-5d43-452c-b688-045a3fde4cc0
+      - 6c9041f5-a13a-446e-9348-4cf80fafe946
     status: 200 OK
     code: 200
     duration: ""
@@ -6003,19 +6597,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3161b3a1-c691-4566-aeb8-03eb610ff2ee
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-07T16:05:40.803436Z","dhcp_enabled":true,"id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:05:40.803436Z","id":"593394e2-e265-4d2d-8acd-a46de571baa7","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:55.400175Z"},{"created_at":"2023-11-07T16:05:40.803436Z","id":"f1c14d0f-4e1b-4c61-ac26-67402c6a15ed","subnet":"fd5f:519c:6d46:63f8::/64","updated_at":"2023-11-07T16:13:55.403852Z"}],"tags":[],"updated_at":"2023-11-07T16:13:57.844907Z","vpc_id":"733d8205-e6f3-4481-abc1-d3d8760a8139"}'
     headers:
       Content-Length:
-      - "614"
+      - "702"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:17:26 GMT
+      - Tue, 07 Nov 2023 16:18:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6025,7 +6619,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a864f2c-953e-439b-a281-af9de797919f
+      - d305caad-42b9-4b76-b5f8-aa7477ba8999
     status: 200 OK
     code: 200
     duration: ""
@@ -6036,19 +6630,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T17:12:32.693869Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:18:26.750409Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "614"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:17:31 GMT
+      - Tue, 07 Nov 2023 16:18:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6058,7 +6652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16497050-c5eb-43f7-9ee9-8fd4dd4d33e1
+      - 36770158-45d7-4497-a434-ad8ee862e198
     status: 200 OK
     code: 200
     duration: ""
@@ -6069,19 +6663,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/nodes?order_by=created_at_asc&pool_id=1eac1bd9-8533-4d1b-b549-a1ef95831940&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-18T17:17:33.680749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T16:15:34.157632Z","error_message":null,"id":"6009f374-7e80-461a-9638-aa60ee66dba9","name":"scw-test-k8s-public-i-test-k8s-public-i-6009f3","pool_id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","provider_id":"scaleway://instance/fr-par-1/038043dc-93d2-40f9-8b0e-690d1f35ebbe","public_ip_v4":"","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:18:26.736312Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "612"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:17:36 GMT
+      - Tue, 07 Nov 2023 16:18:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6091,7 +6685,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f4d8237-ff27-4cb7-a5fc-d06a4f4b3e35
+      - 4f33bd29-2ba8-4223-bf7c-5698e41beff0
     status: 200 OK
     code: 200
     duration: ""
@@ -6102,221 +6696,23 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-18T17:17:33.680749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "612"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 17:17:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 84b39ebc-3d99-4cbc-aefa-b499f633c4ed
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79/nodes?order_by=created_at_asc&page=1&pool_id=6b6234af-3545-4aa1-b11f-ef98a2b77e67&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T17:12:33.325563Z","error_message":null,"id":"62415402-e0fd-4809-9d91-f229848ec235","name":"scw-test-k8s-public-ip-pool-62415402e0fd48099d","pool_id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","provider_id":"scaleway://instance/fr-par-1/dc1ad339-95cd-4a89-9f88-c5d55cfb30ba","public_ip_v4":"","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T17:17:33.664899Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "645"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 17:17:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 88f0975d-0bfd-4f33-bdc6-acfbc2addade
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f82f936-189f-46c3-b063-e7b2af051c79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T17:05:41.115898Z","created_at":"2023-10-18T17:05:41.115898Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f82f936-189f-46c3-b063-e7b2af051c79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f82f936-189f-46c3-b063-e7b2af051c79","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-18T17:07:10.949789Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1500"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 17:17:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2c70d459-199a-4c07-bb36-790d9a53f04c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b27b50b7-86ff-406e-b08b-de82de78fe7a
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-18T17:05:38.963133Z","dhcp_enabled":true,"id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T17:05:38.963133Z","id":"b6f618ae-5f6f-4745-acbc-66e1cba782d7","subnet":"192.168.0.0/22","updated_at":"2023-10-18T17:12:25.636357Z"},{"created_at":"2023-10-18T17:05:38.963133Z","id":"385347c4-de12-4c0f-ab0e-d6fc33b70b07","subnet":"fd63:256c:45f7:2b74::/64","updated_at":"2023-10-18T17:12:25.643032Z"}],"tags":[],"updated_at":"2023-10-18T17:12:28.761724Z","vpc_id":"3f025108-2715-4c51-98eb-61df2d52ec49"}'
-    headers:
-      Content-Length:
-      - "719"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 17:17:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1d0ddbf6-ff13-400a-b100-46ee0e40842e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-18T17:17:33.680749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "612"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 17:17:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5701a659-3596-4f1c-a01f-bae79c3edf9d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79/nodes?order_by=created_at_asc&pool_id=6b6234af-3545-4aa1-b11f-ef98a2b77e67&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T17:12:33.325563Z","error_message":null,"id":"62415402-e0fd-4809-9d91-f229848ec235","name":"scw-test-k8s-public-ip-pool-62415402e0fd48099d","pool_id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","provider_id":"scaleway://instance/fr-par-1/dc1ad339-95cd-4a89-9f88-c5d55cfb30ba","public_ip_v4":"","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T17:17:33.664899Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "645"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 17:17:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 325dc8c5-4f7f-4933-a294-7bb55c4dbd13
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/dc1ad339-95cd-4a89-9f88-c5d55cfb30ba
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/038043dc-93d2-40f9-8b0e-690d1f35ebbe
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-10-18T17:12:33.904220+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scw-test-k8s-public-ip-pool-62415402e0fd48099d","id":"dc1ad339-95cd-4a89-9f88-c5d55cfb30ba","image":{"arch":"x86_64","creation_date":"2023-10-17T13:58:22.900323+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"058ec9bf-0cd8-4b2d-a68e-cb7578338a88","modification_date":"2023-10-17T14:08:43.096919+00:00","name":"k8s_base_node_2023-10-11.1","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"84ef0475-6a5a-4ab4-9acd-8e5855eee050","name":"k8s_base_node_2023-10-11.1","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"28","hypervisor_id":"1702","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:29:5e:4f","maintenances":[],"modification_date":"2023-10-18T17:12:48.110756+00:00","name":"scw-test-k8s-public-ip-pool-62415402e0fd48099d","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","placement_group":null,"private_ip":"10.66.72.73","private_nics":[{"creation_date":"2023-10-18T17:12:34.559921+00:00","id":"9381fddd-3982-475b-8eb3-814f39e16e53","mac_address":"02:00:00:14:4d:5c","modification_date":"2023-10-18T17:12:37.176997+00:00","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","server_id":"dc1ad339-95cd-4a89-9f88-c5d55cfb30ba","state":"available","tags":[],"zone":"fr-par-1"}],"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"92e3a255-acd6-4ef5-bc55-ba14ba229683","name":"kubernetes
-      4f82f936-189f-46c3-b063-e7b2af051c79"},"state":"running","state_detail":"booting
-      kernel","tags":["kapsule=4f82f936-189f-46c3-b063-e7b2af051c79","pool=6b6234af-3545-4aa1-b11f-ef98a2b77e67","pool-name=pool","runtime=containerd","managed=true","node=62415402-e0fd-4809-9d91-f229848ec235"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-18T17:12:33.904220+00:00","export_uri":null,"id":"a6b4ed5a-e698-4b3a-9405-8f66699d6391","modification_date":"2023-10-18T17:12:33.904220+00:00","name":"k8s_base_node_2023-10-11.1","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","server":{"id":"dc1ad339-95cd-4a89-9f88-c5d55cfb30ba","name":"scw-test-k8s-public-ip-pool-62415402e0fd48099d"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"GP1-XS","creation_date":"2023-11-07T16:15:35.059441+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scw-test-k8s-public-i-test-k8s-public-i-6009f3","id":"038043dc-93d2-40f9-8b0e-690d1f35ebbe","image":{"arch":"x86_64","creation_date":"2023-10-17T13:58:22.900323+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"058ec9bf-0cd8-4b2d-a68e-cb7578338a88","modification_date":"2023-10-17T14:08:43.096919+00:00","name":"k8s_base_node_2023-10-11.1","organization":"d3009bdc-497e-4b60-a785-1abfad8740ca","project":"d3009bdc-497e-4b60-a785-1abfad8740ca","public":true,"root_volume":{"id":"84ef0475-6a5a-4ab4-9acd-8e5855eee050","name":"k8s_base_node_2023-10-11.1","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"29","hypervisor_id":"602","node_id":"1","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:5f:4d","maintenances":[],"modification_date":"2023-11-07T16:15:49.662790+00:00","name":"scw-test-k8s-public-i-test-k8s-public-i-6009f3","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.66.76.193","private_nics":[{"creation_date":"2023-11-07T16:15:35.816671+00:00","id":"9627f7ec-0873-487e-af23-c721cce340b1","mac_address":"02:00:00:14:a4:1f","modification_date":"2023-11-07T16:15:36.663237+00:00","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","server_id":"038043dc-93d2-40f9-8b0e-690d1f35ebbe","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"8ee2862c-bbf8-44af-82cf-9ec4d2265dd9","name":"kubernetes
+      39d9f145-02ea-4e4e-a5da-f146630c632b"},"state":"running","state_detail":"booting
+      kernel","tags":["kapsule=39d9f145-02ea-4e4e-a5da-f146630c632b","pool=1eac1bd9-8533-4d1b-b549-a1ef95831940","pool-name=test-k8s-public-ip","runtime=containerd","managed=true","node=6009f374-7e80-461a-9638-aa60ee66dba9"],"volumes":{"0":{"boot":false,"creation_date":"2023-11-07T16:15:35.059441+00:00","export_uri":null,"id":"01f83a60-f844-4d27-a19b-474c6e270be4","modification_date":"2023-11-07T16:15:35.059441+00:00","name":"k8s_base_node_2023-10-11.1","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"038043dc-93d2-40f9-8b0e-690d1f35ebbe","name":"scw-test-k8s-public-i-test-k8s-public-i-6009f3"},"size":150000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3466"
+      - "3480"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:17:37 GMT
+      - Tue, 07 Nov 2023 16:18:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6326,7 +6722,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5309781a-1ad8-4e27-933f-29f4cd024a22
+      - 6df69012-a86f-444a-90ba-86d9203bc3b4
     status: 200 OK
     code: 200
     duration: ""
@@ -6337,19 +6733,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/8488fefa-e9b0-4874-9796-d69f72ea632b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
     method: GET
   response:
-    body: '{"address":"192.168.0.1","created_at":"2023-10-18T17:12:19.486701Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8488fefa-e9b0-4874-9796-d69f72ea632b","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-18T17:12:19.486701Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":"02:00:00:14:A4:17","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"ready","updated_at":"2023-11-07T16:14:00.919968Z","zone":"fr-par-1"}],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:14:01.031794Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "586"
+      - "1919"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:17:38 GMT
+      - Tue, 07 Nov 2023 16:18:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6359,7 +6755,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f51f9d79-09d9-40d2-95f9-fe006ac6a5ae
+      - 7e747c9b-0ed5-4cde-8165-2b1f7e11b480
     status: 200 OK
     code: 200
     duration: ""
@@ -6370,19 +6766,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/5b346518-375f-4ecb-95ec-0e48b3b50d54
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/9a11d235-abb0-476b-aefe-580f5054044b
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-18T17:12:20.078194Z","gateway_networks":[{"address":null,"created_at":"2023-10-18T17:12:26.924175Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-18T17:12:19.486701Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8488fefa-e9b0-4874-9796-d69f72ea632b","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-18T17:12:19.486701Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","id":"9bec2bc2-3cd3-475d-aa88-056cc9a6d7a4","ipam_config":null,"mac_address":"02:00:00:14:4D:5A","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","status":"ready","updated_at":"2023-10-18T17:12:29.107374Z","zone":"fr-par-1"}],"id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","ip":{"address":"51.15.224.248","created_at":"2023-10-18T17:12:20.064132Z","gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","id":"349cc528-45f1-4aac-a1ad-65ea6a66aa50","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"248-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-18T17:12:20.064132Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-18T17:12:29.202280Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1976"
+      - "568"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:17:38 GMT
+      - Tue, 07 Nov 2023 16:18:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6392,7 +6788,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b49a421-0fce-49b7-a45a-805211d12078
+      - 5c099738-a1e9-4287-b658-6e3181dd4190
     status: 200 OK
     code: 200
     duration: ""
@@ -6403,19 +6799,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b27b50b7-86ff-406e-b08b-de82de78fe7a
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3161b3a1-c691-4566-aeb8-03eb610ff2ee
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T17:05:38.963133Z","dhcp_enabled":true,"id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T17:05:38.963133Z","id":"b6f618ae-5f6f-4745-acbc-66e1cba782d7","subnet":"192.168.0.0/22","updated_at":"2023-10-18T17:12:25.636357Z"},{"created_at":"2023-10-18T17:05:38.963133Z","id":"385347c4-de12-4c0f-ab0e-d6fc33b70b07","subnet":"fd63:256c:45f7:2b74::/64","updated_at":"2023-10-18T17:12:25.643032Z"}],"tags":[],"updated_at":"2023-10-18T17:12:28.761724Z","vpc_id":"3f025108-2715-4c51-98eb-61df2d52ec49"}'
+    body: '{"created_at":"2023-11-07T16:05:40.803436Z","dhcp_enabled":true,"id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:05:40.803436Z","id":"593394e2-e265-4d2d-8acd-a46de571baa7","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:55.400175Z"},{"created_at":"2023-11-07T16:05:40.803436Z","id":"f1c14d0f-4e1b-4c61-ac26-67402c6a15ed","subnet":"fd5f:519c:6d46:63f8::/64","updated_at":"2023-11-07T16:13:55.403852Z"}],"tags":[],"updated_at":"2023-11-07T16:13:57.844907Z","vpc_id":"733d8205-e6f3-4481-abc1-d3d8760a8139"}'
     headers:
       Content-Length:
-      - "719"
+      - "702"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:17:38 GMT
+      - Tue, 07 Nov 2023 16:18:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6425,7 +6821,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07daa29a-e73a-4a45-9d22-04856d2c3fd8
+      - f4a1cfe0-7f7c-478d-9594-1c74a4deb9fb
     status: 200 OK
     code: 200
     duration: ""
@@ -6436,19 +6832,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/9bec2bc2-3cd3-475d-aa88-056cc9a6d7a4
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cb4961bb-038a-4b42-842b-4cf377d6b06f
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-18T17:12:26.924175Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-18T17:12:19.486701Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8488fefa-e9b0-4874-9796-d69f72ea632b","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-18T17:12:19.486701Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","id":"9bec2bc2-3cd3-475d-aa88-056cc9a6d7a4","ipam_config":null,"mac_address":"02:00:00:14:4D:5A","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","status":"ready","updated_at":"2023-10-18T17:12:29.107374Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":"02:00:00:14:A4:17","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"ready","updated_at":"2023-11-07T16:14:00.919968Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "996"
+      - "966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:17:38 GMT
+      - Tue, 07 Nov 2023 16:18:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6458,7 +6854,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5c93e3d-9b46-4a65-9d81-ce4544192383
+      - a6dc1eb4-1eef-40de-9df4-f14d3ea6b91c
     status: 200 OK
     code: 200
     duration: ""
@@ -6469,19 +6865,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/5b346518-375f-4ecb-95ec-0e48b3b50d54
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-18T17:12:20.078194Z","gateway_networks":[{"address":null,"created_at":"2023-10-18T17:12:26.924175Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-18T17:12:19.486701Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8488fefa-e9b0-4874-9796-d69f72ea632b","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-18T17:12:19.486701Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","id":"9bec2bc2-3cd3-475d-aa88-056cc9a6d7a4","ipam_config":null,"mac_address":"02:00:00:14:4D:5A","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","status":"ready","updated_at":"2023-10-18T17:12:29.107374Z","zone":"fr-par-1"}],"id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","ip":{"address":"51.15.224.248","created_at":"2023-10-18T17:12:20.064132Z","gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","id":"349cc528-45f1-4aac-a1ad-65ea6a66aa50","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"248-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-18T17:12:20.064132Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-18T17:12:29.202280Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":"02:00:00:14:A4:17","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"ready","updated_at":"2023-11-07T16:14:00.919968Z","zone":"fr-par-1"}],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:14:01.031794Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1976"
+      - "1919"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:17:38 GMT
+      - Tue, 07 Nov 2023 16:18:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6491,7 +6887,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0fe8d54d-118e-4911-897d-d84b35cdab1c
+      - 3cb317e0-dcd1-487f-a7dc-f61de3163b6a
     status: 200 OK
     code: 200
     duration: ""
@@ -6502,19 +6898,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/9bec2bc2-3cd3-475d-aa88-056cc9a6d7a4
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cb4961bb-038a-4b42-842b-4cf377d6b06f
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-18T17:12:26.924175Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-18T17:12:19.486701Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8488fefa-e9b0-4874-9796-d69f72ea632b","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-18T17:12:19.486701Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","id":"9bec2bc2-3cd3-475d-aa88-056cc9a6d7a4","ipam_config":null,"mac_address":"02:00:00:14:4D:5A","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","status":"ready","updated_at":"2023-10-18T17:12:29.107374Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":"02:00:00:14:A4:17","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"ready","updated_at":"2023-11-07T16:14:00.919968Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "996"
+      - "966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:17:38 GMT
+      - Tue, 07 Nov 2023 16:18:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6524,7 +6920,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ee5956c-2528-4bc4-a36d-76ea6737a791
+      - fbe0159e-297d-47e9-b822-b7f9adfa1972
     status: 200 OK
     code: 200
     duration: ""
@@ -6535,19 +6931,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f82f936-189f-46c3-b063-e7b2af051c79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T17:05:41.115898Z","created_at":"2023-10-18T17:05:41.115898Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f82f936-189f-46c3-b063-e7b2af051c79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f82f936-189f-46c3-b063-e7b2af051c79","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-18T17:07:10.949789Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:15:32.328838Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1500"
+      - "1455"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:17:38 GMT
+      - Tue, 07 Nov 2023 16:18:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6557,7 +6953,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d95892f-ebfa-4810-8271-a3116851d7d9
+      - c244d8eb-d63c-4d75-9d3a-a82e4fa460b0
     status: 200 OK
     code: 200
     duration: ""
@@ -6568,19 +6964,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVelRVUlZNRTFzYjFoRVZFMTZUVlJCZUU1NlJUTk5SRlV3VFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUMjl4Q2xrNFNIaDRhR3M1UkVreE56TjNZMGd4ZVRnemMzcFhiWFpFZDJ0d2FrOVhVRXhxTDFwa05scEZjSE5FWlRoalpVMVNOVUZYUWxwNVExWjFaRUpXVUhrS1VXWlFUVXRQUTNkRGQwRjFaekJpVldFelIwZE1UREZoVldkWFUwd3dlbkZRY0dsTGRtMUxTRXhtTkV4cVVHcE1VRGxaZUdKTFYyMWFPRGRXVjBVelRncEJRM3B0VTNGQk9VYzJNa1U1UjFGNVJYWkhRbHBJWW1sWksza3lkV0pLVVhWQmJHbFpSMG94ZUZNMVVWbGxhRTFSU25GSFJIQXhSMDg1ZDJSeU5VZHlDbmc1TDJKdmVqQmpPR3Q2TmxoT1NucFZSblJOZUU0NFpEQXZaVlZwUjBNMmFTdHBSMU5GVFU0eWEwUkhjVW8yTW1NMU4yaDJXbk40UTJZek1HUTFVbXNLWjB0NFQwRXpaVWhLVFVwNFQyMXpabEJLUjNoUVFubDJVR1FyU2tkaVJuUlZkME5SVkhkbVluTnFTSGRuSzFOYVJXczRSVkl2U0RsdlJVbHRWa3hyZUFwbFFtazNTMUUwSzIxRmVVWTVNelU0WVZjd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUGJUWTRTbUZsWm1GclZWUm9SMDR2UkhFMVIwNUtWVXBNV1VoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmNFeDBaVnBFWm1veFMyeDVkV3hIV1U5SmJrbDNlRlpDZVhFM1RYQnRZa3gyUVRkeFNFcFNTaTg1YUV4emRWSkpWd3ByUVRaUVVVZHBhemRVYzJGdFQwUlVOU3Q0ZDBRck1rY3daRzB5Vm5KSlkyRkdSVzAyYjJJNVpHeDNiRkJ2WjFwRU1rZFBTVFo1UVVWcVdWZFdiWFpqQ20xeGEweEpaRGR6UkRWb01EbHVURmhoVGt4aFZUbHRZblYyT1d3MGFXbExPVmw0VFcxQk1WQlJUbUptUjBOTGJYbHVPREpoYVVsTU9XMTBiRkFyYUVnS1VIcFZNbVp5TmxkemNTOU9ibEo1VkZOaWIyZ3haVkJ5TmpOV2JGazVkazk2YkROTWVVUnlaMnR1UldnNFFVaHpVVGxvYlRaVUx6aFBXR2xTUzBjNGNRbzRiV2xMVHk5eFprMW5NWFZzZVRJMmNuZFBiV1ZVVmk5TVdITktNbmRCUldJeU5rTndXR3hMZEdWWVYyc3phRGxDVUVSYVlYcG1TMGh2WTNWNWFWbHVDbFZJU1ROdVIzTTNUQzlvWVhaeVF6QkhUVkYwZVdzNFIydFBkbU5vVDJOQk4zQjZVd290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNGY4MmY5MzYtMTg5Zi00NmMzLWIwNjMtZTdiMmFmMDUxYzc5LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHVibGljLWlwIgogICAgdXNlcjogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBDT2FQVE5idURiSFpYY3pBbDhKWTN6R29UeTZFeXlWWjNPMkE3YXBpWE1TVm9MclhFaThkdmR5SA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtazhzLXB1YmxpYy1pcCIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRVUlZNRTB4YjFoRVZFMTZUVlJGZDA1cVJUSk5SRlV3VFRGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJURkJUQ2tReEwxcG5TMVF2TW5oT2MyaDVlVVU1YlVWNlQwTktTRGgwUWs4MksyOWxiSEZJU2pSMU1YcDNjRGRLSzFjeWNYQnBNMEprVUhwMFJYSlJkMlpTYXpZS1NWbHBhV00yT0dvNFkzQTFlR2x2T1dGU1FURnRhbmxFWlZGamNXMUJUVzlJT1hwVWVISlJXWE5hVVVablEyUlhZMUpGT0VselYycEtPR3BYYlN0SFNncFVSUzh2VFVaa2N5dDNiblZoU2pFMllrZHdValpxTUZobVJXUkZPVlZoZDFvMk5WVjZjRFF4YUZReVREY3pRVTQ0TkdJck5XUmlVRXB6Wmk5Wk0yaElDa28wYjNWaU1WbFFXa0pXT0ZGTFpsSjNTMGhzU0hVeVlqQlZiak14WjNWbVVsSk9TM0l2WVd0TFNsYzFZVUpCY2pJeU9XZG1VbVJWVkdscFJrOXZTSFFLUzA5V1NGSXJNRmM1YVhkU2JYRmtkMFp6TTNkQ1JrTTRPV3BvWkRSSlFtZFJhME0yYW5WU1JHVTBWRk16VEhjMU1IRkVSM2s0Ym04MVJqaFBVamhXVFFwRlVGWnhRWHB0T0RWUVNtMW1jVlZFWTBKVlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaT1kwZEVNbTl6TlZaaGVHNWFVMEptUmtSS09XUjRSbG8zTDNsTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ2JVRkpiVWhVV1M5TVdUSmlXREFyVTJSSU0zQXZXVGRqVmtKbk5XWTVkRU0zVERsUlFqSnFlV1o1YVhoUFZGUktWQXB6YlVGTUwzSkhia1pNZVU1d2JsSmlUMmNyVW1STVpDdEZUVlJoVERJNFJuSXZkRXRxU25OU2FGTnRVbTFZVmxWS1NtVllibWxtYjBGMVpUQnhZMVl4Q21Wc2NsRkJReXMxZGtOM2FDOW5lbGhFY2xGVVZtdzVZMk42UVUwMGJGUTJOell6Wm5SbmVFMHJUMDVSSzFwcVoxWlplRlEwZW1WaFMwUlFaWGd2ZUZNS1VIaGxUekJCWldNNVV6aHZiRzlZWkRjcloycGpXWHBKWjFCSk1VSm1VRmhQTmxvMGFWcHBjVVJyU0VVMlZISlZla3RyZGxwaE1XNDNOV3hLUzBoa1l3b3dUMUpHY1VOT01UazRlaTh3VVZkclVWbDRkQzlSVUZaUWRrdE1TbWhqZHpsTVZIWnNOR2RSVXpkR1Z6SlNVV0p5YlhsMlNFVlZabGxIVVRkeldXcE9Da1pKWkUxRU5rMXRhMnBsTURSQ055dDZTbU5ZYVc1b2MyTnFPREZDUW1WQ05qZGxkZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMzlkOWYxNDUtMDJlYS00ZTRlLWE1ZGEtZjE0NjYzMGM2MzJiLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtazhzLXB1YmxpYy1pcAogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1rOHMtcHVibGljLWlwIgogICAgdXNlcjogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1rOHMtcHVibGljLWlwCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1rOHMtcHVibGljLWlwLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpaVEzZlhGSHBDWWI2bUxkdjZkOEVkNnJwd1dTT3c2TmJHWFhPcDRjTWxUY0xaazN4VEx1YTR0MA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2638"
+      - "2636"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:17:38 GMT
+      - Tue, 07 Nov 2023 16:18:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6590,7 +6986,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9f43dd7-2fe1-4588-91d6-60860643a165
+      - 79857ec9-fea6-489e-9440-da0c04af9d1a
     status: 200 OK
     code: 200
     duration: ""
@@ -6601,19 +6997,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-18T17:17:33.680749Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:18:26.750409Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "612"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:17:38 GMT
+      - Tue, 07 Nov 2023 16:18:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6623,7 +7019,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a28a7d7-3d52-49b6-9251-c995d5fd2319
+      - 30a441ed-6c23-4135-9e09-3a1ec3f24483
     status: 200 OK
     code: 200
     duration: ""
@@ -6634,19 +7030,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79/nodes?order_by=created_at_asc&page=1&pool_id=6b6234af-3545-4aa1-b11f-ef98a2b77e67&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b/nodes?order_by=created_at_asc&page=1&pool_id=1eac1bd9-8533-4d1b-b549-a1ef95831940&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T17:12:33.325563Z","error_message":null,"id":"62415402-e0fd-4809-9d91-f229848ec235","name":"scw-test-k8s-public-ip-pool-62415402e0fd48099d","pool_id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","provider_id":"scaleway://instance/fr-par-1/dc1ad339-95cd-4a89-9f88-c5d55cfb30ba","public_ip_v4":"","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T17:17:33.664899Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T16:15:34.157632Z","error_message":null,"id":"6009f374-7e80-461a-9638-aa60ee66dba9","name":"scw-test-k8s-public-i-test-k8s-public-i-6009f3","pool_id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","provider_id":"scaleway://instance/fr-par-1/038043dc-93d2-40f9-8b0e-690d1f35ebbe","public_ip_v4":"","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:18:26.736312Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "645"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:17:38 GMT
+      - Tue, 07 Nov 2023 16:18:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6656,7 +7052,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84a74d61-111f-4016-ba2b-7bd46911ceca
+      - 945901b3-270a-473b-a9d7-b56f92e58720
     status: 200 OK
     code: 200
     duration: ""
@@ -6667,19 +7063,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/6b6234af-3545-4aa1-b11f-ef98a2b77e67
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"4f82f936-189f-46c3-b063-e7b2af051c79","container_runtime":"containerd","created_at":"2023-10-18T17:12:32.687164Z","id":"6b6234af-3545-4aa1-b11f-ef98a2b77e67","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-10-18T17:17:40.003127793Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:18:33.456768316Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "618"
+      - "609"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:17:40 GMT
+      - Tue, 07 Nov 2023 16:18:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6689,7 +7085,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b7cb944-dbe8-44a7-add5-24643e157f44
+      - 3652e507-33c3-4ad0-bbf1-448f50ad88de
     status: 200 OK
     code: 200
     duration: ""
@@ -6700,52 +7096,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79?with_additional_resources=true
-    method: DELETE
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f82f936-189f-46c3-b063-e7b2af051c79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T17:05:41.115898Z","created_at":"2023-10-18T17:05:41.115898Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f82f936-189f-46c3-b063-e7b2af051c79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f82f936-189f-46c3-b063-e7b2af051c79","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-18T17:17:40.121580370Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1506"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 17:17:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a7db918c-910c-4f31-80e3-3b3e686a3e88
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f82f936-189f-46c3-b063-e7b2af051c79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T17:05:41.115898Z","created_at":"2023-10-18T17:05:41.115898Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f82f936-189f-46c3-b063-e7b2af051c79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f82f936-189f-46c3-b063-e7b2af051c79","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-18T17:17:40.121580Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:18:33.456768Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1503"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:17:40 GMT
+      - Tue, 07 Nov 2023 16:18:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6755,7 +7118,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08a4f3ff-5de9-45ed-a7ec-28c5c2b9cb38
+      - bba62a86-a8f7-4120-a17f-7ca7ec592573
     status: 200 OK
     code: 200
     duration: ""
@@ -6766,19 +7129,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f82f936-189f-46c3-b063-e7b2af051c79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T17:05:41.115898Z","created_at":"2023-10-18T17:05:41.115898Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f82f936-189f-46c3-b063-e7b2af051c79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f82f936-189f-46c3-b063-e7b2af051c79","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-18T17:17:40.121580Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","container_runtime":"containerd","created_at":"2023-11-07T16:14:01.683142Z","id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-k8s-public-ip","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":true,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:18:33.456768Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1503"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:17:45 GMT
+      - Tue, 07 Nov 2023 16:18:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6788,7 +7151,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a090c4b-227e-4676-9b72-5a48cf36ff4f
+      - 33905644-8f31-42b5-9439-3733a34d1e61
     status: 200 OK
     code: 200
     duration: ""
@@ -6799,19 +7162,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/1eac1bd9-8533-4d1b-b549-a1ef95831940
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f82f936-189f-46c3-b063-e7b2af051c79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T17:05:41.115898Z","created_at":"2023-10-18T17:05:41.115898Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f82f936-189f-46c3-b063-e7b2af051c79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f82f936-189f-46c3-b063-e7b2af051c79","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-18T17:17:40.121580Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"1eac1bd9-8533-4d1b-b549-a1ef95831940","type":"not_found"}'
     headers:
       Content-Length:
-      - "1503"
+      - "125"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:17:50 GMT
+      - Tue, 07 Nov 2023 16:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6821,172 +7184,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d721bc0-07eb-42f5-8f52-010f0209aee2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f82f936-189f-46c3-b063-e7b2af051c79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T17:05:41.115898Z","created_at":"2023-10-18T17:05:41.115898Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f82f936-189f-46c3-b063-e7b2af051c79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f82f936-189f-46c3-b063-e7b2af051c79","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-18T17:17:40.121580Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1503"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 17:17:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 595a6e97-7f7e-44f0-ace8-f55ff473c5bc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f82f936-189f-46c3-b063-e7b2af051c79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T17:05:41.115898Z","created_at":"2023-10-18T17:05:41.115898Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f82f936-189f-46c3-b063-e7b2af051c79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f82f936-189f-46c3-b063-e7b2af051c79","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-18T17:17:40.121580Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1503"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 17:18:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 52de512f-244f-43cb-a1ed-2d2714564b14
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f82f936-189f-46c3-b063-e7b2af051c79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T17:05:41.115898Z","created_at":"2023-10-18T17:05:41.115898Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f82f936-189f-46c3-b063-e7b2af051c79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f82f936-189f-46c3-b063-e7b2af051c79","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-18T17:17:40.121580Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1503"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 17:18:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2608dbe6-d6a7-4ab3-a9a6-89c320ec2934
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f82f936-189f-46c3-b063-e7b2af051c79.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T17:05:41.115898Z","created_at":"2023-10-18T17:05:41.115898Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f82f936-189f-46c3-b063-e7b2af051c79.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f82f936-189f-46c3-b063-e7b2af051c79","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-10-18T17:17:40.121580Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1503"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 17:18:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 07c43d17-1873-4d90-8c36-91a5b5239fce
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"4f82f936-189f-46c3-b063-e7b2af051c79","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "128"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 17:18:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a7379869-2b36-4d23-a23b-834329cc662b
+      - 7d1ee68e-7d76-4711-a23e-d142e5e655c4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -6997,19 +7195,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/9bec2bc2-3cd3-475d-aa88-056cc9a6d7a4
-    method: GET
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b?with_additional_resources=true
+    method: DELETE
   response:
-    body: '{"address":null,"created_at":"2023-10-18T17:12:26.924175Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-18T17:12:19.486701Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8488fefa-e9b0-4874-9796-d69f72ea632b","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-18T17:12:19.486701Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","id":"9bec2bc2-3cd3-475d-aa88-056cc9a6d7a4","ipam_config":null,"mac_address":"02:00:00:14:4D:5A","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","status":"ready","updated_at":"2023-10-18T17:12:29.107374Z","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:18:43.673774620Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "996"
+      - "1461"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:18:15 GMT
+      - Tue, 07 Nov 2023 16:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7019,7 +7217,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a15d3997-3901-492b-bc6e-cc9797018141
+      - baedd61f-646b-46ee-af81-ae7cd7c2efb9
     status: 200 OK
     code: 200
     duration: ""
@@ -7030,17 +7228,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/9bec2bc2-3cd3-475d-aa88-056cc9a6d7a4?cleanup_dhcp=false
-    method: DELETE
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
+    method: GET
   response:
-    body: ""
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:18:43.673775Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
+      Content-Length:
+      - "1458"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:18:15 GMT
+      - Tue, 07 Nov 2023 16:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7050,7 +7250,137 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e86892c-57cd-485e-908e-df125bbbd6f0
+      - 9138c05c-f302-4ebc-878c-3bc09cd2db80
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://39d9f145-02ea-4e4e-a5da-f146630c632b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:05:42.404253Z","created_at":"2023-11-07T16:05:42.404253Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.39d9f145-02ea-4e4e-a5da-f146630c632b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"39d9f145-02ea-4e4e-a5da-f146630c632b","ingress":"none","name":"test-k8s-public-ip","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","public_ip"],"type":"kapsule","updated_at":"2023-11-07T16:18:43.673775Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1458"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:18:48 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c2788e8b-b256-43c8-a78b-3aeecee9de06
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:18:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7f5cdd9e-32e3-4ae4-801c-f706d90947ee
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cb4961bb-038a-4b42-842b-4cf377d6b06f
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":"02:00:00:14:A4:17","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"ready","updated_at":"2023-11-07T16:14:00.919968Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "966"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:18:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a51d85fa-93ac-427a-a40a-8a8b94e3c565
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cb4961bb-038a-4b42-842b-4cf377d6b06f?cleanup_dhcp=false
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:18:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1685a8c8-e850-4375-b076-886eddb76d78
     status: 204 No Content
     code: 204
     duration: ""
@@ -7061,19 +7391,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/9bec2bc2-3cd3-475d-aa88-056cc9a6d7a4
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cb4961bb-038a-4b42-842b-4cf377d6b06f
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-18T17:12:26.924175Z","dhcp":{"address":"192.168.0.1","created_at":"2023-10-18T17:12:19.486701Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"8488fefa-e9b0-4874-9796-d69f72ea632b","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-10-18T17:12:19.486701Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","id":"9bec2bc2-3cd3-475d-aa88-056cc9a6d7a4","ipam_config":null,"mac_address":"02:00:00:14:4D:5A","private_network_id":"b27b50b7-86ff-406e-b08b-de82de78fe7a","status":"detaching","updated_at":"2023-10-18T17:18:15.943301Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2023-11-07T16:13:55.899920Z","dhcp":{"address":"192.168.0.1","created_at":"2023-11-07T16:13:48.995723Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9a11d235-abb0-476b-aefe-580f5054044b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.3.254","pool_low":"192.168.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.0.0/22","updated_at":"2023-11-07T16:13:48.995723Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","ipam_config":null,"mac_address":"02:00:00:14:A4:17","private_network_id":"3161b3a1-c691-4566-aeb8-03eb610ff2ee","status":"detaching","updated_at":"2023-11-07T16:18:54.010015Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1000"
+      - "970"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:18:16 GMT
+      - Tue, 07 Nov 2023 16:18:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7083,7 +7413,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc7243c2-f398-48af-a4c8-fc1943a019ac
+      - 6ba01ea4-4de9-4272-8427-093591bc90ac
     status: 200 OK
     code: 200
     duration: ""
@@ -7094,10 +7424,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/9bec2bc2-3cd3-475d-aa88-056cc9a6d7a4
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cb4961bb-038a-4b42-842b-4cf377d6b06f
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"9bec2bc2-3cd3-475d-aa88-056cc9a6d7a4","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"cb4961bb-038a-4b42-842b-4cf377d6b06f","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -7106,7 +7436,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:18:21 GMT
+      - Tue, 07 Nov 2023 16:18:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7116,7 +7446,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36e3e339-4174-4851-8944-200296fc9106
+      - e8eeee45-4437-4cf9-bb89-212a46e8ba50
     status: 404 Not Found
     code: 404
     duration: ""
@@ -7127,19 +7457,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/5b346518-375f-4ecb-95ec-0e48b3b50d54
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-18T17:12:20.078194Z","gateway_networks":[],"id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","ip":{"address":"51.15.224.248","created_at":"2023-10-18T17:12:20.064132Z","gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","id":"349cc528-45f1-4aac-a1ad-65ea6a66aa50","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"248-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-18T17:12:20.064132Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-18T17:12:29.202280Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:14:01.031794Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "980"
+      - "953"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:18:21 GMT
+      - Tue, 07 Nov 2023 16:18:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7149,7 +7479,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ded15f45-3324-4070-a302-0fb2625f494c
+      - 2d8818a9-a38c-46a4-a9f2-000f551ec32b
     status: 200 OK
     code: 200
     duration: ""
@@ -7160,19 +7490,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/5b346518-375f-4ecb-95ec-0e48b3b50d54
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-18T17:12:20.078194Z","gateway_networks":[],"id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","ip":{"address":"51.15.224.248","created_at":"2023-10-18T17:12:20.064132Z","gateway_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","id":"349cc528-45f1-4aac-a1ad-65ea6a66aa50","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"248-224-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-18T17:12:20.064132Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-18T17:12:29.202280Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:14:01.031794Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "980"
+      - "953"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:18:21 GMT
+      - Tue, 07 Nov 2023 16:18:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7182,7 +7512,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 209403dc-efa7-467a-8228-459a1b338e38
+      - 3cbfd016-4fd0-418d-a4ee-b51618bc8646
     status: 200 OK
     code: 200
     duration: ""
@@ -7193,7 +7523,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/8488fefa-e9b0-4874-9796-d69f72ea632b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/9a11d235-abb0-476b-aefe-580f5054044b
     method: DELETE
   response:
     body: ""
@@ -7203,7 +7533,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:18:21 GMT
+      - Tue, 07 Nov 2023 16:18:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7213,7 +7543,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f50f60d2-44d8-45d7-b970-6b447bfc7380
+      - d83027a6-519e-4288-8064-6f600851a5d0
     status: 204 No Content
     code: 204
     duration: ""
@@ -7224,7 +7554,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/5b346518-375f-4ecb-95ec-0e48b3b50d54?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -7234,7 +7564,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:18:21 GMT
+      - Tue, 07 Nov 2023 16:18:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7244,7 +7574,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9711ea54-5100-4a20-aa32-4ab075a610bf
+      - 9d7e8a2a-3db3-41fc-808c-90960711484b
     status: 204 No Content
     code: 204
     duration: ""
@@ -7255,10 +7585,74 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/5b346518-375f-4ecb-95ec-0e48b3b50d54
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"5b346518-375f-4ecb-95ec-0e48b3b50d54","type":"not_found"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-07T16:13:49.690251Z","gateway_networks":[],"id":"aae8906e-ef80-44d9-881a-fc6453a63e25","ip":{"address":"51.158.108.188","created_at":"2023-11-07T16:13:49.665524Z","gateway_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","id":"74bd6792-68ba-4991-b037-c7d9ff512e99","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"188-108-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-07T16:13:49.665524Z","zone":"fr-par-1"},"is_legacy":true,"name":"test-k8s-public-ip","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"deleting","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-07T16:18:59.242758Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "954"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:18:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f8770411-1ec2-4818-956e-09ebec86aa81
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3161b3a1-c691-4566-aeb8-03eb610ff2ee
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:18:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4f7472bd-a394-4b8b-af4f-b3e86c185703
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/aae8906e-ef80-44d9-881a-fc6453a63e25
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"aae8906e-ef80-44d9-881a-fc6453a63e25","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -7267,7 +7661,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:18:21 GMT
+      - Tue, 07 Nov 2023 16:19:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7277,7 +7671,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ee42e7e-72d3-493f-bb95-a1f49a82d07f
+      - 2172a1fd-c166-458d-86b5-1b343e9d296c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -7288,41 +7682,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b27b50b7-86ff-406e-b08b-de82de78fe7a
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 17:18:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 62b4a0c9-bce5-4f17-aba2-3e677ffa377c
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f82f936-189f-46c3-b063-e7b2af051c79
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/39d9f145-02ea-4e4e-a5da-f146630c632b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"4f82f936-189f-46c3-b063-e7b2af051c79","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"39d9f145-02ea-4e4e-a5da-f146630c632b","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -7331,7 +7694,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:18:21 GMT
+      - Tue, 07 Nov 2023 16:19:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7341,7 +7704,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8080bdb2-447e-491a-ab54-b080f786f948
+      - ee2a1cf3-0d37-47f9-b772-e3389437bc54
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-size.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-size.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:41 GMT
+      - Tue, 07 Nov 2023 15:49:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,12 +34,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7c487ce-7a3b-4021-bf53-70c91238dfd5
+      - 6bc8dd12-7443-4411-96c6-8a0a0df9a308
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-size","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"test-pool-size","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-18T16:35:44.548859Z","dhcp_enabled":true,"id":"da6880df-a94a-4f3e-8277-6150a6853c1c","name":"test-pool-size","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:35:44.548859Z","id":"d60333a2-6c87-424b-a126-dcd786170153","subnet":"172.16.16.0/22","updated_at":"2023-10-18T16:35:44.548859Z"},{"created_at":"2023-10-18T16:35:44.548859Z","id":"e4b70249-f22f-4e9f-93b5-be9c9beb9af7","subnet":"fd63:256c:45f7:de01::/64","updated_at":"2023-10-18T16:35:44.548859Z"}],"tags":[],"updated_at":"2023-10-18T16:35:44.548859Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T15:49:51.075136Z","dhcp_enabled":true,"id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","name":"test-pool-size","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.075136Z","id":"4e078c7b-4307-4239-bf9c-ea4d2f217c14","subnet":"172.16.80.0/22","updated_at":"2023-11-07T15:49:51.075136Z"},{"created_at":"2023-11-07T15:49:51.075136Z","id":"825fa982-e1b5-4dd1-b810-d7e91ef02fd1","subnet":"fd5f:519c:6d46:ebc6::/64","updated_at":"2023-11-07T15:49:51.075136Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.075136Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "715"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:45 GMT
+      - Tue, 07 Nov 2023 15:49:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17b253b0-f3bd-422d-8081-9d08fbfab6ac
+      - 45da668c-44c8-4e13-ac35-c63eef31ec97
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/da6880df-a94a-4f3e-8277-6150a6853c1c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/42e67a9e-cba6-407b-a764-9aea1e6574c7
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:35:44.548859Z","dhcp_enabled":true,"id":"da6880df-a94a-4f3e-8277-6150a6853c1c","name":"test-pool-size","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:35:44.548859Z","id":"d60333a2-6c87-424b-a126-dcd786170153","subnet":"172.16.16.0/22","updated_at":"2023-10-18T16:35:44.548859Z"},{"created_at":"2023-10-18T16:35:44.548859Z","id":"e4b70249-f22f-4e9f-93b5-be9c9beb9af7","subnet":"fd63:256c:45f7:de01::/64","updated_at":"2023-10-18T16:35:44.548859Z"}],"tags":[],"updated_at":"2023-10-18T16:35:44.548859Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T15:49:51.075136Z","dhcp_enabled":true,"id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","name":"test-pool-size","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.075136Z","id":"4e078c7b-4307-4239-bf9c-ea4d2f217c14","subnet":"172.16.80.0/22","updated_at":"2023-11-07T15:49:51.075136Z"},{"created_at":"2023-11-07T15:49:51.075136Z","id":"825fa982-e1b5-4dd1-b810-d7e91ef02fd1","subnet":"fd5f:519c:6d46:ebc6::/64","updated_at":"2023-11-07T15:49:51.075136Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.075136Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "715"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:45 GMT
+      - Tue, 07 Nov 2023 15:49:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,7 +102,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 064b5632-6dd8-4b6d-88c1-9c0dcbd05f9c
+      - cd074a81-5200-419c-8fe3-a459ba1bbe76
     status: 200 OK
     code: 200
     duration: ""
@@ -129,7 +129,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:45 GMT
+      - Tue, 07 Nov 2023 15:49:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -139,12 +139,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf24fa55-c0b5-4e00-95a7-d0c2920014b4
+      - 6e04098f-6a41-4478-aa54-6cd962b89db9
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-size","description":"","tags":null,"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":{"enable":true,"maintenance_window":{"start_hour":12,"day":"monday"}},"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":"da6880df-a94a-4f3e-8277-6150a6853c1c"}'
+    body: '{"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","type":"","name":"test-pool-size","description":"","tags":null,"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":{"enable":true,"maintenance_window":{"start_hour":12,"day":"monday"}},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7"}'
     form: {}
     headers:
       Content-Type:
@@ -155,16 +155,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c82ed107-6afb-4c30-be52-11a3d737e780.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.807899662Z","created_at":"2023-10-18T16:35:45.807899662Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c82ed107-6afb-4c30-be52-11a3d737e780.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c82ed107-6afb-4c30-be52-11a3d737e780","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"da6880df-a94a-4f3e-8277-6150a6853c1c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"kapsule","updated_at":"2023-10-18T16:35:45.822059055Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e79ddfa6-c637-49dc-99b3-c0b1a77c7651.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.395909371Z","created_at":"2023-11-07T15:49:53.395909371Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e79ddfa6-c637-49dc-99b3-c0b1a77c7651.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":[],"type":"kapsule","updated_at":"2023-11-07T15:49:53.427022137Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1458"
+      - "1415"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:45 GMT
+      - Tue, 07 Nov 2023 15:49:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -174,7 +174,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e375315-fc43-4b98-908c-c2df2a165323
+      - 5ed59bfd-e93a-4799-ad1a-7e82e49e0dd2
     status: 200 OK
     code: 200
     duration: ""
@@ -185,19 +185,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c82ed107-6afb-4c30-be52-11a3d737e780.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.807900Z","created_at":"2023-10-18T16:35:45.807900Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c82ed107-6afb-4c30-be52-11a3d737e780.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c82ed107-6afb-4c30-be52-11a3d737e780","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"da6880df-a94a-4f3e-8277-6150a6853c1c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"kapsule","updated_at":"2023-10-18T16:35:45.822059Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e79ddfa6-c637-49dc-99b3-c0b1a77c7651.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.395909Z","created_at":"2023-11-07T15:49:53.395909Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e79ddfa6-c637-49dc-99b3-c0b1a77c7651.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":[],"type":"kapsule","updated_at":"2023-11-07T15:49:53.427022Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1449"
+      - "1406"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:45 GMT
+      - Tue, 07 Nov 2023 15:49:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -207,7 +207,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0d266e6-3aaf-4b6a-8c18-1a19f7bb2a96
+      - e64545ec-9efd-4cfe-a7e9-1e00895a6f49
     status: 200 OK
     code: 200
     duration: ""
@@ -218,19 +218,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c82ed107-6afb-4c30-be52-11a3d737e780.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.807900Z","created_at":"2023-10-18T16:35:45.807900Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c82ed107-6afb-4c30-be52-11a3d737e780.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c82ed107-6afb-4c30-be52-11a3d737e780","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"da6880df-a94a-4f3e-8277-6150a6853c1c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":[],"type":"kapsule","updated_at":"2023-10-18T16:35:45.822059Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e79ddfa6-c637-49dc-99b3-c0b1a77c7651.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.395909Z","created_at":"2023-11-07T15:49:53.395909Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e79ddfa6-c637-49dc-99b3-c0b1a77c7651.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":[],"type":"kapsule","updated_at":"2023-11-07T15:49:55.327661Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1449"
+      - "1411"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:50 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -240,7 +240,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1dc59eb3-d548-48c7-b1fd-d0374c7ac976
+      - 4a070f35-655e-4c7c-b989-b5bc0e866c30
     status: 200 OK
     code: 200
     duration: ""
@@ -251,19 +251,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c82ed107-6afb-4c30-be52-11a3d737e780.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.807900Z","created_at":"2023-10-18T16:35:45.807900Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c82ed107-6afb-4c30-be52-11a3d737e780.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c82ed107-6afb-4c30-be52-11a3d737e780","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"da6880df-a94a-4f3e-8277-6150a6853c1c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":[],"type":"kapsule","updated_at":"2023-10-18T16:35:51.674265Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e79ddfa6-c637-49dc-99b3-c0b1a77c7651.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.395909Z","created_at":"2023-11-07T15:49:53.395909Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e79ddfa6-c637-49dc-99b3-c0b1a77c7651.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":[],"type":"kapsule","updated_at":"2023-11-07T15:49:55.327661Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1454"
+      - "1411"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:56 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -273,7 +273,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0c8324f-e3ad-4997-938f-c1294e47c704
+      - 96099275-c73a-4122-95e5-5a46f9d177b2
     status: 200 OK
     code: 200
     duration: ""
@@ -284,19 +284,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c82ed107-6afb-4c30-be52-11a3d737e780.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.807900Z","created_at":"2023-10-18T16:35:45.807900Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c82ed107-6afb-4c30-be52-11a3d737e780.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c82ed107-6afb-4c30-be52-11a3d737e780","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"da6880df-a94a-4f3e-8277-6150a6853c1c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":[],"type":"kapsule","updated_at":"2023-10-18T16:35:51.674265Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1zaXplIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRuQnlDa0p1T1ZkWVptMVdhM2syTlcxNVEwVkZRM3AxTmtGb1pGaHlSbFZUV0RSemFEaENURkZyV1haTGIxWXpTV3BPV1dwdlJHdFZVbkJzVjBsNGFYRjFia3dLYjBsc05HNVFNak01TTJsbFMzWnZXR1J0TjA0eGRYVlFWMWRQVkVWUFFtVXdWRmMzUTJwYUswUnZVVlJxWkM4d1JIY3hVbGRsVERWQllpOVBLeTl2TWdvNGJtWXlTVkJCYWxkTGJFUlpiVWw0YkdOVGFFVkRlblZDVFd0V1NFRjZPR3RoV2trMWNpdExOR1V5Y0N0SkwzVjFUa1ZpT1VWWVYxWlRRbVJMWlVwSENtTnhXVEk0UVZsS1QzbHlSelV4TWxWQ015dHBXbXB2VFZZNU5XNTRTSGRDVldabE9IUjBPREYxV2t0WllXWkZUalJFZEZkclREaFRNbWt3T0cxTU1FRUtRVkJDWjI5M1oxVjFUME52Y2tGQk1XMDBlbUpOU3pscGNucGxXa1JIYWt3NGFrMDVkVXROYTBod1FWTllOVlpvZFhkelMxcFFPRWhEWkVGb1EyZzFid3BHTW5aNEwxcHZTV05uY2tONk1WcEhUM1l3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpMZERKaVRuUTVVekYwY2poeVNtczRiRzVRZWpFMVFuUkdaM0ZOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDYjFjM2FWcENNekZ0TDA1dFZtcEVTek5STjNCMVl6SkdWRlJKUkhOWVJrRlhhR3BKWkRaMFdWbE5hMkpOU0ZBelRncFhXVUYyTDBsalJGWnZNR2xyZVdKaGVsSnFNbEUxVG5walRVSkpjMlJPZVdGWE1VNTRVM2cwTDBZNEwyZFpUa2d3VjFOVmVHeHBkSEEzTjFWSGJrNVZDa3BwTlVOc1prTm1lR2syZVVzNVduTlZkRk5EY21wcFRYUkpWRmxaYzA1dFFrTnJZakY2VjFoT04yaFVObGRvWjBodGIzaDBXSFp0WnpCS1EweFphblVLY0hweGFFZDVUMFp6VVhCb1ZqWmxTa1pOUjJaT2FEbFNjbTFGY0VaamFVOWFlUzlsUkVscFFrNXVWbXhYUTJKS1EwMVlOQzlrWW14elZIUlpSbFpRV2dwdWExTXZja3BYTW00MGFGZFVNWGRoV2pBNGFtZHZWMFF5U2tSM1dIZFJZbkJ1UjBjd2VUSlVMeXQyY1ZKV2QzSnZXVWR5ZURZMFZ5dHdZaTh4UjFaTUNtTkdNR2x0WjNCNFJHaEtRalZYYkVVclUyUmlWamd5T1hKaWMzQmlibEZtTUROSlNBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9lNzlkZGZhNi1jNjM3LTQ5ZGMtOTliMy1jMGIxYTc3Yzc2NTEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXNpemUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1zaXplIgogICAgdXNlcjogdGVzdC1wb29sLXNpemUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtc2l6ZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1zaXplLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBWZXZjWHdGZklmc3VtcElvY3l2QUNEU1pGQWNOVzFRcng2bUpsZGdacjRDbmVkbjZKanRsMDhwQw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1454"
+      - "2604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:56 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -306,7 +306,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83dd6ade-fddb-46ae-a939-79f735f150c9
+      - 7ea2ecdc-cd76-44a7-b258-42a9d7ef6083
     status: 200 OK
     code: 200
     duration: ""
@@ -317,19 +317,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1zaXplIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VFhwVk1VMVdiMWhFVkUxNlRWUkJlRTU2UlRKTmVsVXhUVlp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlNuTlRDbEJzZDIxeE1FUTVWVzFzTlZwNVVVWnlaRTVZTlZodWIzUkxNMnBEVDJKYVpHRmhlRWgxVWtGbVFXWjFaVTFrYzJkdldrTnVlRFk1VDJJM0wweExhVklLV0RoNWJrSlVObHBEV2xObGJXcG1WMDlwYzFWNU5sSm9iRUZWWnpjMmMxaE9UV05RYldoNU5YbGhPRFl5Y2xoS1pGSllWRGRwVG5wSFNVOTFSVkpvUndwTGNuQnhSbmswVlhoWVpGb3lTSFJuZVVSUFZHWTFZbTFvYm1aMlpVcEJkMVJIWnpkUFQxWjZSMjQ1UVdoRFZHNHlhMUFyTmtsdVUxTXdSbVZwTUN0MENtRm5aRWRWZUhaS2QycE9PV2RGT0M5dFdsTkZkRk5pU1hCWlMwbHJSVGh6WlRaWU9HMHdVRWxOYkRORlMyaGtUSHBuY210RWJsWnlWMEV2WmxkM0x6QUtTa1ZYY1hrNVQydFBWM05ZV0M4eFlXUkdNRTlRYUZkVWJIYzVUbWN3YzJkclVTOU1VVU5MZVRSQ1NqTklXRWMwWldNd1FVaG1OSFZIYzJ0R2VrY3ZhUXBrTkdac2MwdHpSM3B1U1d3dlFYTmxkV3ROUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpNVWpsbGNGQTNha0ZuTlVSTFZteHJkSFpJVGxGbVNYcEphMFpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDTkZaQlNWZDNhVlJhZEhGcGFrNTNlSFZoWkZwYVNrVlNNRlU1Wm5adVlreFpTVEZNZFU1NGJURnhUbkJ6WmxGWk9RcHdNblJ3YTJZeGR6bHJOeTlKYXpSS1NsVm5VWFZ2YVZjMGR6QnlkWEJoZVRaekx5dHZjbFpzTlZsdWMwdHVWMHB2U0RabmVrOUNUakZZY1dWaWFFa3pDalV3YTI1SlFsWlVjSGh0WkZkQlZIZFVhVU0yUm1rd05qQXdjVFEyUW0xSmVrc3pMM0EwTjJkQlRWWk9kVU16Ym5SWFNEVnROak5qY0ZGQ1pHZHhWbU1LV2t4d1RYZDFkR3N6VVVaS1JUaGxORVJXZVVsQ2JrRmliRXN6VnpoaGVTOU5kM2R0ZDJsSWRETk5Ta3MwUWpkRWNuRldXRUUwVFRSUVlsRmpOMVJDU2dveWNEaDNhbll3THpobFNqbG5WVTFGUzI4cmVYWnlPVmxKV1U1NlJIbFJRVEpEV1hoMFJWTnpSR0ZTTjJaeWJrcHpZVmM0VmpOTFQxcGpSakpIS3pKQkNqSnBWemt2Y2l0bFRIUjZWVkZtU1hsbGJWWTFWRVJGYjNWbGEyeFNRMFJ3SzBSaVF3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9jODJlZDEwNy02YWZiLTRjMzAtYmU1Mi0xMWEzZDczN2U3ODAuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXNpemUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1zaXplIgogICAgdXNlcjogdGVzdC1wb29sLXNpemUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtc2l6ZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1zaXplLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBlZ04yR2ZKVjlpTEhNVmIwcERMNkhidFg2aFNBQWJncGpKdEIwVGN6bHprSVRLWEpUV2Y3UVllTA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e79ddfa6-c637-49dc-99b3-c0b1a77c7651.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.395909Z","created_at":"2023-11-07T15:49:53.395909Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e79ddfa6-c637-49dc-99b3-c0b1a77c7651.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":[],"type":"kapsule","updated_at":"2023-11-07T15:49:55.327661Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2606"
+      - "1411"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:57 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -339,45 +339,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c80d4b5c-0908-4de5-834f-02bdd6f29fb5
+      - ab4df752-3a8e-43dc-99b1-6c0176f74d40
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c82ed107-6afb-4c30-be52-11a3d737e780.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.807900Z","created_at":"2023-10-18T16:35:45.807900Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c82ed107-6afb-4c30-be52-11a3d737e780.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c82ed107-6afb-4c30-be52-11a3d737e780","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"da6880df-a94a-4f3e-8277-6150a6853c1c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":[],"type":"kapsule","updated_at":"2023-10-18T16:35:51.674265Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1454"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:35:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e0b9b544-5660-4b51-b915-bd09e77cdccb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"pool","node_type":"gp1_xs","placement_group_id":null,"autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":null,"kubelet_args":{},"upgrade_policy":null,"zone":"fr-par-1","root_volume_type":"default_volume_type","root_volume_size":null,"public_ip_disabled":false}'
+    body: '{"name":"pool","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":null,"kubelet_args":{},"zone":"fr-par-1","root_volume_type":"default_volume_type","public_ip_disabled":false}'
     form: {}
     headers:
       Content-Type:
@@ -385,19 +352,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289255Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853381998Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "618"
+      - "595"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:59 GMT
+      - Tue, 07 Nov 2023 15:49:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -407,7 +374,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df3c4744-d5cd-4648-8a78-4bb24421f51a
+      - 6d413054-a86c-4b35-bc88-759c9bff73c1
     status: 200 OK
     code: 200
     duration: ""
@@ -418,19 +385,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:59 GMT
+      - Tue, 07 Nov 2023 15:49:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -440,7 +407,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b1c2d83-ae68-4239-879e-33e00cbadd21
+      - e11fd724-11e2-49c7-a564-62f5b00441d9
     status: 200 OK
     code: 200
     duration: ""
@@ -451,19 +418,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:05 GMT
+      - Tue, 07 Nov 2023 15:50:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -473,7 +440,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16077522-063c-4527-8820-7e18e55225f1
+      - e164cb10-6f17-48ba-b3c0-5c38079b5ec1
     status: 200 OK
     code: 200
     duration: ""
@@ -484,19 +451,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:10 GMT
+      - Tue, 07 Nov 2023 15:50:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -506,7 +473,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc849cdd-ddd1-4612-b9ee-cf2f40f6367e
+      - 88b98aa8-b830-41d4-8e20-15c457f5ed81
     status: 200 OK
     code: 200
     duration: ""
@@ -517,19 +484,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:15 GMT
+      - Tue, 07 Nov 2023 15:50:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -539,7 +506,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 162aa0f6-36b9-44c7-8023-e98174ebdf7d
+      - a2b204fd-e0c8-48f7-8e2a-fe2ddd5f8d26
     status: 200 OK
     code: 200
     duration: ""
@@ -550,19 +517,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:21 GMT
+      - Tue, 07 Nov 2023 15:50:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -572,7 +539,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 698c7f4e-51f7-4e79-b89a-f2983ed641ba
+      - bdbf55d3-b732-4d61-86be-2006ae1e8c4c
     status: 200 OK
     code: 200
     duration: ""
@@ -583,19 +550,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:26 GMT
+      - Tue, 07 Nov 2023 15:50:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -605,7 +572,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5bdeb0fa-21eb-401c-be6b-11c0d6a65053
+      - 956c8433-2944-4728-8ec9-dde24ac4bf88
     status: 200 OK
     code: 200
     duration: ""
@@ -616,19 +583,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:31 GMT
+      - Tue, 07 Nov 2023 15:50:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -638,7 +605,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - adfa1699-4791-473a-9b22-2f4aa62f2524
+      - 349937b7-7701-4659-8ff0-f9c160826888
     status: 200 OK
     code: 200
     duration: ""
@@ -649,19 +616,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:36 GMT
+      - Tue, 07 Nov 2023 15:50:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -671,7 +638,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f31b9ef-c497-42de-8502-6eff8c3c07b2
+      - 4b20c13b-fd1c-4436-85e2-0975e9abc074
     status: 200 OK
     code: 200
     duration: ""
@@ -682,19 +649,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:41 GMT
+      - Tue, 07 Nov 2023 15:50:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -704,7 +671,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f06d7b9-cecd-4c41-85c3-99b390acb8ac
+      - fefbfcd9-fb5f-48f3-9ba4-156088c6d845
     status: 200 OK
     code: 200
     duration: ""
@@ -715,19 +682,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:46 GMT
+      - Tue, 07 Nov 2023 15:50:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -737,7 +704,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 609712b3-6e86-4b1d-93cf-3e3613b94611
+      - 5c1eb094-cf37-4e1d-8967-e5c366ba8b8f
     status: 200 OK
     code: 200
     duration: ""
@@ -748,19 +715,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:51 GMT
+      - Tue, 07 Nov 2023 15:50:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -770,7 +737,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed912eed-8a8a-48e0-ba5b-cfdbf5cab0b5
+      - 2ddcd36c-759b-4242-8462-3649040187ab
     status: 200 OK
     code: 200
     duration: ""
@@ -781,19 +748,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:56 GMT
+      - Tue, 07 Nov 2023 15:50:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -803,7 +770,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d79e1350-dc2a-4de7-8d39-0c8bf56407c3
+      - c43445e1-2fcb-43a8-bf45-0388cf1c36c9
     status: 200 OK
     code: 200
     duration: ""
@@ -814,19 +781,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:01 GMT
+      - Tue, 07 Nov 2023 15:51:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -836,7 +803,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 973a8ffe-0b9d-4480-ab38-fa4e44689c29
+      - 4476ddb2-af9a-46ac-bc51-a8f6057c23ce
     status: 200 OK
     code: 200
     duration: ""
@@ -847,19 +814,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:06 GMT
+      - Tue, 07 Nov 2023 15:51:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -869,7 +836,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10944ae9-01f2-4061-8c48-546e932b8788
+      - 770e29cf-8b38-45db-a78d-413f7e842516
     status: 200 OK
     code: 200
     duration: ""
@@ -880,19 +847,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:11 GMT
+      - Tue, 07 Nov 2023 15:51:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -902,7 +869,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ab95638-4882-40d0-b098-e242a9db7097
+      - a3f3d4d1-e153-48d3-bb17-e40d0434f141
     status: 200 OK
     code: 200
     duration: ""
@@ -913,19 +880,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:16 GMT
+      - Tue, 07 Nov 2023 15:51:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -935,7 +902,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0df6b23-2494-4469-a50c-633923e2c479
+      - 71985818-6ed0-4f4f-8fb2-b489393d3579
     status: 200 OK
     code: 200
     duration: ""
@@ -946,19 +913,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:21 GMT
+      - Tue, 07 Nov 2023 15:51:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -968,7 +935,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7f5b660-1552-4f15-9332-255fdb9c92fa
+      - aa7b3751-f092-404f-a672-ddbe81ad64d2
     status: 200 OK
     code: 200
     duration: ""
@@ -979,19 +946,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:26 GMT
+      - Tue, 07 Nov 2023 15:51:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1001,7 +968,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ef31ce5-16a1-4241-86f1-87f350f354f0
+      - 0c5ad233-1524-4db8-95fd-547dd4eceff7
     status: 200 OK
     code: 200
     duration: ""
@@ -1012,19 +979,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:31 GMT
+      - Tue, 07 Nov 2023 15:51:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1034,7 +1001,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be29497d-ddf0-49ca-ba95-d486c63e8d26
+      - 9a288e58-7824-4fe3-882d-00a79147d1f9
     status: 200 OK
     code: 200
     duration: ""
@@ -1045,19 +1012,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:36 GMT
+      - Tue, 07 Nov 2023 15:51:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1067,7 +1034,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2a012c2-8598-4f5d-ab93-0e2c4a817d67
+      - aaa00be4-82f9-4b12-b1d2-10c6e12f3aa8
     status: 200 OK
     code: 200
     duration: ""
@@ -1078,19 +1045,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:41 GMT
+      - Tue, 07 Nov 2023 15:51:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1100,7 +1067,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f949b5f-fc23-4955-8b53-e734a667dcb2
+      - 5e48519a-d5ca-4608-86d4-2e22d44e2981
     status: 200 OK
     code: 200
     duration: ""
@@ -1111,19 +1078,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:47 GMT
+      - Tue, 07 Nov 2023 15:51:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1133,7 +1100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fefb4c5d-f9bb-4a0d-8747-c376e260b7ae
+      - c2640eeb-aaf2-4994-8f24-2e03e07d4f8b
     status: 200 OK
     code: 200
     duration: ""
@@ -1144,19 +1111,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:52 GMT
+      - Tue, 07 Nov 2023 15:51:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1166,7 +1133,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a910596d-98fe-407d-a873-6331c93ded22
+      - 724ac307-9363-4db0-9f40-70a55a3520b7
     status: 200 OK
     code: 200
     duration: ""
@@ -1177,19 +1144,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:57 GMT
+      - Tue, 07 Nov 2023 15:51:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1199,7 +1166,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 189d1236-b54b-463b-9799-90471df8d8c7
+      - ff2629b2-fd31-4bae-a0af-75e118bb79b5
     status: 200 OK
     code: 200
     duration: ""
@@ -1210,19 +1177,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:02 GMT
+      - Tue, 07 Nov 2023 15:52:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1232,7 +1199,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03e80b28-d66d-4c3b-820f-f0bddfd489bf
+      - d1eff721-2b6e-4a7e-89c9-7e782fcee37f
     status: 200 OK
     code: 200
     duration: ""
@@ -1243,19 +1210,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:07 GMT
+      - Tue, 07 Nov 2023 15:52:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1265,7 +1232,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4ab6fc1-9d67-4573-966d-927eaace70c1
+      - 7c872128-0d1c-4654-9754-91593e44488b
     status: 200 OK
     code: 200
     duration: ""
@@ -1276,19 +1243,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:12 GMT
+      - Tue, 07 Nov 2023 15:52:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1298,7 +1265,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 477e8a51-57d2-4709-b5a8-43675b36e31a
+      - 89ac1dff-ba03-4259-92d5-35cd5d1059a0
     status: 200 OK
     code: 200
     duration: ""
@@ -1309,19 +1276,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:17 GMT
+      - Tue, 07 Nov 2023 15:52:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1331,7 +1298,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ef5b258-1d75-460d-bde4-8a9f74a6fcb5
+      - c456e972-34b6-4578-9586-7e42c70d5cad
     status: 200 OK
     code: 200
     duration: ""
@@ -1342,19 +1309,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:22 GMT
+      - Tue, 07 Nov 2023 15:52:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1364,7 +1331,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8486adfc-415d-42aa-bbee-e925bdfe52a9
+      - 23f78939-ea9d-4b89-a6d5-93752fae2fd8
     status: 200 OK
     code: 200
     duration: ""
@@ -1375,19 +1342,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:27 GMT
+      - Tue, 07 Nov 2023 15:52:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1397,7 +1364,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8e42956-b570-4f62-8014-d82567ce71ec
+      - 3b237fa0-1ba8-4e82-bd17-bdd30fe629ee
     status: 200 OK
     code: 200
     duration: ""
@@ -1408,19 +1375,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:32 GMT
+      - Tue, 07 Nov 2023 15:52:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1430,7 +1397,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d5ecfc4-b71e-4cb5-bea8-2c953f6de7c6
+      - 4828f77d-a9eb-4a17-b399-1247de5162dd
     status: 200 OK
     code: 200
     duration: ""
@@ -1441,19 +1408,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:37 GMT
+      - Tue, 07 Nov 2023 15:52:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1463,7 +1430,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f89ff293-4c84-49aa-a372-8fef24fdf50f
+      - c663eeff-27a2-491f-abe9-dcf020937ab0
     status: 200 OK
     code: 200
     duration: ""
@@ -1474,19 +1441,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:42 GMT
+      - Tue, 07 Nov 2023 15:52:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1496,7 +1463,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea8ef313-6f1d-43ae-bcbd-675963825c71
+      - c39b6710-24b9-42e5-b877-0b5b09e39798
     status: 200 OK
     code: 200
     duration: ""
@@ -1507,19 +1474,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:47 GMT
+      - Tue, 07 Nov 2023 15:52:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1529,7 +1496,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4d66ea7-0c44-4818-879e-3446b53de10a
+      - f8ecda96-049a-4d23-b9d1-738d71dd4606
     status: 200 OK
     code: 200
     duration: ""
@@ -1540,19 +1507,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:53 GMT
+      - Tue, 07 Nov 2023 15:52:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1562,7 +1529,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f58fada2-60c8-4747-9a96-1242bb44f2cb
+      - 9f5209d0-ecab-47f3-95e9-6aadda56461e
     status: 200 OK
     code: 200
     duration: ""
@@ -1573,19 +1540,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:58 GMT
+      - Tue, 07 Nov 2023 15:52:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1595,7 +1562,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9434bd04-0a51-493b-bf72-5b4580d2c468
+      - f511392b-cb00-47db-955f-f3d1d3e72e82
     status: 200 OK
     code: 200
     duration: ""
@@ -1606,19 +1573,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:03 GMT
+      - Tue, 07 Nov 2023 15:53:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1628,7 +1595,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d39bb62d-89e6-49ee-8532-be7c625df87b
+      - d11e932f-03cc-4543-a854-b30596252332
     status: 200 OK
     code: 200
     duration: ""
@@ -1639,19 +1606,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:08 GMT
+      - Tue, 07 Nov 2023 15:53:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1661,7 +1628,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 936e9b09-9008-4caf-bc8f-dd86b8705ff6
+      - cf4b4518-8a9c-4c63-aa76-f59d8d78b36a
     status: 200 OK
     code: 200
     duration: ""
@@ -1672,19 +1639,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:13 GMT
+      - Tue, 07 Nov 2023 15:53:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1694,7 +1661,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ae6b46c-a734-4f8f-8121-29eb1d06d519
+      - c7e76f8c-4ed7-40a8-bfbe-586335f7fa1a
     status: 200 OK
     code: 200
     duration: ""
@@ -1705,19 +1672,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:18 GMT
+      - Tue, 07 Nov 2023 15:53:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1727,7 +1694,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1cac3b66-f892-44eb-8737-33403c8e8b3e
+      - 87f16a69-d634-4aa2-bdee-79118eff1e2c
     status: 200 OK
     code: 200
     duration: ""
@@ -1738,19 +1705,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:23 GMT
+      - Tue, 07 Nov 2023 15:53:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1760,7 +1727,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 735e7777-8802-4037-9a8c-ebf6baeb4aaa
+      - 5afaec73-9b6d-438d-a9fa-b94be8f235e9
     status: 200 OK
     code: 200
     duration: ""
@@ -1771,19 +1738,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:28 GMT
+      - Tue, 07 Nov 2023 15:53:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1793,7 +1760,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a3fdcfe-dd1d-4969-8100-aa210fe198e1
+      - 16eab2a6-48b2-485e-9f20-1c6283be56e7
     status: 200 OK
     code: 200
     duration: ""
@@ -1804,19 +1771,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:33 GMT
+      - Tue, 07 Nov 2023 15:53:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1826,7 +1793,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ccab8ae6-5889-4863-bfca-0dd25d43c693
+      - 3a972c8c-5ce9-4835-a98d-12c4ecf4d32e
     status: 200 OK
     code: 200
     duration: ""
@@ -1837,19 +1804,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:38 GMT
+      - Tue, 07 Nov 2023 15:53:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1859,7 +1826,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 348c6863-8d47-4236-8377-6e7ddc184e71
+      - f0a89199-924c-4daa-a38e-bcfc37679e74
     status: 200 OK
     code: 200
     duration: ""
@@ -1870,19 +1837,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:43 GMT
+      - Tue, 07 Nov 2023 15:53:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1892,7 +1859,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf4e7ede-4221-4517-813c-c38c233bd717
+      - c4cf65f2-2973-49f5-98d4-3af76f9fce55
     status: 200 OK
     code: 200
     duration: ""
@@ -1903,19 +1870,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:48 GMT
+      - Tue, 07 Nov 2023 15:53:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1925,7 +1892,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - adfc31f4-8071-4ba6-b7a0-0d6b29bda1c8
+      - a11445cd-9bb3-4c10-b066-7a915484feb1
     status: 200 OK
     code: 200
     duration: ""
@@ -1936,19 +1903,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:53 GMT
+      - Tue, 07 Nov 2023 15:53:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1958,7 +1925,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16a21bdf-204f-441c-a02d-c01658eb003d
+      - 2f5b367a-edc8-4123-8d2f-32b7e1591b12
     status: 200 OK
     code: 200
     duration: ""
@@ -1969,19 +1936,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:58 GMT
+      - Tue, 07 Nov 2023 15:53:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1991,7 +1958,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7f5dd2c-dc2f-4487-b254-50dbdd66ca03
+      - 9f99880b-2208-4702-86a0-6eb82c991bd0
     status: 200 OK
     code: 200
     duration: ""
@@ -2002,19 +1969,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:03 GMT
+      - Tue, 07 Nov 2023 15:54:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2024,7 +1991,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5bab43ed-d041-497c-921c-d1c45c4933e7
+      - 0d99a81a-3a3f-44ee-b1f7-e9764203a241
     status: 200 OK
     code: 200
     duration: ""
@@ -2035,19 +2002,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:08 GMT
+      - Tue, 07 Nov 2023 15:54:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2057,7 +2024,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0897ee8-4115-4c71-9fb3-58a30ea86f66
+      - e1e8ae9a-8119-41a4-a7f4-706079da6bbe
     status: 200 OK
     code: 200
     duration: ""
@@ -2068,19 +2035,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:13 GMT
+      - Tue, 07 Nov 2023 15:54:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2090,7 +2057,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc989711-da43-4d56-a9e7-5e04d4b711e9
+      - edfdd9f2-9dbb-4818-82ea-98cf448da4f2
     status: 200 OK
     code: 200
     duration: ""
@@ -2101,19 +2068,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:19 GMT
+      - Tue, 07 Nov 2023 15:54:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2123,7 +2090,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b19dbbbd-f547-48f0-833c-4eb9d4ae78a6
+      - 1b0dbdad-86be-44ab-8aa5-1a508a48c3f2
     status: 200 OK
     code: 200
     duration: ""
@@ -2134,19 +2101,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:24 GMT
+      - Tue, 07 Nov 2023 15:54:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2156,7 +2123,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23b120c8-953a-40a6-ac01-941acaa3e4fc
+      - 6191e568-bfe5-46fd-92c8-904f859ddbd0
     status: 200 OK
     code: 200
     duration: ""
@@ -2167,19 +2134,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:29 GMT
+      - Tue, 07 Nov 2023 15:54:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2189,7 +2156,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3bcf1f6b-1c1e-4196-ac84-8b7d44bf5b92
+      - fc959185-0240-430b-a005-e4522955f248
     status: 200 OK
     code: 200
     duration: ""
@@ -2200,19 +2167,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:34 GMT
+      - Tue, 07 Nov 2023 15:54:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2222,7 +2189,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be9922fc-0e32-44f9-ac29-2f4d41566321
+      - 17579a1a-6c98-47e9-88c0-559e28130518
     status: 200 OK
     code: 200
     duration: ""
@@ -2233,19 +2200,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:39 GMT
+      - Tue, 07 Nov 2023 15:54:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2255,7 +2222,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1017262c-9bcd-48cd-bee7-7f57621c83a2
+      - f510feb7-6432-44f8-915a-3bda4041629e
     status: 200 OK
     code: 200
     duration: ""
@@ -2266,19 +2233,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:44 GMT
+      - Tue, 07 Nov 2023 15:54:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2288,7 +2255,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 47112030-ec74-4b65-a6fa-4c25af4566af
+      - 3d0a0f3e-8397-4b7e-8a0f-8bd23d9f799c
     status: 200 OK
     code: 200
     duration: ""
@@ -2299,19 +2266,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:49 GMT
+      - Tue, 07 Nov 2023 15:54:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2321,7 +2288,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe37f8e8-a6a0-4acd-8d57-fb78590930c7
+      - 3b71b560-4080-47a3-9173-d35c19b17f6b
     status: 200 OK
     code: 200
     duration: ""
@@ -2332,19 +2299,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:54 GMT
+      - Tue, 07 Nov 2023 15:54:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2354,7 +2321,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec1579e4-b732-4b81-bd2d-9a72738175bb
+      - 4a30c73d-d0f1-46e2-81ab-fd7b7aabccce
     status: 200 OK
     code: 200
     duration: ""
@@ -2365,19 +2332,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:59 GMT
+      - Tue, 07 Nov 2023 15:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2387,7 +2354,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af8213fe-d63e-4792-b345-b34cdc279e45
+      - 39e9ccb6-8d90-4f6b-b753-bcef52b2ee63
     status: 200 OK
     code: 200
     duration: ""
@@ -2398,19 +2365,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:04 GMT
+      - Tue, 07 Nov 2023 15:55:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2420,7 +2387,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84a4a98e-80ea-4d1f-857b-f1e1f69629b6
+      - 5d452fd9-41c8-48c9-9f5a-fc66836ddf48
     status: 200 OK
     code: 200
     duration: ""
@@ -2431,19 +2398,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:09 GMT
+      - Tue, 07 Nov 2023 15:55:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2453,7 +2420,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f86a9c9a-a442-4e5f-b928-22d5b940f420
+      - 064c107d-05ca-45b6-86a6-4bba3a8b23e6
     status: 200 OK
     code: 200
     duration: ""
@@ -2464,19 +2431,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:14 GMT
+      - Tue, 07 Nov 2023 15:55:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2486,7 +2453,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7c8ee61-b25a-4d9e-a6b0-1977395e9151
+      - 4efd39c0-d419-48bf-8fda-0b9d58d1904a
     status: 200 OK
     code: 200
     duration: ""
@@ -2497,19 +2464,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.853382Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:19 GMT
+      - Tue, 07 Nov 2023 15:55:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2519,7 +2486,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2fc7137-197b-434c-af41-8cd5754b5fb5
+      - 86bb51a8-5499-4661-a943-3bdd1bd687fc
     status: 200 OK
     code: 200
     duration: ""
@@ -2530,19 +2497,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:55:21.138409Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "590"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:24 GMT
+      - Tue, 07 Nov 2023 15:55:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2552,7 +2519,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2008c32c-3cc6-4748-a2d7-4faa0de04b31
+      - f031c964-91cb-46d7-9ce9-6cdb9c60979f
     status: 200 OK
     code: 200
     duration: ""
@@ -2563,19 +2530,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e79ddfa6-c637-49dc-99b3-c0b1a77c7651.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.395909Z","created_at":"2023-11-07T15:49:53.395909Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e79ddfa6-c637-49dc-99b3-c0b1a77c7651.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":[],"type":"kapsule","updated_at":"2023-11-07T15:51:23.428519Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "615"
+      - "1403"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:29 GMT
+      - Tue, 07 Nov 2023 15:55:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2585,7 +2552,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7633540-3702-45db-9dc2-cb0b2eba0999
+      - 0dbb34b8-4449-4bab-97d8-063a9ce47827
     status: 200 OK
     code: 200
     duration: ""
@@ -2596,19 +2563,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:55:21.138409Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "590"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:34 GMT
+      - Tue, 07 Nov 2023 15:55:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2618,7 +2585,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43d151c2-ed8f-4dbb-b4b9-28a7c94da452
+      - fc22b046-7347-41b0-b885-4376e9851a29
     status: 200 OK
     code: 200
     duration: ""
@@ -2629,19 +2596,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651/nodes?order_by=created_at_asc&page=1&pool_id=ca1816d2-cee8-4dbb-a2b7-b5426f828f4f&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:52:59.663925Z","error_message":null,"id":"fccb2aa2-f698-4860-b5d7-84f7c26c9c1e","name":"scw-test-pool-size-pool-fccb2aa2f6984860b5d784","pool_id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","provider_id":"scaleway://instance/fr-par-1/8e8866d0-1f44-4255-a8aa-e12aea3bf282","public_ip_v4":"51.158.78.84","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:55:21.123104Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "615"
+      - "640"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:39 GMT
+      - Tue, 07 Nov 2023 15:55:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2651,7 +2618,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 890dc258-d3fc-4e1c-8e42-fcc5456b01f2
+      - f76814a9-cff9-42e1-94b8-57eeec4c3031
     status: 200 OK
     code: 200
     duration: ""
@@ -2662,19 +2629,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/42e67a9e-cba6-407b-a764-9aea1e6574c7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-07T15:49:51.075136Z","dhcp_enabled":true,"id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","name":"test-pool-size","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.075136Z","id":"4e078c7b-4307-4239-bf9c-ea4d2f217c14","subnet":"172.16.80.0/22","updated_at":"2023-11-07T15:49:51.075136Z"},{"created_at":"2023-11-07T15:49:51.075136Z","id":"825fa982-e1b5-4dd1-b810-d7e91ef02fd1","subnet":"fd5f:519c:6d46:ebc6::/64","updated_at":"2023-11-07T15:49:51.075136Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.075136Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "615"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:44 GMT
+      - Tue, 07 Nov 2023 15:55:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2684,7 +2651,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed795849-7901-43df-8c7a-06874fbf4c6d
+      - 400d57d9-8f4f-43e8-b79b-79a4389e717e
     status: 200 OK
     code: 200
     duration: ""
@@ -2695,19 +2662,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e79ddfa6-c637-49dc-99b3-c0b1a77c7651.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.395909Z","created_at":"2023-11-07T15:49:53.395909Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e79ddfa6-c637-49dc-99b3-c0b1a77c7651.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":[],"type":"kapsule","updated_at":"2023-11-07T15:51:23.428519Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "615"
+      - "1403"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:49 GMT
+      - Tue, 07 Nov 2023 15:55:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2717,7 +2684,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31b37f1b-f946-412d-bd72-acfb94af2349
+      - a7beb66a-18ae-4ccb-a380-d2fdea9a88e3
     status: 200 OK
     code: 200
     duration: ""
@@ -2728,19 +2695,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1zaXplIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRuQnlDa0p1T1ZkWVptMVdhM2syTlcxNVEwVkZRM3AxTmtGb1pGaHlSbFZUV0RSemFEaENURkZyV1haTGIxWXpTV3BPV1dwdlJHdFZVbkJzVjBsNGFYRjFia3dLYjBsc05HNVFNak01TTJsbFMzWnZXR1J0TjA0eGRYVlFWMWRQVkVWUFFtVXdWRmMzUTJwYUswUnZVVlJxWkM4d1JIY3hVbGRsVERWQllpOVBLeTl2TWdvNGJtWXlTVkJCYWxkTGJFUlpiVWw0YkdOVGFFVkRlblZDVFd0V1NFRjZPR3RoV2trMWNpdExOR1V5Y0N0SkwzVjFUa1ZpT1VWWVYxWlRRbVJMWlVwSENtTnhXVEk0UVZsS1QzbHlSelV4TWxWQ015dHBXbXB2VFZZNU5XNTRTSGRDVldabE9IUjBPREYxV2t0WllXWkZUalJFZEZkclREaFRNbWt3T0cxTU1FRUtRVkJDWjI5M1oxVjFUME52Y2tGQk1XMDBlbUpOU3pscGNucGxXa1JIYWt3NGFrMDVkVXROYTBod1FWTllOVlpvZFhkelMxcFFPRWhEWkVGb1EyZzFid3BHTW5aNEwxcHZTV05uY2tONk1WcEhUM1l3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpMZERKaVRuUTVVekYwY2poeVNtczRiRzVRZWpFMVFuUkdaM0ZOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDYjFjM2FWcENNekZ0TDA1dFZtcEVTek5STjNCMVl6SkdWRlJKUkhOWVJrRlhhR3BKWkRaMFdWbE5hMkpOU0ZBelRncFhXVUYyTDBsalJGWnZNR2xyZVdKaGVsSnFNbEUxVG5walRVSkpjMlJPZVdGWE1VNTRVM2cwTDBZNEwyZFpUa2d3VjFOVmVHeHBkSEEzTjFWSGJrNVZDa3BwTlVOc1prTm1lR2syZVVzNVduTlZkRk5EY21wcFRYUkpWRmxaYzA1dFFrTnJZakY2VjFoT04yaFVObGRvWjBodGIzaDBXSFp0WnpCS1EweFphblVLY0hweGFFZDVUMFp6VVhCb1ZqWmxTa1pOUjJaT2FEbFNjbTFGY0VaamFVOWFlUzlsUkVscFFrNXVWbXhYUTJKS1EwMVlOQzlrWW14elZIUlpSbFpRV2dwdWExTXZja3BYTW00MGFGZFVNWGRoV2pBNGFtZHZWMFF5U2tSM1dIZFJZbkJ1UjBjd2VUSlVMeXQyY1ZKV2QzSnZXVWR5ZURZMFZ5dHdZaTh4UjFaTUNtTkdNR2x0WjNCNFJHaEtRalZYYkVVclUyUmlWamd5T1hKaWMzQmlibEZtTUROSlNBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9lNzlkZGZhNi1jNjM3LTQ5ZGMtOTliMy1jMGIxYTc3Yzc2NTEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXNpemUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1zaXplIgogICAgdXNlcjogdGVzdC1wb29sLXNpemUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtc2l6ZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1zaXplLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBWZXZjWHdGZklmc3VtcElvY3l2QUNEU1pGQWNOVzFRcng2bUpsZGdacjRDbmVkbjZKanRsMDhwQw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "615"
+      - "2604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:54 GMT
+      - Tue, 07 Nov 2023 15:55:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2750,7 +2717,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 508a6642-99b5-4089-9a89-e582439b7c61
+      - 336fe596-c7a2-4c12-866c-08c2a84956dd
     status: 200 OK
     code: 200
     duration: ""
@@ -2761,19 +2728,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:55:21.138409Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "590"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:59 GMT
+      - Tue, 07 Nov 2023 15:55:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2783,7 +2750,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2b1d16f-45c6-48bc-a6ee-03ba29769df4
+      - bcf94416-2bb6-4a81-b9b7-63701cb55824
     status: 200 OK
     code: 200
     duration: ""
@@ -2794,19 +2761,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651/nodes?order_by=created_at_asc&page=1&pool_id=ca1816d2-cee8-4dbb-a2b7-b5426f828f4f&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:52:59.663925Z","error_message":null,"id":"fccb2aa2-f698-4860-b5d7-84f7c26c9c1e","name":"scw-test-pool-size-pool-fccb2aa2f6984860b5d784","pool_id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","provider_id":"scaleway://instance/fr-par-1/8e8866d0-1f44-4255-a8aa-e12aea3bf282","public_ip_v4":"51.158.78.84","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:55:21.123104Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "615"
+      - "640"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:05 GMT
+      - Tue, 07 Nov 2023 15:55:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2816,7 +2783,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56c1b54a-5cd7-4382-beae-a0a0379a7e93
+      - 39daa3fa-b692-4fdc-92a9-b9c2becf5ff9
     status: 200 OK
     code: 200
     duration: ""
@@ -2827,19 +2794,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/42e67a9e-cba6-407b-a764-9aea1e6574c7
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-07T15:49:51.075136Z","dhcp_enabled":true,"id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","name":"test-pool-size","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.075136Z","id":"4e078c7b-4307-4239-bf9c-ea4d2f217c14","subnet":"172.16.80.0/22","updated_at":"2023-11-07T15:49:51.075136Z"},{"created_at":"2023-11-07T15:49:51.075136Z","id":"825fa982-e1b5-4dd1-b810-d7e91ef02fd1","subnet":"fd5f:519c:6d46:ebc6::/64","updated_at":"2023-11-07T15:49:51.075136Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.075136Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "615"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:10 GMT
+      - Tue, 07 Nov 2023 15:55:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2849,7 +2816,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51b897da-5474-4059-9856-fb45b5f88c76
+      - 7a35990d-05a8-4ad7-a82f-d5bcb3461368
     status: 200 OK
     code: 200
     duration: ""
@@ -2860,19 +2827,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e79ddfa6-c637-49dc-99b3-c0b1a77c7651.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.395909Z","created_at":"2023-11-07T15:49:53.395909Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e79ddfa6-c637-49dc-99b3-c0b1a77c7651.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":[],"type":"kapsule","updated_at":"2023-11-07T15:51:23.428519Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "615"
+      - "1403"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:15 GMT
+      - Tue, 07 Nov 2023 15:55:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2882,7 +2849,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 258edfc2-7b08-4abd-9445-e023e426394b
+      - e468d9c9-84d4-44b0-ba4c-092c8fb3c6a5
     status: 200 OK
     code: 200
     duration: ""
@@ -2893,19 +2860,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1zaXplIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRuQnlDa0p1T1ZkWVptMVdhM2syTlcxNVEwVkZRM3AxTmtGb1pGaHlSbFZUV0RSemFEaENURkZyV1haTGIxWXpTV3BPV1dwdlJHdFZVbkJzVjBsNGFYRjFia3dLYjBsc05HNVFNak01TTJsbFMzWnZXR1J0TjA0eGRYVlFWMWRQVkVWUFFtVXdWRmMzUTJwYUswUnZVVlJxWkM4d1JIY3hVbGRsVERWQllpOVBLeTl2TWdvNGJtWXlTVkJCYWxkTGJFUlpiVWw0YkdOVGFFVkRlblZDVFd0V1NFRjZPR3RoV2trMWNpdExOR1V5Y0N0SkwzVjFUa1ZpT1VWWVYxWlRRbVJMWlVwSENtTnhXVEk0UVZsS1QzbHlSelV4TWxWQ015dHBXbXB2VFZZNU5XNTRTSGRDVldabE9IUjBPREYxV2t0WllXWkZUalJFZEZkclREaFRNbWt3T0cxTU1FRUtRVkJDWjI5M1oxVjFUME52Y2tGQk1XMDBlbUpOU3pscGNucGxXa1JIYWt3NGFrMDVkVXROYTBod1FWTllOVlpvZFhkelMxcFFPRWhEWkVGb1EyZzFid3BHTW5aNEwxcHZTV05uY2tONk1WcEhUM1l3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpMZERKaVRuUTVVekYwY2poeVNtczRiRzVRZWpFMVFuUkdaM0ZOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDYjFjM2FWcENNekZ0TDA1dFZtcEVTek5STjNCMVl6SkdWRlJKUkhOWVJrRlhhR3BKWkRaMFdWbE5hMkpOU0ZBelRncFhXVUYyTDBsalJGWnZNR2xyZVdKaGVsSnFNbEUxVG5walRVSkpjMlJPZVdGWE1VNTRVM2cwTDBZNEwyZFpUa2d3VjFOVmVHeHBkSEEzTjFWSGJrNVZDa3BwTlVOc1prTm1lR2syZVVzNVduTlZkRk5EY21wcFRYUkpWRmxaYzA1dFFrTnJZakY2VjFoT04yaFVObGRvWjBodGIzaDBXSFp0WnpCS1EweFphblVLY0hweGFFZDVUMFp6VVhCb1ZqWmxTa1pOUjJaT2FEbFNjbTFGY0VaamFVOWFlUzlsUkVscFFrNXVWbXhYUTJKS1EwMVlOQzlrWW14elZIUlpSbFpRV2dwdWExTXZja3BYTW00MGFGZFVNWGRoV2pBNGFtZHZWMFF5U2tSM1dIZFJZbkJ1UjBjd2VUSlVMeXQyY1ZKV2QzSnZXVWR5ZURZMFZ5dHdZaTh4UjFaTUNtTkdNR2x0WjNCNFJHaEtRalZYYkVVclUyUmlWamd5T1hKaWMzQmlibEZtTUROSlNBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9lNzlkZGZhNi1jNjM3LTQ5ZGMtOTliMy1jMGIxYTc3Yzc2NTEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXNpemUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1zaXplIgogICAgdXNlcjogdGVzdC1wb29sLXNpemUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtc2l6ZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1zaXplLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBWZXZjWHdGZklmc3VtcElvY3l2QUNEU1pGQWNOVzFRcng2bUpsZGdacjRDbmVkbjZKanRsMDhwQw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "615"
+      - "2604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:20 GMT
+      - Tue, 07 Nov 2023 15:55:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2915,7 +2882,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc0ad493-9073-46a8-9c36-cd50fd8818b0
+      - 50470fe4-c323-4ad9-af16-ef1969cde583
     status: 200 OK
     code: 200
     duration: ""
@@ -2926,19 +2893,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-18T16:35:58.226289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:55:21.138409Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "615"
+      - "590"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:25 GMT
+      - Tue, 07 Nov 2023 15:55:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2948,7 +2915,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0231c3c8-ceb1-4ddf-b176-29076fb07073
+      - d4c9e575-e361-4dd6-8b59-f14c3eb0c128
     status: 200 OK
     code: 200
     duration: ""
@@ -2959,19 +2926,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651/nodes?order_by=created_at_asc&page=1&pool_id=ca1816d2-cee8-4dbb-a2b7-b5426f828f4f&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-18T16:42:25.423707Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:52:59.663925Z","error_message":null,"id":"fccb2aa2-f698-4860-b5d7-84f7c26c9c1e","name":"scw-test-pool-size-pool-fccb2aa2f6984860b5d784","pool_id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","provider_id":"scaleway://instance/fr-par-1/8e8866d0-1f44-4255-a8aa-e12aea3bf282","public_ip_v4":"51.158.78.84","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:55:21.123104Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "613"
+      - "640"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:30 GMT
+      - Tue, 07 Nov 2023 15:55:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2981,7 +2948,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55380260-db41-4a08-9caf-9f053868412a
+      - f693bb94-255d-48e4-ac3c-31bc0adfd857
     status: 200 OK
     code: 200
     duration: ""
@@ -2992,19 +2959,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/42e67a9e-cba6-407b-a764-9aea1e6574c7
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c82ed107-6afb-4c30-be52-11a3d737e780.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.807900Z","created_at":"2023-10-18T16:35:45.807900Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c82ed107-6afb-4c30-be52-11a3d737e780.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c82ed107-6afb-4c30-be52-11a3d737e780","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"da6880df-a94a-4f3e-8277-6150a6853c1c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"kapsule","updated_at":"2023-10-18T16:37:25.299493Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"created_at":"2023-11-07T15:49:51.075136Z","dhcp_enabled":true,"id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","name":"test-pool-size","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:51.075136Z","id":"4e078c7b-4307-4239-bf9c-ea4d2f217c14","subnet":"172.16.80.0/22","updated_at":"2023-11-07T15:49:51.075136Z"},{"created_at":"2023-11-07T15:49:51.075136Z","id":"825fa982-e1b5-4dd1-b810-d7e91ef02fd1","subnet":"fd5f:519c:6d46:ebc6::/64","updated_at":"2023-11-07T15:49:51.075136Z"}],"tags":[],"updated_at":"2023-11-07T15:49:51.075136Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "1446"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:30 GMT
+      - Tue, 07 Nov 2023 15:55:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3014,7 +2981,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 300836c9-63f3-4d94-8f54-5ee7c157d3ed
+      - 483b10af-bd9b-437e-be11-7956bfb443da
     status: 200 OK
     code: 200
     duration: ""
@@ -3025,19 +2992,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-18T16:42:25.423707Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e79ddfa6-c637-49dc-99b3-c0b1a77c7651.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.395909Z","created_at":"2023-11-07T15:49:53.395909Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e79ddfa6-c637-49dc-99b3-c0b1a77c7651.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":[],"type":"kapsule","updated_at":"2023-11-07T15:51:23.428519Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "613"
+      - "1403"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:30 GMT
+      - Tue, 07 Nov 2023 15:55:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3047,7 +3014,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 813ac9c4-7c3c-4973-bf20-ebe5df7e22ba
+      - 0a2e1a7d-ce1d-4967-847a-726dcaaa119d
     status: 200 OK
     code: 200
     duration: ""
@@ -3058,19 +3025,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780/nodes?order_by=created_at_asc&page=1&pool_id=36d4af35-38dd-43ed-b018-0c2276ba501e&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651/kubeconfig
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:37:52.206981Z","error_message":null,"id":"db82eee8-2227-4175-96d8-73a9140bb89c","name":"scw-test-pool-size-pool-db82eee82227417596d873","pool_id":"36d4af35-38dd-43ed-b018-0c2276ba501e","provider_id":"scaleway://instance/fr-par-1/bbb9fa61-5605-4403-b8ae-13ea3b0a9433","public_ip_v4":"51.158.121.51","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:42:25.409288Z"}],"total_count":1}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1zaXplIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRuQnlDa0p1T1ZkWVptMVdhM2syTlcxNVEwVkZRM3AxTmtGb1pGaHlSbFZUV0RSemFEaENURkZyV1haTGIxWXpTV3BPV1dwdlJHdFZVbkJzVjBsNGFYRjFia3dLYjBsc05HNVFNak01TTJsbFMzWnZXR1J0TjA0eGRYVlFWMWRQVkVWUFFtVXdWRmMzUTJwYUswUnZVVlJxWkM4d1JIY3hVbGRsVERWQllpOVBLeTl2TWdvNGJtWXlTVkJCYWxkTGJFUlpiVWw0YkdOVGFFVkRlblZDVFd0V1NFRjZPR3RoV2trMWNpdExOR1V5Y0N0SkwzVjFUa1ZpT1VWWVYxWlRRbVJMWlVwSENtTnhXVEk0UVZsS1QzbHlSelV4TWxWQ015dHBXbXB2VFZZNU5XNTRTSGRDVldabE9IUjBPREYxV2t0WllXWkZUalJFZEZkclREaFRNbWt3T0cxTU1FRUtRVkJDWjI5M1oxVjFUME52Y2tGQk1XMDBlbUpOU3pscGNucGxXa1JIYWt3NGFrMDVkVXROYTBod1FWTllOVlpvZFhkelMxcFFPRWhEWkVGb1EyZzFid3BHTW5aNEwxcHZTV05uY2tONk1WcEhUM1l3UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpMZERKaVRuUTVVekYwY2poeVNtczRiRzVRZWpFMVFuUkdaM0ZOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDYjFjM2FWcENNekZ0TDA1dFZtcEVTek5STjNCMVl6SkdWRlJKUkhOWVJrRlhhR3BKWkRaMFdWbE5hMkpOU0ZBelRncFhXVUYyTDBsalJGWnZNR2xyZVdKaGVsSnFNbEUxVG5walRVSkpjMlJPZVdGWE1VNTRVM2cwTDBZNEwyZFpUa2d3VjFOVmVHeHBkSEEzTjFWSGJrNVZDa3BwTlVOc1prTm1lR2syZVVzNVduTlZkRk5EY21wcFRYUkpWRmxaYzA1dFFrTnJZakY2VjFoT04yaFVObGRvWjBodGIzaDBXSFp0WnpCS1EweFphblVLY0hweGFFZDVUMFp6VVhCb1ZqWmxTa1pOUjJaT2FEbFNjbTFGY0VaamFVOWFlUzlsUkVscFFrNXVWbXhYUTJKS1EwMVlOQzlrWW14elZIUlpSbFpRV2dwdWExTXZja3BYTW00MGFGZFVNWGRoV2pBNGFtZHZWMFF5U2tSM1dIZFJZbkJ1UjBjd2VUSlVMeXQyY1ZKV2QzSnZXVWR5ZURZMFZ5dHdZaTh4UjFaTUNtTkdNR2x0WjNCNFJHaEtRalZYYkVVclUyUmlWamd5T1hKaWMzQmlibEZtTUROSlNBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9lNzlkZGZhNi1jNjM3LTQ5ZGMtOTliMy1jMGIxYTc3Yzc2NTEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXNpemUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1zaXplIgogICAgdXNlcjogdGVzdC1wb29sLXNpemUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtc2l6ZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1zaXplLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBWZXZjWHdGZklmc3VtcElvY3l2QUNEU1pGQWNOVzFRcng2bUpsZGdacjRDbmVkbjZKanRsMDhwQw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "658"
+      - "2604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:30 GMT
+      - Tue, 07 Nov 2023 15:55:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3080,7 +3047,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3a39a8e-be5f-4730-a6c5-ac4afd8dce77
+      - 69ac39e9-c59d-46d4-a686-fbee4728c2db
     status: 200 OK
     code: 200
     duration: ""
@@ -3091,19 +3058,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/da6880df-a94a-4f3e-8277-6150a6853c1c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:35:44.548859Z","dhcp_enabled":true,"id":"da6880df-a94a-4f3e-8277-6150a6853c1c","name":"test-pool-size","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:35:44.548859Z","id":"d60333a2-6c87-424b-a126-dcd786170153","subnet":"172.16.16.0/22","updated_at":"2023-10-18T16:35:44.548859Z"},{"created_at":"2023-10-18T16:35:44.548859Z","id":"e4b70249-f22f-4e9f-93b5-be9c9beb9af7","subnet":"fd63:256c:45f7:de01::/64","updated_at":"2023-10-18T16:35:44.548859Z"}],"tags":[],"updated_at":"2023-10-18T16:35:44.548859Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:55:21.138409Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "715"
+      - "590"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:30 GMT
+      - Tue, 07 Nov 2023 15:55:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3113,7 +3080,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26fa94be-7ded-46eb-a25c-0636975e6ea3
+      - 0f75af08-bf00-4856-84ab-095dae4a0449
     status: 200 OK
     code: 200
     duration: ""
@@ -3124,19 +3091,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651/nodes?order_by=created_at_asc&page=1&pool_id=ca1816d2-cee8-4dbb-a2b7-b5426f828f4f&status=unknown
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c82ed107-6afb-4c30-be52-11a3d737e780.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.807900Z","created_at":"2023-10-18T16:35:45.807900Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c82ed107-6afb-4c30-be52-11a3d737e780.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c82ed107-6afb-4c30-be52-11a3d737e780","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"da6880df-a94a-4f3e-8277-6150a6853c1c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"kapsule","updated_at":"2023-10-18T16:37:25.299493Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"nodes":[{"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:52:59.663925Z","error_message":null,"id":"fccb2aa2-f698-4860-b5d7-84f7c26c9c1e","name":"scw-test-pool-size-pool-fccb2aa2f6984860b5d784","pool_id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","provider_id":"scaleway://instance/fr-par-1/8e8866d0-1f44-4255-a8aa-e12aea3bf282","public_ip_v4":"51.158.78.84","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:55:21.123104Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1446"
+      - "640"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:30 GMT
+      - Tue, 07 Nov 2023 15:55:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3146,7 +3113,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28680945-fa63-426a-9e64-41856068759c
+      - 1687cf05-353b-46c9-a484-3bd4a9d34c47
     status: 200 OK
     code: 200
     duration: ""
@@ -3157,448 +3124,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1zaXplIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VFhwVk1VMVdiMWhFVkUxNlRWUkJlRTU2UlRKTmVsVXhUVlp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlNuTlRDbEJzZDIxeE1FUTVWVzFzTlZwNVVVWnlaRTVZTlZodWIzUkxNMnBEVDJKYVpHRmhlRWgxVWtGbVFXWjFaVTFrYzJkdldrTnVlRFk1VDJJM0wweExhVklLV0RoNWJrSlVObHBEV2xObGJXcG1WMDlwYzFWNU5sSm9iRUZWWnpjMmMxaE9UV05RYldoNU5YbGhPRFl5Y2xoS1pGSllWRGRwVG5wSFNVOTFSVkpvUndwTGNuQnhSbmswVlhoWVpGb3lTSFJuZVVSUFZHWTFZbTFvYm1aMlpVcEJkMVJIWnpkUFQxWjZSMjQ1UVdoRFZHNHlhMUFyTmtsdVUxTXdSbVZwTUN0MENtRm5aRWRWZUhaS2QycE9PV2RGT0M5dFdsTkZkRk5pU1hCWlMwbHJSVGh6WlRaWU9HMHdVRWxOYkRORlMyaGtUSHBuY210RWJsWnlWMEV2WmxkM0x6QUtTa1ZYY1hrNVQydFBWM05ZV0M4eFlXUkdNRTlRYUZkVWJIYzVUbWN3YzJkclVTOU1VVU5MZVRSQ1NqTklXRWMwWldNd1FVaG1OSFZIYzJ0R2VrY3ZhUXBrTkdac2MwdHpSM3B1U1d3dlFYTmxkV3ROUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpNVWpsbGNGQTNha0ZuTlVSTFZteHJkSFpJVGxGbVNYcEphMFpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDTkZaQlNWZDNhVlJhZEhGcGFrNTNlSFZoWkZwYVNrVlNNRlU1Wm5adVlreFpTVEZNZFU1NGJURnhUbkJ6WmxGWk9RcHdNblJ3YTJZeGR6bHJOeTlKYXpSS1NsVm5VWFZ2YVZjMGR6QnlkWEJoZVRaekx5dHZjbFpzTlZsdWMwdHVWMHB2U0RabmVrOUNUakZZY1dWaWFFa3pDalV3YTI1SlFsWlVjSGh0WkZkQlZIZFVhVU0yUm1rd05qQXdjVFEyUW0xSmVrc3pMM0EwTjJkQlRWWk9kVU16Ym5SWFNEVnROak5qY0ZGQ1pHZHhWbU1LV2t4d1RYZDFkR3N6VVVaS1JUaGxORVJXZVVsQ2JrRmliRXN6VnpoaGVTOU5kM2R0ZDJsSWRETk5Ta3MwUWpkRWNuRldXRUUwVFRSUVlsRmpOMVJDU2dveWNEaDNhbll3THpobFNqbG5WVTFGUzI4cmVYWnlPVmxKV1U1NlJIbFJRVEpEV1hoMFJWTnpSR0ZTTjJaeWJrcHpZVmM0VmpOTFQxcGpSakpIS3pKQkNqSnBWemt2Y2l0bFRIUjZWVkZtU1hsbGJWWTFWRVJGYjNWbGEyeFNRMFJ3SzBSaVF3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9jODJlZDEwNy02YWZiLTRjMzAtYmU1Mi0xMWEzZDczN2U3ODAuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXNpemUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1zaXplIgogICAgdXNlcjogdGVzdC1wb29sLXNpemUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtc2l6ZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1zaXplLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBlZ04yR2ZKVjlpTEhNVmIwcERMNkhidFg2aFNBQWJncGpKdEIwVGN6bHprSVRLWEpUV2Y3UVllTA==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2606"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5aa51e6a-1b32-4ed2-8b7a-3257c233ca72
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-18T16:42:25.423707Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "613"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a7b97027-90fa-4754-9c8b-b6043308586b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780/nodes?order_by=created_at_asc&page=1&pool_id=36d4af35-38dd-43ed-b018-0c2276ba501e&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:37:52.206981Z","error_message":null,"id":"db82eee8-2227-4175-96d8-73a9140bb89c","name":"scw-test-pool-size-pool-db82eee82227417596d873","pool_id":"36d4af35-38dd-43ed-b018-0c2276ba501e","provider_id":"scaleway://instance/fr-par-1/bbb9fa61-5605-4403-b8ae-13ea3b0a9433","public_ip_v4":"51.158.121.51","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:42:25.409288Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "658"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 30029ccf-ceb4-44e6-ab3c-e9060c6b4a80
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/da6880df-a94a-4f3e-8277-6150a6853c1c
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-18T16:35:44.548859Z","dhcp_enabled":true,"id":"da6880df-a94a-4f3e-8277-6150a6853c1c","name":"test-pool-size","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:35:44.548859Z","id":"d60333a2-6c87-424b-a126-dcd786170153","subnet":"172.16.16.0/22","updated_at":"2023-10-18T16:35:44.548859Z"},{"created_at":"2023-10-18T16:35:44.548859Z","id":"e4b70249-f22f-4e9f-93b5-be9c9beb9af7","subnet":"fd63:256c:45f7:de01::/64","updated_at":"2023-10-18T16:35:44.548859Z"}],"tags":[],"updated_at":"2023-10-18T16:35:44.548859Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "715"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7f655957-c72a-4042-b767-ebf4ae708bb5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c82ed107-6afb-4c30-be52-11a3d737e780.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.807900Z","created_at":"2023-10-18T16:35:45.807900Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c82ed107-6afb-4c30-be52-11a3d737e780.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c82ed107-6afb-4c30-be52-11a3d737e780","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"da6880df-a94a-4f3e-8277-6150a6853c1c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"kapsule","updated_at":"2023-10-18T16:37:25.299493Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1446"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 67f92a69-00a1-4c9f-84ea-b64e8430eb6e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1zaXplIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VFhwVk1VMVdiMWhFVkUxNlRWUkJlRTU2UlRKTmVsVXhUVlp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlNuTlRDbEJzZDIxeE1FUTVWVzFzTlZwNVVVWnlaRTVZTlZodWIzUkxNMnBEVDJKYVpHRmhlRWgxVWtGbVFXWjFaVTFrYzJkdldrTnVlRFk1VDJJM0wweExhVklLV0RoNWJrSlVObHBEV2xObGJXcG1WMDlwYzFWNU5sSm9iRUZWWnpjMmMxaE9UV05RYldoNU5YbGhPRFl5Y2xoS1pGSllWRGRwVG5wSFNVOTFSVkpvUndwTGNuQnhSbmswVlhoWVpGb3lTSFJuZVVSUFZHWTFZbTFvYm1aMlpVcEJkMVJIWnpkUFQxWjZSMjQ1UVdoRFZHNHlhMUFyTmtsdVUxTXdSbVZwTUN0MENtRm5aRWRWZUhaS2QycE9PV2RGT0M5dFdsTkZkRk5pU1hCWlMwbHJSVGh6WlRaWU9HMHdVRWxOYkRORlMyaGtUSHBuY210RWJsWnlWMEV2WmxkM0x6QUtTa1ZYY1hrNVQydFBWM05ZV0M4eFlXUkdNRTlRYUZkVWJIYzVUbWN3YzJkclVTOU1VVU5MZVRSQ1NqTklXRWMwWldNd1FVaG1OSFZIYzJ0R2VrY3ZhUXBrTkdac2MwdHpSM3B1U1d3dlFYTmxkV3ROUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpNVWpsbGNGQTNha0ZuTlVSTFZteHJkSFpJVGxGbVNYcEphMFpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDTkZaQlNWZDNhVlJhZEhGcGFrNTNlSFZoWkZwYVNrVlNNRlU1Wm5adVlreFpTVEZNZFU1NGJURnhUbkJ6WmxGWk9RcHdNblJ3YTJZeGR6bHJOeTlKYXpSS1NsVm5VWFZ2YVZjMGR6QnlkWEJoZVRaekx5dHZjbFpzTlZsdWMwdHVWMHB2U0RabmVrOUNUakZZY1dWaWFFa3pDalV3YTI1SlFsWlVjSGh0WkZkQlZIZFVhVU0yUm1rd05qQXdjVFEyUW0xSmVrc3pMM0EwTjJkQlRWWk9kVU16Ym5SWFNEVnROak5qY0ZGQ1pHZHhWbU1LV2t4d1RYZDFkR3N6VVVaS1JUaGxORVJXZVVsQ2JrRmliRXN6VnpoaGVTOU5kM2R0ZDJsSWRETk5Ta3MwUWpkRWNuRldXRUUwVFRSUVlsRmpOMVJDU2dveWNEaDNhbll3THpobFNqbG5WVTFGUzI4cmVYWnlPVmxKV1U1NlJIbFJRVEpEV1hoMFJWTnpSR0ZTTjJaeWJrcHpZVmM0VmpOTFQxcGpSakpIS3pKQkNqSnBWemt2Y2l0bFRIUjZWVkZtU1hsbGJWWTFWRVJGYjNWbGEyeFNRMFJ3SzBSaVF3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9jODJlZDEwNy02YWZiLTRjMzAtYmU1Mi0xMWEzZDczN2U3ODAuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXNpemUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1zaXplIgogICAgdXNlcjogdGVzdC1wb29sLXNpemUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtc2l6ZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1zaXplLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBlZ04yR2ZKVjlpTEhNVmIwcERMNkhidFg2aFNBQWJncGpKdEIwVGN6bHprSVRLWEpUV2Y3UVllTA==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2606"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1a47697f-b616-45d6-854c-a8e70d13f59a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-18T16:42:25.423707Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "613"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8df9b2c2-7e4c-487d-81c8-9461d165efb4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780/nodes?order_by=created_at_asc&page=1&pool_id=36d4af35-38dd-43ed-b018-0c2276ba501e&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:37:52.206981Z","error_message":null,"id":"db82eee8-2227-4175-96d8-73a9140bb89c","name":"scw-test-pool-size-pool-db82eee82227417596d873","pool_id":"36d4af35-38dd-43ed-b018-0c2276ba501e","provider_id":"scaleway://instance/fr-par-1/bbb9fa61-5605-4403-b8ae-13ea3b0a9433","public_ip_v4":"51.158.121.51","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:42:25.409288Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "658"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 25f7db5a-c136-4108-98f5-58b33079f98a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/da6880df-a94a-4f3e-8277-6150a6853c1c
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-18T16:35:44.548859Z","dhcp_enabled":true,"id":"da6880df-a94a-4f3e-8277-6150a6853c1c","name":"test-pool-size","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:35:44.548859Z","id":"d60333a2-6c87-424b-a126-dcd786170153","subnet":"172.16.16.0/22","updated_at":"2023-10-18T16:35:44.548859Z"},{"created_at":"2023-10-18T16:35:44.548859Z","id":"e4b70249-f22f-4e9f-93b5-be9c9beb9af7","subnet":"fd63:256c:45f7:de01::/64","updated_at":"2023-10-18T16:35:44.548859Z"}],"tags":[],"updated_at":"2023-10-18T16:35:44.548859Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "715"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3db28870-2ff8-4589-aed5-e1abb3b64a9f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c82ed107-6afb-4c30-be52-11a3d737e780.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.807900Z","created_at":"2023-10-18T16:35:45.807900Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c82ed107-6afb-4c30-be52-11a3d737e780.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c82ed107-6afb-4c30-be52-11a3d737e780","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"da6880df-a94a-4f3e-8277-6150a6853c1c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":[],"type":"kapsule","updated_at":"2023-10-18T16:37:25.299493Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1446"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d8cd17d1-9f28-4d34-8d38-61022045f9fd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC1zaXplIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VFhwVk1VMVdiMWhFVkUxNlRWUkJlRTU2UlRKTmVsVXhUVlp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlNuTlRDbEJzZDIxeE1FUTVWVzFzTlZwNVVVWnlaRTVZTlZodWIzUkxNMnBEVDJKYVpHRmhlRWgxVWtGbVFXWjFaVTFrYzJkdldrTnVlRFk1VDJJM0wweExhVklLV0RoNWJrSlVObHBEV2xObGJXcG1WMDlwYzFWNU5sSm9iRUZWWnpjMmMxaE9UV05RYldoNU5YbGhPRFl5Y2xoS1pGSllWRGRwVG5wSFNVOTFSVkpvUndwTGNuQnhSbmswVlhoWVpGb3lTSFJuZVVSUFZHWTFZbTFvYm1aMlpVcEJkMVJIWnpkUFQxWjZSMjQ1UVdoRFZHNHlhMUFyTmtsdVUxTXdSbVZwTUN0MENtRm5aRWRWZUhaS2QycE9PV2RGT0M5dFdsTkZkRk5pU1hCWlMwbHJSVGh6WlRaWU9HMHdVRWxOYkRORlMyaGtUSHBuY210RWJsWnlWMEV2WmxkM0x6QUtTa1ZYY1hrNVQydFBWM05ZV0M4eFlXUkdNRTlRYUZkVWJIYzVUbWN3YzJkclVTOU1VVU5MZVRSQ1NqTklXRWMwWldNd1FVaG1OSFZIYzJ0R2VrY3ZhUXBrTkdac2MwdHpSM3B1U1d3dlFYTmxkV3ROUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpNVWpsbGNGQTNha0ZuTlVSTFZteHJkSFpJVGxGbVNYcEphMFpOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZDTkZaQlNWZDNhVlJhZEhGcGFrNTNlSFZoWkZwYVNrVlNNRlU1Wm5adVlreFpTVEZNZFU1NGJURnhUbkJ6WmxGWk9RcHdNblJ3YTJZeGR6bHJOeTlKYXpSS1NsVm5VWFZ2YVZjMGR6QnlkWEJoZVRaekx5dHZjbFpzTlZsdWMwdHVWMHB2U0RabmVrOUNUakZZY1dWaWFFa3pDalV3YTI1SlFsWlVjSGh0WkZkQlZIZFVhVU0yUm1rd05qQXdjVFEyUW0xSmVrc3pMM0EwTjJkQlRWWk9kVU16Ym5SWFNEVnROak5qY0ZGQ1pHZHhWbU1LV2t4d1RYZDFkR3N6VVVaS1JUaGxORVJXZVVsQ2JrRmliRXN6VnpoaGVTOU5kM2R0ZDJsSWRETk5Ta3MwUWpkRWNuRldXRUUwVFRSUVlsRmpOMVJDU2dveWNEaDNhbll3THpobFNqbG5WVTFGUzI4cmVYWnlPVmxKV1U1NlJIbFJRVEpEV1hoMFJWTnpSR0ZTTjJaeWJrcHpZVmM0VmpOTFQxcGpSakpIS3pKQkNqSnBWemt2Y2l0bFRIUjZWVkZtU1hsbGJWWTFWRVJGYjNWbGEyeFNRMFJ3SzBSaVF3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly9jODJlZDEwNy02YWZiLTRjMzAtYmU1Mi0xMWEzZDczN2U3ODAuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXNpemUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC1zaXplIgogICAgdXNlcjogdGVzdC1wb29sLXNpemUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtc2l6ZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC1zaXplLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBlZ04yR2ZKVjlpTEhNVmIwcERMNkhidFg2aFNBQWJncGpKdEIwVGN6bHprSVRLWEpUV2Y3UVllTA==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2606"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 35ad99f7-7109-4c27-9421-3803e9888e20
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-18T16:42:25.423707Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "613"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4dbfff49-16a1-4f2a-aace-464e6dfaf936
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780/nodes?order_by=created_at_asc&page=1&pool_id=36d4af35-38dd-43ed-b018-0c2276ba501e&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:37:52.206981Z","error_message":null,"id":"db82eee8-2227-4175-96d8-73a9140bb89c","name":"scw-test-pool-size-pool-db82eee82227417596d873","pool_id":"36d4af35-38dd-43ed-b018-0c2276ba501e","provider_id":"scaleway://instance/fr-par-1/bbb9fa61-5605-4403-b8ae-13ea3b0a9433","public_ip_v4":"51.158.121.51","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:42:25.409288Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "658"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5e787489-a102-4637-8d79-20dd673055ac
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/36d4af35-38dd-43ed-b018-0c2276ba501e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"c82ed107-6afb-4c30-be52-11a3d737e780","container_runtime":"containerd","created_at":"2023-10-18T16:35:57.887111Z","id":"36d4af35-38dd-43ed-b018-0c2276ba501e","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-10-18T16:42:33.752144179Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:55:29.866073209Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "619"
+      - "596"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:33 GMT
+      - Tue, 07 Nov 2023 15:55:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3608,7 +3146,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e61412e-a9da-4240-b0ce-22760c4d5bfb
+      - 0bb19f1d-d062-41ae-b473-743ac61033a2
     status: 200 OK
     code: 200
     duration: ""
@@ -3619,52 +3157,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780?with_additional_resources=true
-    method: DELETE
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c82ed107-6afb-4c30-be52-11a3d737e780.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.807900Z","created_at":"2023-10-18T16:35:45.807900Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c82ed107-6afb-4c30-be52-11a3d737e780.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c82ed107-6afb-4c30-be52-11a3d737e780","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"da6880df-a94a-4f3e-8277-6150a6853c1c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"kapsule","updated_at":"2023-10-18T16:42:33.836162062Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1452"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 797ebd9b-e7f9-4993-a2c3-3e88c6ec9882
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c82ed107-6afb-4c30-be52-11a3d737e780.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.807900Z","created_at":"2023-10-18T16:35:45.807900Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c82ed107-6afb-4c30-be52-11a3d737e780.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c82ed107-6afb-4c30-be52-11a3d737e780","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"da6880df-a94a-4f3e-8277-6150a6853c1c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"kapsule","updated_at":"2023-10-18T16:42:33.836162Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:55:29.866073Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1449"
+      - "593"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:34 GMT
+      - Tue, 07 Nov 2023 15:55:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3674,7 +3179,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f8927ee-53dc-465f-9fbc-a607e1b7c6a9
+      - c0a54fe1-fdec-4f3b-8c03-85d23e0bda19
     status: 200 OK
     code: 200
     duration: ""
@@ -3685,19 +3190,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c82ed107-6afb-4c30-be52-11a3d737e780.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.807900Z","created_at":"2023-10-18T16:35:45.807900Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c82ed107-6afb-4c30-be52-11a3d737e780.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c82ed107-6afb-4c30-be52-11a3d737e780","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"da6880df-a94a-4f3e-8277-6150a6853c1c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"kapsule","updated_at":"2023-10-18T16:42:33.836162Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:55:29.866073Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1449"
+      - "593"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:39 GMT
+      - Tue, 07 Nov 2023 15:55:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3707,7 +3212,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f9e8be5-e9ef-492c-a520-d66d91467700
+      - 01bfa0a4-5bbe-4185-9cc8-d49a8e0d4373
     status: 200 OK
     code: 200
     duration: ""
@@ -3718,19 +3223,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c82ed107-6afb-4c30-be52-11a3d737e780.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.807900Z","created_at":"2023-10-18T16:35:45.807900Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c82ed107-6afb-4c30-be52-11a3d737e780.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c82ed107-6afb-4c30-be52-11a3d737e780","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"da6880df-a94a-4f3e-8277-6150a6853c1c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"kapsule","updated_at":"2023-10-18T16:42:33.836162Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:55:29.866073Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1449"
+      - "593"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:44 GMT
+      - Tue, 07 Nov 2023 15:55:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3740,7 +3245,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e0e19c6-1655-4518-b157-efe40a0c97ad
+      - ef69448d-0877-4885-830c-c7b3b4a03872
     status: 200 OK
     code: 200
     duration: ""
@@ -3751,19 +3256,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c82ed107-6afb-4c30-be52-11a3d737e780.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.807900Z","created_at":"2023-10-18T16:35:45.807900Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c82ed107-6afb-4c30-be52-11a3d737e780.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c82ed107-6afb-4c30-be52-11a3d737e780","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"da6880df-a94a-4f3e-8277-6150a6853c1c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"kapsule","updated_at":"2023-10-18T16:42:33.836162Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:55:29.866073Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1449"
+      - "593"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:49 GMT
+      - Tue, 07 Nov 2023 15:55:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3773,7 +3278,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec435d38-a1d4-40ea-832b-3760803ef562
+      - a798a53a-fb1d-4d09-a051-c629d4381e51
     status: 200 OK
     code: 200
     duration: ""
@@ -3784,19 +3289,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c82ed107-6afb-4c30-be52-11a3d737e780.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.807900Z","created_at":"2023-10-18T16:35:45.807900Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c82ed107-6afb-4c30-be52-11a3d737e780.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c82ed107-6afb-4c30-be52-11a3d737e780","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"da6880df-a94a-4f3e-8277-6150a6853c1c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"kapsule","updated_at":"2023-10-18T16:42:33.836162Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":false,"cluster_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.844846Z","id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","kubelet_args":{},"max_size":1,"min_size":1,"name":"pool","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T15:55:29.866073Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1449"
+      - "593"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:54 GMT
+      - Tue, 07 Nov 2023 15:55:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3806,7 +3311,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 309c15e5-027d-4379-8d81-1967071b8b53
+      - a64773c8-7c04-4e63-b689-b0221a7fabd0
     status: 200 OK
     code: 200
     duration: ""
@@ -3817,19 +3322,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/ca1816d2-cee8-4dbb-a2b7-b5426f828f4f
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://c82ed107-6afb-4c30-be52-11a3d737e780.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.807900Z","created_at":"2023-10-18T16:35:45.807900Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.c82ed107-6afb-4c30-be52-11a3d737e780.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"c82ed107-6afb-4c30-be52-11a3d737e780","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"da6880df-a94a-4f3e-8277-6150a6853c1c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":[],"type":"kapsule","updated_at":"2023-10-18T16:42:33.836162Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"ca1816d2-cee8-4dbb-a2b7-b5426f828f4f","type":"not_found"}'
     headers:
       Content-Length:
-      - "1449"
+      - "125"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:59 GMT
+      - Tue, 07 Nov 2023 15:55:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3839,40 +3344,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5959e7bd-2046-469a-a13c-16ff3bb1caa1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"c82ed107-6afb-4c30-be52-11a3d737e780","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "128"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e578bac9-0b60-4003-b173-fe31728a0fe5
+      - c0a66511-621e-4353-85e9-1d8bb6f2caa6
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3883,10 +3355,142 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/da6880df-a94a-4f3e-8277-6150a6853c1c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"da6880df-a94a-4f3e-8277-6150a6853c1c","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e79ddfa6-c637-49dc-99b3-c0b1a77c7651.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.395909Z","created_at":"2023-11-07T15:49:53.395909Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e79ddfa6-c637-49dc-99b3-c0b1a77c7651.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":[],"type":"kapsule","updated_at":"2023-11-07T15:55:55.258639615Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1409"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7481450c-a35b-4c0e-85d4-37566a54084a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e79ddfa6-c637-49dc-99b3-c0b1a77c7651.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.395909Z","created_at":"2023-11-07T15:49:53.395909Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e79ddfa6-c637-49dc-99b3-c0b1a77c7651.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":[],"type":"kapsule","updated_at":"2023-11-07T15:55:55.258640Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1406"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:55:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3fdfc93b-18b1-4eb5-ad74-c5606ca6b4f1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":true,"maintenance_window":{"day":"monday","start_hour":12}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e79ddfa6-c637-49dc-99b3-c0b1a77c7651.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.395909Z","created_at":"2023-11-07T15:49:53.395909Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e79ddfa6-c637-49dc-99b3-c0b1a77c7651.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","ingress":"none","name":"test-pool-size","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":[],"type":"kapsule","updated_at":"2023-11-07T15:55:55.258640Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1406"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:56:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 16d26f0f-65b1-4e25-a236-635886d974d3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:56:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 16f81f9d-7c5a-49de-9440-f4f38910af16
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/42e67a9e-cba6-407b-a764-9aea1e6574c7
+    method: DELETE
+  response:
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"42e67a9e-cba6-407b-a764-9aea1e6574c7","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3895,7 +3499,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:04 GMT
+      - Tue, 07 Nov 2023 15:56:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3905,7 +3509,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e839f0ac-246c-409a-a01e-96ae2245541f
+      - 7a12a10b-4371-4bcc-8855-d44918d07057
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3916,10 +3520,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/c82ed107-6afb-4c30-be52-11a3d737e780
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e79ddfa6-c637-49dc-99b3-c0b1a77c7651
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"c82ed107-6afb-4c30-be52-11a3d737e780","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"e79ddfa6-c637-49dc-99b3-c0b1a77c7651","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3928,7 +3532,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:04 GMT
+      - Tue, 07 Nov 2023 15:56:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3938,7 +3542,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc1b64cb-5338-4aea-bc95-ebbcbf45a12b
+      - 48eec477-805c-41bb-bc47-8afc3811c25c
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-upgrade-policy.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-upgrade-policy.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:41 GMT
+      - Tue, 07 Nov 2023 15:49:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,12 +34,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03a57cf9-fc16-4c2e-8e76-eba7785a8208
+      - 8d9e1f61-6435-4495-a54d-39bd896581de
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-upgrade-policy","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"test-pool-upgrade-policy","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-18T16:35:44.465392Z","dhcp_enabled":true,"id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36","name":"test-pool-upgrade-policy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:35:44.465392Z","id":"40e8207c-fd50-48b8-a880-6d481e30d7c3","subnet":"172.16.8.0/22","updated_at":"2023-10-18T16:35:44.465392Z"},{"created_at":"2023-10-18T16:35:44.465392Z","id":"6846558a-d0de-482f-ae6d-28b2a6233ccd","subnet":"fd63:256c:45f7:1fe4::/64","updated_at":"2023-10-18T16:35:44.465392Z"}],"tags":[],"updated_at":"2023-10-18T16:35:44.465392Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T15:49:50.649852Z","dhcp_enabled":true,"id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","name":"test-pool-upgrade-policy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.649852Z","id":"6080f05f-89b3-4884-bbd5-5375c1aed7af","subnet":"172.16.52.0/22","updated_at":"2023-11-07T15:49:50.649852Z"},{"created_at":"2023-11-07T15:49:50.649852Z","id":"3c774edd-bbde-47db-b249-4f82521fc377","subnet":"fd5f:519c:6d46:1dbf::/64","updated_at":"2023-11-07T15:49:50.649852Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.649852Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "724"
+      - "708"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:45 GMT
+      - Tue, 07 Nov 2023 15:49:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b500ed0-cf10-436a-858e-70aad9d8f0fa
+      - be840193-c77f-4519-a8c2-36705bca5d17
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/07c1b4c0-aa12-4485-b99a-358f4db4ea36
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/4f3402c1-6ce1-4a28-ac04-c22019bece2f
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:35:44.465392Z","dhcp_enabled":true,"id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36","name":"test-pool-upgrade-policy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:35:44.465392Z","id":"40e8207c-fd50-48b8-a880-6d481e30d7c3","subnet":"172.16.8.0/22","updated_at":"2023-10-18T16:35:44.465392Z"},{"created_at":"2023-10-18T16:35:44.465392Z","id":"6846558a-d0de-482f-ae6d-28b2a6233ccd","subnet":"fd63:256c:45f7:1fe4::/64","updated_at":"2023-10-18T16:35:44.465392Z"}],"tags":[],"updated_at":"2023-10-18T16:35:44.465392Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T15:49:50.649852Z","dhcp_enabled":true,"id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","name":"test-pool-upgrade-policy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.649852Z","id":"6080f05f-89b3-4884-bbd5-5375c1aed7af","subnet":"172.16.52.0/22","updated_at":"2023-11-07T15:49:50.649852Z"},{"created_at":"2023-11-07T15:49:50.649852Z","id":"3c774edd-bbde-47db-b249-4f82521fc377","subnet":"fd5f:519c:6d46:1dbf::/64","updated_at":"2023-11-07T15:49:50.649852Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.649852Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "724"
+      - "708"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:45 GMT
+      - Tue, 07 Nov 2023 15:49:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12693c1a-f5b7-46b9-ae44-58932b4debff
+      - 42ee26d1-5986-4907-89a9-49113b69cab9
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-upgrade-policy","description":"","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36"}'
+    body: '{"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","type":"","name":"test-pool-upgrade-policy","description":"","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f"}'
     form: {}
     headers:
       Content-Type:
@@ -118,16 +118,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://936f1f4a-cf5a-421d-bae6-c209e68bdf5c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.731241728Z","created_at":"2023-10-18T16:35:45.731241728Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.936f1f4a-cf5a-421d-bae6-c209e68bdf5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-10-18T16:35:45.741517905Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097024964Z","created_at":"2023-11-07T15:49:53.097024964Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:49:53.106145379Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1523"
+      - "1478"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:45 GMT
+      - Tue, 07 Nov 2023 15:49:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5bdfa98-9041-4a78-8373-9a74bf3952ed
+      - 14f96dc1-eddb-4c2f-a029-0515aedcd89c
     status: 200 OK
     code: 200
     duration: ""
@@ -148,19 +148,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://936f1f4a-cf5a-421d-bae6-c209e68bdf5c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.731242Z","created_at":"2023-10-18T16:35:45.731242Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.936f1f4a-cf5a-421d-bae6-c209e68bdf5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-10-18T16:35:45.741518Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:49:53.106145Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1514"
+      - "1469"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:45 GMT
+      - Tue, 07 Nov 2023 15:49:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d69e0b3c-aa1c-41f5-aaca-64687442f677
+      - 3b6f9401-b8c0-45e0-91c7-e26be774c93c
     status: 200 OK
     code: 200
     duration: ""
@@ -181,19 +181,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://936f1f4a-cf5a-421d-bae6-c209e68bdf5c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.731242Z","created_at":"2023-10-18T16:35:45.731242Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.936f1f4a-cf5a-421d-bae6-c209e68bdf5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-10-18T16:35:47.496738Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:49:54.941453Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1519"
+      - "1474"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:50 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0fa87fb0-a1bc-4127-8b0d-0980703dd651
+      - 747df2ac-59a1-4b19-8b00-55377ec3ad11
     status: 200 OK
     code: 200
     duration: ""
@@ -214,19 +214,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://936f1f4a-cf5a-421d-bae6-c209e68bdf5c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.731242Z","created_at":"2023-10-18T16:35:45.731242Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.936f1f4a-cf5a-421d-bae6-c209e68bdf5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-10-18T16:35:47.496738Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:49:54.941453Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1519"
+      - "1474"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:50 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10df94c3-326b-4b03-9c78-ac1f7cedd7b7
+      - be5ac9e9-c86f-43fb-b8bf-c66669fba1f2
     status: 200 OK
     code: 200
     duration: ""
@@ -247,19 +247,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC11cGdyYWRlLXBvbGljeSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVeVRYcFZNRTR4YjFoRVZFMTZUVlJCZUU1NlJUSk5lbFV3VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTbkZYQ2xKeWVrVnFibWR0Ym1kNlRVUTVXRkk0UlV4YWFYcEthRVZRZUZaUWNYaDNLMmhDZUZGSGFYbFpObWxqU3pNeU9IUk5XbVUxZDNJclVXTkxZWE5uYlcwS1JVWnJiVUZGS3pkbWVuRlRXVGxoTkRGVlFUSndWMHBKYUd0dlowaHdZbXhOZW1seVZXaG1ZazVSU2tOaFFrTkNNMDh2Y3paRmFITnhLMXBzVGpoNWNBcDRURWgzT1hWM1YwaHphMXBzT0ZSTWRFaHdiRkZWVTFaSE9EUkViRkpwWkVOU1ptSTFZV3BUYzJjMlZsa3JlVEUzYm1KbFpuQm1LekZ3UkVka01tMTVDbGxvZVZOdU5VNTFOMXB0WW5FMk1FcGFRMmRuV214dlpqaGpWMHBvYlV3MlRtTTJUVXQwY2s1WlNrRnJVbTl5TlUxVEwwTlRRV3hHUTBOblJHSTJObTBLVDJWQlRuVjFNMlYxUVRWNlFUZExZM0ZtYVVsSmFuQkJWSEo1UlZka1ZrUlhWbWc0WVZJdmRVOXRPVmN6WVV4d2NtWmhOakYxVjJGTk1sTmFValZPUkFwdVYyazFZV2N5YjBsM1ZuUkZWek5PTHpZNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUFREZElNRWd6VWtaNWNHbGpkWGRCTmtwUEx6aFRTMGxCTUVsTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1lqTjBVRXBrUlZWR1UyMVlORGhIUm1GbmMxWktlRVpPVkVkTFduTkRlRmw2ZW5SbVMzVXlVRTl2UWxCbGJtSXZUd3BUUkUxRk1qSmhVbkoxZFhCT09UVnBlRzVvYlM5TWJWVjRhbGQwYjNjMFRqY3haRW80U2t0MmJsUjNWVFp3UWpObE5XUlJkVzV6WWswNWJXbERhRzg0Q2tGWVkwaFBValp2VFRCUVZuZEthVGcxUzA5a1RtSmlXak5ZUzJKalVtSjVOVmRvZDFaVVExRXhVbXh0V2pkeWRIQklOMlpIYjNob2JEaHdaSGxOYlM4S1pucGhNVlptVTJSMWJqWnRPWGR6ZWpkYVVEZ3ZlSEZZVW5kcVdISlhPVk5RVUdsd2JuUjVlRXg2VXpGWWRrVmhObGd6YmpsRFRYQnBWbk5oYW5SWWFBb3pkRFp0T1dGMFlVUkRhMEYyTVVrMFpUWTBPVzFTVjJSTFVsRlFTR3BJTW1GelEydHdiemR5WmswM00zRmhabEpxWmxsSWVGY3JUbmN5TDBOU2FrbzBDbUYzYTBaQ2VGTkhWelpsU0ZwNGNYSmxkWFpqT0VGSlVHMUVlSEZZYkVoV1YxbDVSZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOTM2ZjFmNGEtY2Y1YS00MjFkLWJhZTYtYzIwOWU2OGJkZjVjLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC11cGdyYWRlLXBvbGljeQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5IgogICAgdXNlcjogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBQMDB2bmRXS2lmaE5EVm02Q2wyMVRxSVVLSGtZNFZXVThkVndMeDFLa2NnQUd1MVlvU0xzYjc4Ug==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC11cGdyYWRlLXBvbGljeSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeFRrUnJNVTVHYjFoRVZFMTZUVlJGZDA1cVJURk9SR3N4VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUMDVaQ2xkbVZ6TkNURTlPUWtSSFlXUlBUWEU1UVdneE5ESlVjbFJEUW04M1oxVk1PR1ZWTUVsV2FrZFlWbW9yTjNaQ2RtYzROakJIZGxGMVdtTlpUbUpqUVRFS2RUTndlbVJWTW1rNEwwVjFjSFl3UjJ4SVNDOU9RblpYZVN0QlIwbG5abWxVWVRGUmRsWnlValoxT0dGVE1rOW5ZM051YjFVd1J6RjBSRzFXTDNKUVlnbzNWMFJwU1VFNWRFNVZhVlJsWlRsVWNVODNPWEJ2ZWxKdU1rOWtSbE5EVFU0eVRtMDFhbFJUWVVGTU4wbzJSbVpDZW1GU1kwRTJTM05YTTJoNE5pOWhDbkV4SzJzd1pVMUdVMU52WTBkcVVGQjNWSE51Tmxaa2NVVlVOelZLTHpGVFFTOVNhalJFZVhKVVYyRkhiRXRKYWpsck5tVmpiMnMzYnpWVlZsTnhWRGtLT1VwNVRXcDRRbmxxYlVweWIzbHVNek5RVkd0bloyWlVPVmxSYkdoaU4wTTBTbVZDWmpOTWFHRlpTazVoV1dnelZGSnVXVlJ0UjNaTlVIQXhOa2N3TndwaU9IVXpjbEZ4VTFkQlpUaENWV3hxZURKTlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ2JGSm5lR0kwU1ZoaFVEaE5XQ3MxYWpsM1JuVlNPR1pPU2taTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmJrOVFZVXhPUWpsc1VFWjVPVUZqTjFGRVZFcEVkMWt6VW5WbFZVZFZiSHB6ZEdnelVsWTJiekpCUkdaa1NFUkVTQXBrVEVObmQzVnBiMVJRYjNaR1pqRXhSakptYm5vMk1WQnpkbVZPVmxNMlNIYzRkbEpIUkRSSFJDdHRWemhPUVdkeE4zbGtORGhCVTBaQ01XdzFUa1pNQ25kclRYbEVXRkJYYm5CaE4ycFlUMXB3UkZsUWFEaEhWR3RTYTFwMGVFRkhUak5TVURSbFJIcE1lWGsxZDI1NE9XNHZUWFExZFUwelZIRTNVSGt3UWprS2QwWlZPVmxJU2pkVGNFaDFWUzlHYzB3elFVRjBPRkJWVm01ak9VNHhNV3d2Y25KV2NVUkhRV3d5VUZkeVZFYzFkSFJaTlN0MU5HTnNXV3h1VTBocWRncFVRa1ZqTW1aNmRXODRkbUZIUlVsMGJsVllkblJxZVRCNlkyRk1XWFU0TDJOaVpVUXdaa2xMZERZNEsyVmpjSEpRUm1sTFV5dHZUekZ3VWxsTGVsUk1DbTlRYjFCbE1HaHBhV2hPZFdJM2EzRkZTMDh4Wm5Sb1VFOW5OR1V4V0hadWRGZFFTQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTE3Zjc2ZGUtNGUxMy00YjdhLWI2NWEtNDFiYzRiYTllYTRhLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC11cGdyYWRlLXBvbGljeQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5IgogICAgdXNlcjogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA1d2tLVElQNVREdnRvQUF3QU0yMWNPVTBDWnpRVDN0TWpyVnBEMTl4Qmg4azREWGliS1R0ZlBCWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2686"
+      - "2684"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bdde1cb7-f230-417d-8ccf-0cb5e777c1c0
+      - a5fb4720-3fa4-4e7a-ba24-ea7f07e27330
     status: 200 OK
     code: 200
     duration: ""
@@ -280,19 +280,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://936f1f4a-cf5a-421d-bae6-c209e68bdf5c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.731242Z","created_at":"2023-10-18T16:35:45.731242Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.936f1f4a-cf5a-421d-bae6-c209e68bdf5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-10-18T16:35:47.496738Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:49:54.941453Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1519"
+      - "1474"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,12 +302,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72393c62-9aeb-45a5-b867-c63819ca09fc
+      - 341e2818-e6a3-4a39-acc0-e2a08adf92ad
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"default_volume_type","root_volume_size":null,"public_ip_disabled":false}'
+    body: '{"name":"test-pool-upgrade-policy","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"kubelet_args":{},"upgrade_policy":{"max_unavailable":3,"max_surge":2},"zone":"fr-par-1","root_volume_type":"default_volume_type","public_ip_disabled":false}'
     form: {}
     headers:
       Content-Type:
@@ -315,19 +315,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360135Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423194Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "695"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -337,7 +337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 721b4f46-7e42-475d-a77b-f497d0006d71
+      - 2d33b306-4992-4df8-93dd-78edb332a484
     status: 200 OK
     code: 200
     duration: ""
@@ -348,19 +348,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -370,7 +370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f657d58-33f9-43e2-b435-9b6583c7008d
+      - 34b11399-141d-40d4-b0c8-67dc8832f1ab
     status: 200 OK
     code: 200
     duration: ""
@@ -381,19 +381,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:56 GMT
+      - Tue, 07 Nov 2023 15:50:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -403,7 +403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 92bb9fc2-5e4f-4ac1-8d73-f7a8c0b310e3
+      - af28f39e-ee17-45a1-9bf3-9cc40f0e7dc2
     status: 200 OK
     code: 200
     duration: ""
@@ -414,19 +414,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:02 GMT
+      - Tue, 07 Nov 2023 15:50:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -436,7 +436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6b69808-1bb0-44d7-af50-2bf971fbe3c2
+      - b8d5bbcc-6b4b-4c16-8ca2-4d0c03e15904
     status: 200 OK
     code: 200
     duration: ""
@@ -447,19 +447,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:07 GMT
+      - Tue, 07 Nov 2023 15:50:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -469,7 +469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca9c6f43-27d6-4505-b391-0258011ab4b7
+      - c9aac5ff-77b2-446c-a0bc-47de230e39df
     status: 200 OK
     code: 200
     duration: ""
@@ -480,19 +480,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:13 GMT
+      - Tue, 07 Nov 2023 15:50:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 366831bf-6365-48b0-bd4f-a39b6ae52539
+      - fa490675-a79d-42ec-afc1-ac2f91a701e5
     status: 200 OK
     code: 200
     duration: ""
@@ -513,19 +513,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:18 GMT
+      - Tue, 07 Nov 2023 15:50:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55ca34c9-74cf-4e93-b34d-1ad6bfa28198
+      - 093fef7d-8413-461b-9e00-2b8cba3a2bc8
     status: 200 OK
     code: 200
     duration: ""
@@ -546,19 +546,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:23 GMT
+      - Tue, 07 Nov 2023 15:50:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 491e5111-655f-4db9-b70e-f3eb683cfad4
+      - 3ee8718f-101b-4b94-8b90-9008daabda5f
     status: 200 OK
     code: 200
     duration: ""
@@ -579,19 +579,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:28 GMT
+      - Tue, 07 Nov 2023 15:50:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a6f4092-26b9-4aa9-bcc2-d5752bf2eee0
+      - f95565b7-1e85-49e3-81c7-b423fcb3d8bd
     status: 200 OK
     code: 200
     duration: ""
@@ -612,19 +612,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:33 GMT
+      - Tue, 07 Nov 2023 15:50:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d5b853d-61ff-426a-a353-11d712a80ecf
+      - f445eb58-919c-4425-8166-5988c7610d21
     status: 200 OK
     code: 200
     duration: ""
@@ -645,19 +645,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:38 GMT
+      - Tue, 07 Nov 2023 15:50:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - feb863dd-50df-4de0-9ee1-30aaa1edde0e
+      - 944bb2cb-16ba-4fb7-8bd3-65c53752fe76
     status: 200 OK
     code: 200
     duration: ""
@@ -678,19 +678,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:43 GMT
+      - Tue, 07 Nov 2023 15:50:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88b198c4-e489-4b6c-a070-38175b189791
+      - d79d7138-1254-4c4f-a6c6-b9543012229e
     status: 200 OK
     code: 200
     duration: ""
@@ -711,19 +711,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:49 GMT
+      - Tue, 07 Nov 2023 15:50:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c4522ec-fd66-4ea8-bde7-302801c1cd95
+      - a9dd9926-1aba-44ac-bfa9-a110f0cf1d03
     status: 200 OK
     code: 200
     duration: ""
@@ -744,19 +744,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:54 GMT
+      - Tue, 07 Nov 2023 15:51:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1850973a-4802-4ee7-98b9-b2260566cb2d
+      - 2ab940cd-10b1-4b03-9f79-2c4632f32cea
     status: 200 OK
     code: 200
     duration: ""
@@ -777,19 +777,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:59 GMT
+      - Tue, 07 Nov 2023 15:51:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f78dbfbd-b952-42b6-be9c-b3fef8e4b37a
+      - 9e66f4a0-a960-48e9-b1cf-60186da2664c
     status: 200 OK
     code: 200
     duration: ""
@@ -810,19 +810,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:04 GMT
+      - Tue, 07 Nov 2023 15:51:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aeae35e0-4553-4eda-8cfa-a49a1789c0e0
+      - afeb5c08-2fa1-4301-8e5f-0997368ff5b6
     status: 200 OK
     code: 200
     duration: ""
@@ -843,19 +843,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:09 GMT
+      - Tue, 07 Nov 2023 15:51:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73217161-1981-495c-90b0-438b688cd28f
+      - a847d1ea-79d6-4542-8fd2-a23b29bf344b
     status: 200 OK
     code: 200
     duration: ""
@@ -876,19 +876,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:14 GMT
+      - Tue, 07 Nov 2023 15:51:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe91709c-ea51-4c4b-a30b-463115b50390
+      - 331d6cb8-acbe-4101-8fca-e5d83c99a1f8
     status: 200 OK
     code: 200
     duration: ""
@@ -909,19 +909,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:19 GMT
+      - Tue, 07 Nov 2023 15:51:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84abe3b4-5b5e-4483-a03c-3c1b91fea7e3
+      - acd98847-3027-4343-934a-888300aac868
     status: 200 OK
     code: 200
     duration: ""
@@ -942,19 +942,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:24 GMT
+      - Tue, 07 Nov 2023 15:51:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9272e5a-38a7-449e-b766-7fc01dbaa20f
+      - 62367712-6d6a-4be5-8598-b3e9fd3f1f2f
     status: 200 OK
     code: 200
     duration: ""
@@ -975,19 +975,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:29 GMT
+      - Tue, 07 Nov 2023 15:51:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f535c142-622a-4095-bbdb-70964ef9a430
+      - d1ba090f-c30a-45d5-a5b5-b747b4c79f7f
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,19 +1008,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:34 GMT
+      - Tue, 07 Nov 2023 15:51:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3cf07ca4-1925-486a-a7fe-7baab9165bb2
+      - 1dbc15f0-86b4-4c6c-a464-09db35e17ced
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,19 +1041,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:39 GMT
+      - Tue, 07 Nov 2023 15:51:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02b5551b-9af5-4493-91bd-74add1582c9a
+      - 7ff855fa-2bc3-406d-aaa5-05b52688d946
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,19 +1074,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:44 GMT
+      - Tue, 07 Nov 2023 15:51:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f169bb7-812b-4797-822b-47cee0622886
+      - ab501d86-0a5e-4757-8ba7-3616f58d2a8d
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,19 +1107,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:49 GMT
+      - Tue, 07 Nov 2023 15:51:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1129,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6023a928-abc9-4f51-8ba1-c7283a0c5115
+      - 7e553530-0aff-4919-a072-c576d64534d1
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,19 +1140,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:54 GMT
+      - Tue, 07 Nov 2023 15:52:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 342b7472-50fb-4acc-aa63-1dc887223b70
+      - 6ef788c6-c124-4674-884b-8fcdacc7108c
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,19 +1173,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:59 GMT
+      - Tue, 07 Nov 2023 15:52:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7fa1224-36bd-4ecb-9c22-60e6b953e5a2
+      - e39296b0-4f9c-4ceb-9c26-1c1b3f73158d
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,19 +1206,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:04 GMT
+      - Tue, 07 Nov 2023 15:52:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be38099a-b797-4536-9c1d-58591486b7b2
+      - b8a97c77-9ba7-438b-9e02-632ffc0e8dc3
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,19 +1239,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:09 GMT
+      - Tue, 07 Nov 2023 15:52:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 186f15ce-5901-4882-901f-53ef585de6ab
+      - 6d118130-195e-4b38-b8fb-00eae0bee059
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,19 +1272,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:14 GMT
+      - Tue, 07 Nov 2023 15:52:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb4e6b26-550f-4076-9f78-9cb59ecd2b1c
+      - 74c41ce4-5a63-4e63-9830-3b3570c3d929
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,19 +1305,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:19 GMT
+      - Tue, 07 Nov 2023 15:52:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b44adf9-6a2d-4b97-bf4d-9f8e1f5dd071
+      - 56079bd5-3eea-4fcf-a233-323279905646
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,19 +1338,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:24 GMT
+      - Tue, 07 Nov 2023 15:52:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1360,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a1c056b-d885-470a-9c42-5097fc15c754
+      - 67f57dc8-83b7-4324-ab0e-418acc21bd01
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,19 +1371,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:29 GMT
+      - Tue, 07 Nov 2023 15:52:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1393,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d40c5d0-52bb-4b48-abb3-e0719cf96677
+      - 8e28f425-0b65-44f5-9b68-71ff3a3c54f7
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,19 +1404,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:35 GMT
+      - Tue, 07 Nov 2023 15:52:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1426,7 +1426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54892fa8-e0f5-4958-a485-deef5d77dc43
+      - 858b48fb-bb5d-4bc3-bf4e-bafb57ac8c26
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,19 +1437,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:40 GMT
+      - Tue, 07 Nov 2023 15:52:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1459,7 +1459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5fd60919-368b-42ad-a3fc-e0b74e9915fa
+      - e6882b51-d341-4096-b6a4-49764813cec5
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,19 +1470,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:45 GMT
+      - Tue, 07 Nov 2023 15:52:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1492,7 +1492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf9ced2f-cf98-4e50-b8ad-12ceb1e20210
+      - 235b12da-68d5-4dc5-97de-eb368887d1a7
     status: 200 OK
     code: 200
     duration: ""
@@ -1503,19 +1503,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:50 GMT
+      - Tue, 07 Nov 2023 15:52:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4f8049e-4b07-49c1-a4db-745a279da15f
+      - fae45fe1-ada2-4834-bb22-0cca6f21a64c
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,19 +1536,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:55 GMT
+      - Tue, 07 Nov 2023 15:53:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1558,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d770883-c41d-4989-bb56-97ca849c72b6
+      - 6585034c-70f5-4d29-86f1-0538267bdd67
     status: 200 OK
     code: 200
     duration: ""
@@ -1569,19 +1569,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:00 GMT
+      - Tue, 07 Nov 2023 15:53:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1591,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b97ba80-3101-42f5-ba01-514dc3e9e74c
+      - 32202bae-8613-4718-8560-e2a6a9df4a19
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,19 +1602,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:05 GMT
+      - Tue, 07 Nov 2023 15:53:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 501bed74-4284-4da1-b2cc-324d40c16385
+      - ab6e586e-298b-4d7e-b5ff-67c0d01de29b
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,19 +1635,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:10 GMT
+      - Tue, 07 Nov 2023 15:53:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1657,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95ae5024-c32a-4704-9f73-4be6475ec25e
+      - e4f0d2d0-f107-46ec-997c-9aefdf00ff1a
     status: 200 OK
     code: 200
     duration: ""
@@ -1668,19 +1668,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:15 GMT
+      - Tue, 07 Nov 2023 15:53:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1690,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5875de44-da09-41d2-9285-e8682714f437
+      - 530fb147-953f-4d78-8106-85febc9bc841
     status: 200 OK
     code: 200
     duration: ""
@@ -1701,19 +1701,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:20 GMT
+      - Tue, 07 Nov 2023 15:53:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1723,7 +1723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9620921-7ca9-4dcd-99fb-b7005b41e6fe
+      - a556949a-89a6-43a0-8a96-38ce55cb2605
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,19 +1734,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:25 GMT
+      - Tue, 07 Nov 2023 15:53:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1756,7 +1756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40241dfa-681b-4c99-9519-344f694d3b14
+      - 453b3404-48b3-4872-b154-866aec278254
     status: 200 OK
     code: 200
     duration: ""
@@ -1767,19 +1767,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:30 GMT
+      - Tue, 07 Nov 2023 15:53:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1789,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 947baa70-874c-4f92-9db8-cb918c9856f4
+      - 13a7bc91-a685-44c6-9fbf-e1191d24a1f1
     status: 200 OK
     code: 200
     duration: ""
@@ -1800,19 +1800,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:35 GMT
+      - Tue, 07 Nov 2023 15:53:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1822,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32a61ae4-7f12-47af-9a3e-300c3c24488b
+      - 9c51c36c-bd90-4b06-b208-b4674ef6ba2e
     status: 200 OK
     code: 200
     duration: ""
@@ -1833,19 +1833,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:40 GMT
+      - Tue, 07 Nov 2023 15:53:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1855,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c66b0741-b96c-44bf-a981-ec23d984bb27
+      - 692d0336-b3fb-46f7-9df4-20c11a7b2e82
     status: 200 OK
     code: 200
     duration: ""
@@ -1866,19 +1866,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:45 GMT
+      - Tue, 07 Nov 2023 15:53:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1888,7 +1888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b29ca922-dd45-4159-989b-ffd8309aea4d
+      - c712f058-716b-45e9-ad88-669d33cd7300
     status: 200 OK
     code: 200
     duration: ""
@@ -1899,19 +1899,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:50 GMT
+      - Tue, 07 Nov 2023 15:53:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1921,7 +1921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b76ef31e-ffdd-4c55-8010-a2de66046087
+      - 2312c493-3f4c-4d91-923a-392bed5efce6
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,19 +1932,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:55 GMT
+      - Tue, 07 Nov 2023 15:54:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1954,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22a8277b-e28a-4639-a242-2de60a93c659
+      - 2ead22a7-1f85-411d-9d1a-19b1eb5f0bd8
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,19 +1965,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:00 GMT
+      - Tue, 07 Nov 2023 15:54:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1987,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2361ec0d-5b8c-4706-bbe1-e2d615b65612
+      - bee5dfbe-5df0-4f30-a27d-2d6f4b76ea6b
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,19 +1998,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:05 GMT
+      - Tue, 07 Nov 2023 15:54:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2020,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27bf611f-4c6c-4ce2-a1ac-2216a862923c
+      - 0d2d1949-f812-4fc1-a041-15052ff5d75f
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,19 +2031,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:49:58.550423Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:10 GMT
+      - Tue, 07 Nov 2023 15:54:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2053,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec2013ef-7d82-4eca-8231-0bad65576dca
+      - f0a87b75-dfd3-4f10-940f-2416a15c1f5a
     status: 200 OK
     code: 200
     duration: ""
@@ -2064,19 +2064,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:22.457056Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "665"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:15 GMT
+      - Tue, 07 Nov 2023 15:54:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2086,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc9478c5-d9a1-47a1-b4b2-b4f53b394b77
+      - ea90610b-02b1-43d2-a917-64d4eefd85c1
     status: 200 OK
     code: 200
     duration: ""
@@ -2097,19 +2097,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:51:42.474016Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "692"
+      - "1466"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:21 GMT
+      - Tue, 07 Nov 2023 15:54:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2119,7 +2119,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae3d2d3a-18ca-4784-978c-9ed54ec59653
+      - baea5ea4-b6d7-4f30-9947-368a0e75e132
     status: 200 OK
     code: 200
     duration: ""
@@ -2130,19 +2130,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:22.457056Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "665"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:26 GMT
+      - Tue, 07 Nov 2023 15:54:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2152,7 +2152,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a034bca5-43bb-427c-9260-68398e96fde2
+      - 6232db2b-eac1-42bd-a79e-3fcc55435a90
     status: 200 OK
     code: 200
     duration: ""
@@ -2163,19 +2163,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a/nodes?order_by=created_at_asc&page=1&pool_id=f2906988-2cb9-4253-bc59-d0cc0c91a6a2&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:52:10.010165Z","error_message":null,"id":"77d4aa2a-2cc5-44bd-8ff5-9a796e1f6514","name":"scw-test-pool-upgrade-test-pool-upgrade-77d4aa","pool_id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","provider_id":"scaleway://instance/fr-par-1/37c5f0e7-c7f7-49a2-b580-85f5b3c4d70d","public_ip_v4":"51.15.242.191","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:22.442471Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "692"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:31 GMT
+      - Tue, 07 Nov 2023 15:54:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2185,7 +2185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12395a06-15bb-4bda-bdee-c8df58635e1b
+      - 754429d9-1e8d-4e68-95f0-f2f073045455
     status: 200 OK
     code: 200
     duration: ""
@@ -2196,19 +2196,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:51:42.474016Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "692"
+      - "1466"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:36 GMT
+      - Tue, 07 Nov 2023 15:54:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2218,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 221f6060-1dde-46d0-82c3-4e0a19ffd6f8
+      - 6a303a1e-5c80-4cab-bc3e-c41f65eea49c
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,19 +2229,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:22.457056Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "665"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:41 GMT
+      - Tue, 07 Nov 2023 15:54:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2251,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 731ffe76-3e7a-42f8-93c2-bd8e073133de
+      - aa52e1b5-b878-4740-b5e9-6ae8f447b024
     status: 200 OK
     code: 200
     duration: ""
@@ -2262,19 +2262,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/4f3402c1-6ce1-4a28-ac04-c22019bece2f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-07T15:49:50.649852Z","dhcp_enabled":true,"id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","name":"test-pool-upgrade-policy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.649852Z","id":"6080f05f-89b3-4884-bbd5-5375c1aed7af","subnet":"172.16.52.0/22","updated_at":"2023-11-07T15:49:50.649852Z"},{"created_at":"2023-11-07T15:49:50.649852Z","id":"3c774edd-bbde-47db-b249-4f82521fc377","subnet":"fd5f:519c:6d46:1dbf::/64","updated_at":"2023-11-07T15:49:50.649852Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.649852Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "692"
+      - "708"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:46 GMT
+      - Tue, 07 Nov 2023 15:54:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2284,7 +2284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee6b1e23-05c2-49cb-8ddd-991b68f92d72
+      - d2960b4b-ae94-41ef-b56a-b697132809cb
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,19 +2295,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:51:42.474016Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "692"
+      - "1466"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:51 GMT
+      - Tue, 07 Nov 2023 15:54:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2317,7 +2317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87edcf8e-60aa-4622-812d-969efa53c6c0
+      - 7cb44280-1675-4c42-b8e0-98abd0b50b13
     status: 200 OK
     code: 200
     duration: ""
@@ -2328,19 +2328,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC11cGdyYWRlLXBvbGljeSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeFRrUnJNVTVHYjFoRVZFMTZUVlJGZDA1cVJURk9SR3N4VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUMDVaQ2xkbVZ6TkNURTlPUWtSSFlXUlBUWEU1UVdneE5ESlVjbFJEUW04M1oxVk1PR1ZWTUVsV2FrZFlWbW9yTjNaQ2RtYzROakJIZGxGMVdtTlpUbUpqUVRFS2RUTndlbVJWTW1rNEwwVjFjSFl3UjJ4SVNDOU9RblpYZVN0QlIwbG5abWxVWVRGUmRsWnlValoxT0dGVE1rOW5ZM051YjFVd1J6RjBSRzFXTDNKUVlnbzNWMFJwU1VFNWRFNVZhVlJsWlRsVWNVODNPWEJ2ZWxKdU1rOWtSbE5EVFU0eVRtMDFhbFJUWVVGTU4wbzJSbVpDZW1GU1kwRTJTM05YTTJoNE5pOWhDbkV4SzJzd1pVMUdVMU52WTBkcVVGQjNWSE51Tmxaa2NVVlVOelZLTHpGVFFTOVNhalJFZVhKVVYyRkhiRXRKYWpsck5tVmpiMnMzYnpWVlZsTnhWRGtLT1VwNVRXcDRRbmxxYlVweWIzbHVNek5RVkd0bloyWlVPVmxSYkdoaU4wTTBTbVZDWmpOTWFHRlpTazVoV1dnelZGSnVXVlJ0UjNaTlVIQXhOa2N3TndwaU9IVXpjbEZ4VTFkQlpUaENWV3hxZURKTlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ2JGSm5lR0kwU1ZoaFVEaE5XQ3MxYWpsM1JuVlNPR1pPU2taTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmJrOVFZVXhPUWpsc1VFWjVPVUZqTjFGRVZFcEVkMWt6VW5WbFZVZFZiSHB6ZEdnelVsWTJiekpCUkdaa1NFUkVTQXBrVEVObmQzVnBiMVJRYjNaR1pqRXhSakptYm5vMk1WQnpkbVZPVmxNMlNIYzRkbEpIUkRSSFJDdHRWemhPUVdkeE4zbGtORGhCVTBaQ01XdzFUa1pNQ25kclRYbEVXRkJYYm5CaE4ycFlUMXB3UkZsUWFEaEhWR3RTYTFwMGVFRkhUak5TVURSbFJIcE1lWGsxZDI1NE9XNHZUWFExZFUwelZIRTNVSGt3UWprS2QwWlZPVmxJU2pkVGNFaDFWUzlHYzB3elFVRjBPRkJWVm01ak9VNHhNV3d2Y25KV2NVUkhRV3d5VUZkeVZFYzFkSFJaTlN0MU5HTnNXV3h1VTBocWRncFVRa1ZqTW1aNmRXODRkbUZIUlVsMGJsVllkblJxZVRCNlkyRk1XWFU0TDJOaVpVUXdaa2xMZERZNEsyVmpjSEpRUm1sTFV5dHZUekZ3VWxsTGVsUk1DbTlRYjFCbE1HaHBhV2hPZFdJM2EzRkZTMDh4Wm5Sb1VFOW5OR1V4V0hadWRGZFFTQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTE3Zjc2ZGUtNGUxMy00YjdhLWI2NWEtNDFiYzRiYTllYTRhLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC11cGdyYWRlLXBvbGljeQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5IgogICAgdXNlcjogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA1d2tLVElQNVREdnRvQUF3QU0yMWNPVTBDWnpRVDN0TWpyVnBEMTl4Qmg4azREWGliS1R0ZlBCWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "692"
+      - "2684"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:56 GMT
+      - Tue, 07 Nov 2023 15:54:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2350,7 +2350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 045fabcf-8f7c-4f10-b16d-f04c0aca90e3
+      - 64143625-7821-409d-96dc-39f014aaf554
     status: 200 OK
     code: 200
     duration: ""
@@ -2361,19 +2361,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:22.457056Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "665"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:01 GMT
+      - Tue, 07 Nov 2023 15:54:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2383,7 +2383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fec7a724-18bc-4826-87ef-43469e518574
+      - f95dd5b4-ab33-4a86-aa7f-932e83b27d28
     status: 200 OK
     code: 200
     duration: ""
@@ -2394,19 +2394,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a/nodes?order_by=created_at_asc&page=1&pool_id=f2906988-2cb9-4253-bc59-d0cc0c91a6a2&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:52:10.010165Z","error_message":null,"id":"77d4aa2a-2cc5-44bd-8ff5-9a796e1f6514","name":"scw-test-pool-upgrade-test-pool-upgrade-77d4aa","pool_id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","provider_id":"scaleway://instance/fr-par-1/37c5f0e7-c7f7-49a2-b580-85f5b3c4d70d","public_ip_v4":"51.15.242.191","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:22.442471Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "692"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:06 GMT
+      - Tue, 07 Nov 2023 15:54:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2416,7 +2416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45620b91-fc7f-4b6f-8478-5fdfc3be4e80
+      - bd104a4b-d71e-4b37-ba27-1066c8e511e9
     status: 200 OK
     code: 200
     duration: ""
@@ -2427,19 +2427,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/4f3402c1-6ce1-4a28-ac04-c22019bece2f
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-07T15:49:50.649852Z","dhcp_enabled":true,"id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","name":"test-pool-upgrade-policy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.649852Z","id":"6080f05f-89b3-4884-bbd5-5375c1aed7af","subnet":"172.16.52.0/22","updated_at":"2023-11-07T15:49:50.649852Z"},{"created_at":"2023-11-07T15:49:50.649852Z","id":"3c774edd-bbde-47db-b249-4f82521fc377","subnet":"fd5f:519c:6d46:1dbf::/64","updated_at":"2023-11-07T15:49:50.649852Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.649852Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "692"
+      - "708"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:11 GMT
+      - Tue, 07 Nov 2023 15:54:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2449,7 +2449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b152877-672e-464d-af32-9496c62ed97d
+      - dce02f59-f844-4002-bff8-55e2ec9d0215
     status: 200 OK
     code: 200
     duration: ""
@@ -2460,19 +2460,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:51:42.474016Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "692"
+      - "1466"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:16 GMT
+      - Tue, 07 Nov 2023 15:54:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2482,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0661d03-6b60-4467-9a93-0f94c9d90470
+      - 0d8d8b30-ed61-4ed3-8d87-fcd2b236eb57
     status: 200 OK
     code: 200
     duration: ""
@@ -2493,19 +2493,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC11cGdyYWRlLXBvbGljeSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeFRrUnJNVTVHYjFoRVZFMTZUVlJGZDA1cVJURk9SR3N4VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUMDVaQ2xkbVZ6TkNURTlPUWtSSFlXUlBUWEU1UVdneE5ESlVjbFJEUW04M1oxVk1PR1ZWTUVsV2FrZFlWbW9yTjNaQ2RtYzROakJIZGxGMVdtTlpUbUpqUVRFS2RUTndlbVJWTW1rNEwwVjFjSFl3UjJ4SVNDOU9RblpYZVN0QlIwbG5abWxVWVRGUmRsWnlValoxT0dGVE1rOW5ZM051YjFVd1J6RjBSRzFXTDNKUVlnbzNWMFJwU1VFNWRFNVZhVlJsWlRsVWNVODNPWEJ2ZWxKdU1rOWtSbE5EVFU0eVRtMDFhbFJUWVVGTU4wbzJSbVpDZW1GU1kwRTJTM05YTTJoNE5pOWhDbkV4SzJzd1pVMUdVMU52WTBkcVVGQjNWSE51Tmxaa2NVVlVOelZLTHpGVFFTOVNhalJFZVhKVVYyRkhiRXRKYWpsck5tVmpiMnMzYnpWVlZsTnhWRGtLT1VwNVRXcDRRbmxxYlVweWIzbHVNek5RVkd0bloyWlVPVmxSYkdoaU4wTTBTbVZDWmpOTWFHRlpTazVoV1dnelZGSnVXVlJ0UjNaTlVIQXhOa2N3TndwaU9IVXpjbEZ4VTFkQlpUaENWV3hxZURKTlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ2JGSm5lR0kwU1ZoaFVEaE5XQ3MxYWpsM1JuVlNPR1pPU2taTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmJrOVFZVXhPUWpsc1VFWjVPVUZqTjFGRVZFcEVkMWt6VW5WbFZVZFZiSHB6ZEdnelVsWTJiekpCUkdaa1NFUkVTQXBrVEVObmQzVnBiMVJRYjNaR1pqRXhSakptYm5vMk1WQnpkbVZPVmxNMlNIYzRkbEpIUkRSSFJDdHRWemhPUVdkeE4zbGtORGhCVTBaQ01XdzFUa1pNQ25kclRYbEVXRkJYYm5CaE4ycFlUMXB3UkZsUWFEaEhWR3RTYTFwMGVFRkhUak5TVURSbFJIcE1lWGsxZDI1NE9XNHZUWFExZFUwelZIRTNVSGt3UWprS2QwWlZPVmxJU2pkVGNFaDFWUzlHYzB3elFVRjBPRkJWVm01ak9VNHhNV3d2Y25KV2NVUkhRV3d5VUZkeVZFYzFkSFJaTlN0MU5HTnNXV3h1VTBocWRncFVRa1ZqTW1aNmRXODRkbUZIUlVsMGJsVllkblJxZVRCNlkyRk1XWFU0TDJOaVpVUXdaa2xMZERZNEsyVmpjSEpRUm1sTFV5dHZUekZ3VWxsTGVsUk1DbTlRYjFCbE1HaHBhV2hPZFdJM2EzRkZTMDh4Wm5Sb1VFOW5OR1V4V0hadWRGZFFTQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTE3Zjc2ZGUtNGUxMy00YjdhLWI2NWEtNDFiYzRiYTllYTRhLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC11cGdyYWRlLXBvbGljeQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5IgogICAgdXNlcjogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA1d2tLVElQNVREdnRvQUF3QU0yMWNPVTBDWnpRVDN0TWpyVnBEMTl4Qmg4azREWGliS1R0ZlBCWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "692"
+      - "2684"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:21 GMT
+      - Tue, 07 Nov 2023 15:54:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2515,7 +2515,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd31edd3-e6f8-4732-a7e4-231f101e2160
+      - efcfae2d-595c-4c0d-89c2-e0eb8aa181a7
     status: 200 OK
     code: 200
     duration: ""
@@ -2526,19 +2526,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:22.457056Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "692"
+      - "665"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:26 GMT
+      - Tue, 07 Nov 2023 15:54:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2548,7 +2548,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80a4ee0d-09d7-4e76-9c9a-9679e3fa3460
+      - 96f30b2f-1e4e-4b72-a335-b5ec0f823a73
     status: 200 OK
     code: 200
     duration: ""
@@ -2559,19 +2559,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a/nodes?order_by=created_at_asc&page=1&pool_id=f2906988-2cb9-4253-bc59-d0cc0c91a6a2&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:52:10.010165Z","error_message":null,"id":"77d4aa2a-2cc5-44bd-8ff5-9a796e1f6514","name":"scw-test-pool-upgrade-test-pool-upgrade-77d4aa","pool_id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","provider_id":"scaleway://instance/fr-par-1/37c5f0e7-c7f7-49a2-b580-85f5b3c4d70d","public_ip_v4":"51.15.242.191","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:22.442471Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "692"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:32 GMT
+      - Tue, 07 Nov 2023 15:54:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2581,1068 +2581,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e055f900-a420-455b-b45c-789628f6ae26
+      - 83f49bbc-1a56-4938-927c-bdb78d1139be
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "692"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 213d3119-fc5c-4414-9074-a26a86c553c7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "692"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8ded4285-2c76-417a-abc6-bd3f42077733
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "692"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 669292c7-8d25-49e8-80f6-b7246944fb89
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "692"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 870af36d-54a7-466d-adf9-b7f434aa06c1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "692"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 478ec55c-81a8-4901-bcb2-417656dd40cd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "692"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6c32aafc-21c0-4302-907f-de067f87e4e1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "692"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e833287c-93fa-423f-b7f8-e6a791f0b4f0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "692"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a4d70309-94b9-4373-ac27-04eb86f67a54
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "692"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d973de64-fdd6-4314-9929-78aac7b2d674
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "692"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 333fae90-8553-4778-9faf-bb64df23d123
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "692"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0fd12908-c408-4445-994b-85cbd06980b0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "692"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2c505ad5-6c78-4957-9e0c-1534d52d1ce8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "692"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 85e15e86-a053-4c32-bcd8-7e415cbd0cd9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "692"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7e3d41fb-7237-4aec-8eba-a3ccd2f5c392
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "692"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f3e6a0c8-14ec-4267-bed5-f4b99e0d37aa
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:35:51.214360Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "692"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7e09903e-6857-4069-a9a4-237a3d64beb0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:42:56.902696Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "690"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0bbc8902-6e89-40fc-b45c-f39608dc0871
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://936f1f4a-cf5a-421d-bae6-c209e68bdf5c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.731242Z","created_at":"2023-10-18T16:35:45.731242Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.936f1f4a-cf5a-421d-bae6-c209e68bdf5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-10-18T16:37:27.431187Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1511"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e7789d3d-3faa-4641-9321-ebd571526071
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:42:56.902696Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "690"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9c726136-1bb7-4b92-872e-46ab9c24f674
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c/nodes?order_by=created_at_asc&page=1&pool_id=7afe9a29-6a28-4517-b03a-c10185add522&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:37:29.392797Z","error_message":null,"id":"977d1e00-3e4f-46cb-80cd-a9282f007379","name":"scw-test-pool-upgrade-test-pool-upgrade-977d1e","pool_id":"7afe9a29-6a28-4517-b03a-c10185add522","provider_id":"scaleway://instance/fr-par-1/8c13d366-fb99-4e41-a04f-d3fbcc233c1e","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:42:56.885788Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "660"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d6c85d60-a68f-47ec-8168-cb9f7466d43e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://936f1f4a-cf5a-421d-bae6-c209e68bdf5c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.731242Z","created_at":"2023-10-18T16:35:45.731242Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.936f1f4a-cf5a-421d-bae6-c209e68bdf5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-10-18T16:37:27.431187Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1511"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e8d39061-b4b1-413c-b2d2-df68af7d1f33
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:42:56.902696Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "690"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d0606798-0099-4233-bbb8-2538cbc54b83
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/07c1b4c0-aa12-4485-b99a-358f4db4ea36
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-18T16:35:44.465392Z","dhcp_enabled":true,"id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36","name":"test-pool-upgrade-policy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:35:44.465392Z","id":"40e8207c-fd50-48b8-a880-6d481e30d7c3","subnet":"172.16.8.0/22","updated_at":"2023-10-18T16:35:44.465392Z"},{"created_at":"2023-10-18T16:35:44.465392Z","id":"6846558a-d0de-482f-ae6d-28b2a6233ccd","subnet":"fd63:256c:45f7:1fe4::/64","updated_at":"2023-10-18T16:35:44.465392Z"}],"tags":[],"updated_at":"2023-10-18T16:35:44.465392Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "724"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 099f2ac9-d13a-4f2a-8f8f-b4044a7b73b2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://936f1f4a-cf5a-421d-bae6-c209e68bdf5c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.731242Z","created_at":"2023-10-18T16:35:45.731242Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.936f1f4a-cf5a-421d-bae6-c209e68bdf5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-10-18T16:37:27.431187Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1511"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c813b8e4-c029-46a8-b366-fa5574866063
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC11cGdyYWRlLXBvbGljeSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVeVRYcFZNRTR4YjFoRVZFMTZUVlJCZUU1NlJUSk5lbFV3VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTbkZYQ2xKeWVrVnFibWR0Ym1kNlRVUTVXRkk0UlV4YWFYcEthRVZRZUZaUWNYaDNLMmhDZUZGSGFYbFpObWxqU3pNeU9IUk5XbVUxZDNJclVXTkxZWE5uYlcwS1JVWnJiVUZGS3pkbWVuRlRXVGxoTkRGVlFUSndWMHBKYUd0dlowaHdZbXhOZW1seVZXaG1ZazVSU2tOaFFrTkNNMDh2Y3paRmFITnhLMXBzVGpoNWNBcDRURWgzT1hWM1YwaHphMXBzT0ZSTWRFaHdiRkZWVTFaSE9EUkViRkpwWkVOU1ptSTFZV3BUYzJjMlZsa3JlVEUzYm1KbFpuQm1LekZ3UkVka01tMTVDbGxvZVZOdU5VNTFOMXB0WW5FMk1FcGFRMmRuV214dlpqaGpWMHBvYlV3MlRtTTJUVXQwY2s1WlNrRnJVbTl5TlUxVEwwTlRRV3hHUTBOblJHSTJObTBLVDJWQlRuVjFNMlYxUVRWNlFUZExZM0ZtYVVsSmFuQkJWSEo1UlZka1ZrUlhWbWc0WVZJdmRVOXRPVmN6WVV4d2NtWmhOakYxVjJGTk1sTmFValZPUkFwdVYyazFZV2N5YjBsM1ZuUkZWek5PTHpZNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUFREZElNRWd6VWtaNWNHbGpkWGRCTmtwUEx6aFRTMGxCTUVsTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1lqTjBVRXBrUlZWR1UyMVlORGhIUm1GbmMxWktlRVpPVkVkTFduTkRlRmw2ZW5SbVMzVXlVRTl2UWxCbGJtSXZUd3BUUkUxRk1qSmhVbkoxZFhCT09UVnBlRzVvYlM5TWJWVjRhbGQwYjNjMFRqY3haRW80U2t0MmJsUjNWVFp3UWpObE5XUlJkVzV6WWswNWJXbERhRzg0Q2tGWVkwaFBValp2VFRCUVZuZEthVGcxUzA5a1RtSmlXak5ZUzJKalVtSjVOVmRvZDFaVVExRXhVbXh0V2pkeWRIQklOMlpIYjNob2JEaHdaSGxOYlM4S1pucGhNVlptVTJSMWJqWnRPWGR6ZWpkYVVEZ3ZlSEZZVW5kcVdISlhPVk5RVUdsd2JuUjVlRXg2VXpGWWRrVmhObGd6YmpsRFRYQnBWbk5oYW5SWWFBb3pkRFp0T1dGMFlVUkRhMEYyTVVrMFpUWTBPVzFTVjJSTFVsRlFTR3BJTW1GelEydHdiemR5WmswM00zRmhabEpxWmxsSWVGY3JUbmN5TDBOU2FrbzBDbUYzYTBaQ2VGTkhWelpsU0ZwNGNYSmxkWFpqT0VGSlVHMUVlSEZZYkVoV1YxbDVSZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOTM2ZjFmNGEtY2Y1YS00MjFkLWJhZTYtYzIwOWU2OGJkZjVjLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC11cGdyYWRlLXBvbGljeQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5IgogICAgdXNlcjogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBQMDB2bmRXS2lmaE5EVm02Q2wyMVRxSVVLSGtZNFZXVThkVndMeDFLa2NnQUd1MVlvU0xzYjc4Ug==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2686"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 99aeb8f5-a8fd-4da3-a47c-c63d2deb0d00
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:42:56.902696Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "690"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5649b44f-495c-480b-a91c-94a187798a00
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c/nodes?order_by=created_at_asc&page=1&pool_id=7afe9a29-6a28-4517-b03a-c10185add522&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:37:29.392797Z","error_message":null,"id":"977d1e00-3e4f-46cb-80cd-a9282f007379","name":"scw-test-pool-upgrade-test-pool-upgrade-977d1e","pool_id":"7afe9a29-6a28-4517-b03a-c10185add522","provider_id":"scaleway://instance/fr-par-1/8c13d366-fb99-4e41-a04f-d3fbcc233c1e","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:42:56.885788Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "660"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 09a8be03-0825-45bb-89e6-d52186756b51
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/07c1b4c0-aa12-4485-b99a-358f4db4ea36
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-18T16:35:44.465392Z","dhcp_enabled":true,"id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36","name":"test-pool-upgrade-policy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:35:44.465392Z","id":"40e8207c-fd50-48b8-a880-6d481e30d7c3","subnet":"172.16.8.0/22","updated_at":"2023-10-18T16:35:44.465392Z"},{"created_at":"2023-10-18T16:35:44.465392Z","id":"6846558a-d0de-482f-ae6d-28b2a6233ccd","subnet":"fd63:256c:45f7:1fe4::/64","updated_at":"2023-10-18T16:35:44.465392Z"}],"tags":[],"updated_at":"2023-10-18T16:35:44.465392Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "724"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3df4728f-691a-4a8b-bbbe-8a5007c9b66a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://936f1f4a-cf5a-421d-bae6-c209e68bdf5c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.731242Z","created_at":"2023-10-18T16:35:45.731242Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.936f1f4a-cf5a-421d-bae6-c209e68bdf5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-10-18T16:37:27.431187Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1511"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d7c03140-6a71-4f14-a1ce-9a0850fe0505
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC11cGdyYWRlLXBvbGljeSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVeVRYcFZNRTR4YjFoRVZFMTZUVlJCZUU1NlJUSk5lbFV3VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTbkZYQ2xKeWVrVnFibWR0Ym1kNlRVUTVXRkk0UlV4YWFYcEthRVZRZUZaUWNYaDNLMmhDZUZGSGFYbFpObWxqU3pNeU9IUk5XbVUxZDNJclVXTkxZWE5uYlcwS1JVWnJiVUZGS3pkbWVuRlRXVGxoTkRGVlFUSndWMHBKYUd0dlowaHdZbXhOZW1seVZXaG1ZazVSU2tOaFFrTkNNMDh2Y3paRmFITnhLMXBzVGpoNWNBcDRURWgzT1hWM1YwaHphMXBzT0ZSTWRFaHdiRkZWVTFaSE9EUkViRkpwWkVOU1ptSTFZV3BUYzJjMlZsa3JlVEUzYm1KbFpuQm1LekZ3UkVka01tMTVDbGxvZVZOdU5VNTFOMXB0WW5FMk1FcGFRMmRuV214dlpqaGpWMHBvYlV3MlRtTTJUVXQwY2s1WlNrRnJVbTl5TlUxVEwwTlRRV3hHUTBOblJHSTJObTBLVDJWQlRuVjFNMlYxUVRWNlFUZExZM0ZtYVVsSmFuQkJWSEo1UlZka1ZrUlhWbWc0WVZJdmRVOXRPVmN6WVV4d2NtWmhOakYxVjJGTk1sTmFValZPUkFwdVYyazFZV2N5YjBsM1ZuUkZWek5PTHpZNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUFREZElNRWd6VWtaNWNHbGpkWGRCTmtwUEx6aFRTMGxCTUVsTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1lqTjBVRXBrUlZWR1UyMVlORGhIUm1GbmMxWktlRVpPVkVkTFduTkRlRmw2ZW5SbVMzVXlVRTl2UWxCbGJtSXZUd3BUUkUxRk1qSmhVbkoxZFhCT09UVnBlRzVvYlM5TWJWVjRhbGQwYjNjMFRqY3haRW80U2t0MmJsUjNWVFp3UWpObE5XUlJkVzV6WWswNWJXbERhRzg0Q2tGWVkwaFBValp2VFRCUVZuZEthVGcxUzA5a1RtSmlXak5ZUzJKalVtSjVOVmRvZDFaVVExRXhVbXh0V2pkeWRIQklOMlpIYjNob2JEaHdaSGxOYlM4S1pucGhNVlptVTJSMWJqWnRPWGR6ZWpkYVVEZ3ZlSEZZVW5kcVdISlhPVk5RVUdsd2JuUjVlRXg2VXpGWWRrVmhObGd6YmpsRFRYQnBWbk5oYW5SWWFBb3pkRFp0T1dGMFlVUkRhMEYyTVVrMFpUWTBPVzFTVjJSTFVsRlFTR3BJTW1GelEydHdiemR5WmswM00zRmhabEpxWmxsSWVGY3JUbmN5TDBOU2FrbzBDbUYzYTBaQ2VGTkhWelpsU0ZwNGNYSmxkWFpqT0VGSlVHMUVlSEZZYkVoV1YxbDVSZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOTM2ZjFmNGEtY2Y1YS00MjFkLWJhZTYtYzIwOWU2OGJkZjVjLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC11cGdyYWRlLXBvbGljeQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5IgogICAgdXNlcjogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBQMDB2bmRXS2lmaE5EVm02Q2wyMVRxSVVLSGtZNFZXVThkVndMeDFLa2NnQUd1MVlvU0xzYjc4Ug==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2686"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bb4b68c2-a702-4c36-b0c8-1cbdfd86ac9a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:42:56.902696Z","upgrade_policy":{"max_surge":2,"max_unavailable":3},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "690"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 77058a76-2296-474d-bb2e-20baa70521de
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c/nodes?order_by=created_at_asc&page=1&pool_id=7afe9a29-6a28-4517-b03a-c10185add522&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:37:29.392797Z","error_message":null,"id":"977d1e00-3e4f-46cb-80cd-a9282f007379","name":"scw-test-pool-upgrade-test-pool-upgrade-977d1e","pool_id":"7afe9a29-6a28-4517-b03a-c10185add522","provider_id":"scaleway://instance/fr-par-1/8c13d366-fb99-4e41-a04f-d3fbcc233c1e","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:42:56.885788Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "660"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bd6f9fc0-8418-4593-8c94-6d57a741de94
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"autoscaling":null,"size":null,"min_size":null,"max_size":null,"autohealing":null,"tags":null,"kubelet_args":null,"upgrade_policy":{"max_unavailable":1,"max_surge":0}}'
+    body: '{"upgrade_policy":{"max_unavailable":1,"max_surge":0}}'
     form: {}
     headers:
       Content-Type:
@@ -3650,19 +2594,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: PATCH
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:43:00.391025488Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:25.996025191Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "693"
+      - "668"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:00 GMT
+      - Tue, 07 Nov 2023 15:54:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3672,7 +2616,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44f3850c-3d5c-4b03-987c-f0225b117d01
+      - fd2e94d2-165b-4ec8-b1a4-65fcfa9857f5
     status: 200 OK
     code: 200
     duration: ""
@@ -3683,19 +2627,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:43:00.391025Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:25.996025Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "690"
+      - "665"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:00 GMT
+      - Tue, 07 Nov 2023 15:54:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3705,7 +2649,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4435a08f-a8f8-4d76-8dbb-56512000c94f
+      - 2ff8ef6a-d493-428f-b8a8-4e30a66089c5
     status: 200 OK
     code: 200
     duration: ""
@@ -3716,19 +2660,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:43:00.391025Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:25.996025Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "690"
+      - "665"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:00 GMT
+      - Tue, 07 Nov 2023 15:54:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3738,7 +2682,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4101b686-1e53-4a2c-bc64-a84b6e0c33aa
+      - 25e682b5-ef09-4830-89fe-da5c3a1f72ed
     status: 200 OK
     code: 200
     duration: ""
@@ -3749,19 +2693,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c/nodes?order_by=created_at_asc&page=1&pool_id=7afe9a29-6a28-4517-b03a-c10185add522&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a/nodes?order_by=created_at_asc&page=1&pool_id=f2906988-2cb9-4253-bc59-d0cc0c91a6a2&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:37:29.392797Z","error_message":null,"id":"977d1e00-3e4f-46cb-80cd-a9282f007379","name":"scw-test-pool-upgrade-test-pool-upgrade-977d1e","pool_id":"7afe9a29-6a28-4517-b03a-c10185add522","provider_id":"scaleway://instance/fr-par-1/8c13d366-fb99-4e41-a04f-d3fbcc233c1e","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:42:56.885788Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:52:10.010165Z","error_message":null,"id":"77d4aa2a-2cc5-44bd-8ff5-9a796e1f6514","name":"scw-test-pool-upgrade-test-pool-upgrade-77d4aa","pool_id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","provider_id":"scaleway://instance/fr-par-1/37c5f0e7-c7f7-49a2-b580-85f5b3c4d70d","public_ip_v4":"51.15.242.191","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:22.442471Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "660"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:00 GMT
+      - Tue, 07 Nov 2023 15:54:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3771,7 +2715,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4fc6b74-2f81-4c99-b5b8-fe98fe45945e
+      - e3edd187-289b-4d2b-bcda-c128a584a5c8
     status: 200 OK
     code: 200
     duration: ""
@@ -3782,19 +2726,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://936f1f4a-cf5a-421d-bae6-c209e68bdf5c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.731242Z","created_at":"2023-10-18T16:35:45.731242Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.936f1f4a-cf5a-421d-bae6-c209e68bdf5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-10-18T16:37:27.431187Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:51:42.474016Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1511"
+      - "1466"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:00 GMT
+      - Tue, 07 Nov 2023 15:54:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3804,7 +2748,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 878e9b7b-bbd9-4f33-ae6d-5fd766652f4a
+      - 4c3396c0-b175-4383-b03c-e9970c0cd83f
     status: 200 OK
     code: 200
     duration: ""
@@ -3815,19 +2759,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:43:00.391025Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:25.996025Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "690"
+      - "665"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:00 GMT
+      - Tue, 07 Nov 2023 15:54:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3837,7 +2781,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1a03551-9634-4dea-ae70-4f09146ed51e
+      - 50ab8e56-a68d-468e-ae3c-88f9a6deb7de
     status: 200 OK
     code: 200
     duration: ""
@@ -3848,19 +2792,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/07c1b4c0-aa12-4485-b99a-358f4db4ea36
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/4f3402c1-6ce1-4a28-ac04-c22019bece2f
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:35:44.465392Z","dhcp_enabled":true,"id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36","name":"test-pool-upgrade-policy","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:35:44.465392Z","id":"40e8207c-fd50-48b8-a880-6d481e30d7c3","subnet":"172.16.8.0/22","updated_at":"2023-10-18T16:35:44.465392Z"},{"created_at":"2023-10-18T16:35:44.465392Z","id":"6846558a-d0de-482f-ae6d-28b2a6233ccd","subnet":"fd63:256c:45f7:1fe4::/64","updated_at":"2023-10-18T16:35:44.465392Z"}],"tags":[],"updated_at":"2023-10-18T16:35:44.465392Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T15:49:50.649852Z","dhcp_enabled":true,"id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","name":"test-pool-upgrade-policy","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.649852Z","id":"6080f05f-89b3-4884-bbd5-5375c1aed7af","subnet":"172.16.52.0/22","updated_at":"2023-11-07T15:49:50.649852Z"},{"created_at":"2023-11-07T15:49:50.649852Z","id":"3c774edd-bbde-47db-b249-4f82521fc377","subnet":"fd5f:519c:6d46:1dbf::/64","updated_at":"2023-11-07T15:49:50.649852Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.649852Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "724"
+      - "708"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:01 GMT
+      - Tue, 07 Nov 2023 15:54:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3870,7 +2814,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b9ca1b3-9f58-42d5-8c9e-da6d59cfc4e0
+      - 0e26eea2-ef1d-424a-9ad0-a14da17f8a28
     status: 200 OK
     code: 200
     duration: ""
@@ -3881,19 +2825,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://936f1f4a-cf5a-421d-bae6-c209e68bdf5c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.731242Z","created_at":"2023-10-18T16:35:45.731242Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.936f1f4a-cf5a-421d-bae6-c209e68bdf5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-10-18T16:37:27.431187Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:51:42.474016Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1511"
+      - "1466"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:01 GMT
+      - Tue, 07 Nov 2023 15:54:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3903,7 +2847,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7525597f-33f4-4d90-b02e-704d90c5940d
+      - a386b9c7-1b6e-4f6f-9b6b-754f71ca6ac1
     status: 200 OK
     code: 200
     duration: ""
@@ -3914,19 +2858,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC11cGdyYWRlLXBvbGljeSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVeVRYcFZNRTR4YjFoRVZFMTZUVlJCZUU1NlJUSk5lbFV3VGpGdmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTbkZYQ2xKeWVrVnFibWR0Ym1kNlRVUTVXRkk0UlV4YWFYcEthRVZRZUZaUWNYaDNLMmhDZUZGSGFYbFpObWxqU3pNeU9IUk5XbVUxZDNJclVXTkxZWE5uYlcwS1JVWnJiVUZGS3pkbWVuRlRXVGxoTkRGVlFUSndWMHBKYUd0dlowaHdZbXhOZW1seVZXaG1ZazVSU2tOaFFrTkNNMDh2Y3paRmFITnhLMXBzVGpoNWNBcDRURWgzT1hWM1YwaHphMXBzT0ZSTWRFaHdiRkZWVTFaSE9EUkViRkpwWkVOU1ptSTFZV3BUYzJjMlZsa3JlVEUzYm1KbFpuQm1LekZ3UkVka01tMTVDbGxvZVZOdU5VNTFOMXB0WW5FMk1FcGFRMmRuV214dlpqaGpWMHBvYlV3MlRtTTJUVXQwY2s1WlNrRnJVbTl5TlUxVEwwTlRRV3hHUTBOblJHSTJObTBLVDJWQlRuVjFNMlYxUVRWNlFUZExZM0ZtYVVsSmFuQkJWSEo1UlZka1ZrUlhWbWc0WVZJdmRVOXRPVmN6WVV4d2NtWmhOakYxVjJGTk1sTmFValZPUkFwdVYyazFZV2N5YjBsM1ZuUkZWek5PTHpZNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUFREZElNRWd6VWtaNWNHbGpkWGRCTmtwUEx6aFRTMGxCTUVsTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1lqTjBVRXBrUlZWR1UyMVlORGhIUm1GbmMxWktlRVpPVkVkTFduTkRlRmw2ZW5SbVMzVXlVRTl2UWxCbGJtSXZUd3BUUkUxRk1qSmhVbkoxZFhCT09UVnBlRzVvYlM5TWJWVjRhbGQwYjNjMFRqY3haRW80U2t0MmJsUjNWVFp3UWpObE5XUlJkVzV6WWswNWJXbERhRzg0Q2tGWVkwaFBValp2VFRCUVZuZEthVGcxUzA5a1RtSmlXak5ZUzJKalVtSjVOVmRvZDFaVVExRXhVbXh0V2pkeWRIQklOMlpIYjNob2JEaHdaSGxOYlM4S1pucGhNVlptVTJSMWJqWnRPWGR6ZWpkYVVEZ3ZlSEZZVW5kcVdISlhPVk5RVUdsd2JuUjVlRXg2VXpGWWRrVmhObGd6YmpsRFRYQnBWbk5oYW5SWWFBb3pkRFp0T1dGMFlVUkRhMEYyTVVrMFpUWTBPVzFTVjJSTFVsRlFTR3BJTW1GelEydHdiemR5WmswM00zRmhabEpxWmxsSWVGY3JUbmN5TDBOU2FrbzBDbUYzYTBaQ2VGTkhWelpsU0ZwNGNYSmxkWFpqT0VGSlVHMUVlSEZZYkVoV1YxbDVSZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vOTM2ZjFmNGEtY2Y1YS00MjFkLWJhZTYtYzIwOWU2OGJkZjVjLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC11cGdyYWRlLXBvbGljeQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5IgogICAgdXNlcjogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBQMDB2bmRXS2lmaE5EVm02Q2wyMVRxSVVLSGtZNFZXVThkVndMeDFLa2NnQUd1MVlvU0xzYjc4Ug==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC11cGdyYWRlLXBvbGljeSIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeFRrUnJNVTVHYjFoRVZFMTZUVlJGZDA1cVJURk9SR3N4VGtadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUMDVaQ2xkbVZ6TkNURTlPUWtSSFlXUlBUWEU1UVdneE5ESlVjbFJEUW04M1oxVk1PR1ZWTUVsV2FrZFlWbW9yTjNaQ2RtYzROakJIZGxGMVdtTlpUbUpqUVRFS2RUTndlbVJWTW1rNEwwVjFjSFl3UjJ4SVNDOU9RblpYZVN0QlIwbG5abWxVWVRGUmRsWnlValoxT0dGVE1rOW5ZM051YjFVd1J6RjBSRzFXTDNKUVlnbzNWMFJwU1VFNWRFNVZhVlJsWlRsVWNVODNPWEJ2ZWxKdU1rOWtSbE5EVFU0eVRtMDFhbFJUWVVGTU4wbzJSbVpDZW1GU1kwRTJTM05YTTJoNE5pOWhDbkV4SzJzd1pVMUdVMU52WTBkcVVGQjNWSE51Tmxaa2NVVlVOelZLTHpGVFFTOVNhalJFZVhKVVYyRkhiRXRKYWpsck5tVmpiMnMzYnpWVlZsTnhWRGtLT1VwNVRXcDRRbmxxYlVweWIzbHVNek5RVkd0bloyWlVPVmxSYkdoaU4wTTBTbVZDWmpOTWFHRlpTazVoV1dnelZGSnVXVlJ0UjNaTlVIQXhOa2N3TndwaU9IVXpjbEZ4VTFkQlpUaENWV3hxZURKTlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaQ2JGSm5lR0kwU1ZoaFVEaE5XQ3MxYWpsM1JuVlNPR1pPU2taTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQmJrOVFZVXhPUWpsc1VFWjVPVUZqTjFGRVZFcEVkMWt6VW5WbFZVZFZiSHB6ZEdnelVsWTJiekpCUkdaa1NFUkVTQXBrVEVObmQzVnBiMVJRYjNaR1pqRXhSakptYm5vMk1WQnpkbVZPVmxNMlNIYzRkbEpIUkRSSFJDdHRWemhPUVdkeE4zbGtORGhCVTBaQ01XdzFUa1pNQ25kclRYbEVXRkJYYm5CaE4ycFlUMXB3UkZsUWFEaEhWR3RTYTFwMGVFRkhUak5TVURSbFJIcE1lWGsxZDI1NE9XNHZUWFExZFUwelZIRTNVSGt3UWprS2QwWlZPVmxJU2pkVGNFaDFWUzlHYzB3elFVRjBPRkJWVm01ak9VNHhNV3d2Y25KV2NVUkhRV3d5VUZkeVZFYzFkSFJaTlN0MU5HTnNXV3h1VTBocWRncFVRa1ZqTW1aNmRXODRkbUZIUlVsMGJsVllkblJxZVRCNlkyRk1XWFU0TDJOaVpVUXdaa2xMZERZNEsyVmpjSEpRUm1sTFV5dHZUekZ3VWxsTGVsUk1DbTlRYjFCbE1HaHBhV2hPZFdJM2EzRkZTMDh4Wm5Sb1VFOW5OR1V4V0hadWRGZFFTQW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vNTE3Zjc2ZGUtNGUxMy00YjdhLWI2NWEtNDFiYzRiYTllYTRhLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQHRlc3QtcG9vbC11cGdyYWRlLXBvbGljeQogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAidGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5IgogICAgdXNlcjogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5CmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogdGVzdC1wb29sLXVwZ3JhZGUtcG9saWN5LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA1d2tLVElQNVREdnRvQUF3QU0yMWNPVTBDWnpRVDN0TWpyVnBEMTl4Qmg4azREWGliS1R0ZlBCWQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2686"
+      - "2684"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:01 GMT
+      - Tue, 07 Nov 2023 15:54:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3936,7 +2880,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df4f8e5f-67aa-4602-b05e-8d3a1021b927
+      - 98a02706-1c59-4133-8f42-c953b9d7cbc5
     status: 200 OK
     code: 200
     duration: ""
@@ -3947,19 +2891,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:43:00.391025Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:25.996025Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "690"
+      - "665"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:01 GMT
+      - Tue, 07 Nov 2023 15:54:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3969,7 +2913,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 677475ba-2686-44cd-b8a5-86e7115f2f7e
+      - f2ea60bb-df28-4c1f-b3b5-17c3d18c2925
     status: 200 OK
     code: 200
     duration: ""
@@ -3980,19 +2924,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c/nodes?order_by=created_at_asc&page=1&pool_id=7afe9a29-6a28-4517-b03a-c10185add522&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a/nodes?order_by=created_at_asc&page=1&pool_id=f2906988-2cb9-4253-bc59-d0cc0c91a6a2&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:37:29.392797Z","error_message":null,"id":"977d1e00-3e4f-46cb-80cd-a9282f007379","name":"scw-test-pool-upgrade-test-pool-upgrade-977d1e","pool_id":"7afe9a29-6a28-4517-b03a-c10185add522","provider_id":"scaleway://instance/fr-par-1/8c13d366-fb99-4e41-a04f-d3fbcc233c1e","public_ip_v4":"163.172.143.139","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:43:01.069810Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:52:10.010165Z","error_message":null,"id":"77d4aa2a-2cc5-44bd-8ff5-9a796e1f6514","name":"scw-test-pool-upgrade-test-pool-upgrade-77d4aa","pool_id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","provider_id":"scaleway://instance/fr-par-1/37c5f0e7-c7f7-49a2-b580-85f5b3c4d70d","public_ip_v4":"51.15.242.191","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:26.674862Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "660"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:01 GMT
+      - Tue, 07 Nov 2023 15:54:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4002,7 +2946,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 408b9a56-a59f-49f3-b6bf-6cb27179da63
+      - 9de414d6-5af5-49cb-ad8d-b390fa7bd0ec
     status: 200 OK
     code: 200
     duration: ""
@@ -4013,19 +2957,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/7afe9a29-6a28-4517-b03a-c10185add522
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.207222Z","id":"7afe9a29-6a28-4517-b03a-c10185add522","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-10-18T16:43:02.322148224Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:28.068471899Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "696"
+      - "671"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:02 GMT
+      - Tue, 07 Nov 2023 15:54:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4035,7 +2979,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3405364-acbb-4574-91a6-c766fb4ea52e
+      - 4e8f4183-cf4e-4797-a947-5c2de0f1227b
     status: 200 OK
     code: 200
     duration: ""
@@ -4046,52 +2990,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c?with_additional_resources=true
-    method: DELETE
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://936f1f4a-cf5a-421d-bae6-c209e68bdf5c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.731242Z","created_at":"2023-10-18T16:35:45.731242Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.936f1f4a-cf5a-421d-bae6-c209e68bdf5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-10-18T16:43:02.405696234Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1517"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 77bd148d-83cf-4474-be88-85436effb587
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://936f1f4a-cf5a-421d-bae6-c209e68bdf5c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.731242Z","created_at":"2023-10-18T16:35:45.731242Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.936f1f4a-cf5a-421d-bae6-c209e68bdf5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-10-18T16:43:02.405696Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:28.068472Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1514"
+      - "668"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:02 GMT
+      - Tue, 07 Nov 2023 15:54:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4101,7 +3012,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3eb13fb0-f98c-4912-8caf-943b9de84531
+      - cd1b505b-6d41-4383-b104-7f0318cd5674
     status: 200 OK
     code: 200
     duration: ""
@@ -4112,19 +3023,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://936f1f4a-cf5a-421d-bae6-c209e68bdf5c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.731242Z","created_at":"2023-10-18T16:35:45.731242Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.936f1f4a-cf5a-421d-bae6-c209e68bdf5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-10-18T16:43:02.405696Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:28.068472Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1514"
+      - "668"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:07 GMT
+      - Tue, 07 Nov 2023 15:54:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4134,7 +3045,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2b88637-a8e7-496d-b3bf-eba96b6ee857
+      - 019c8d0e-d001-46be-9bb4-c33ff3d9df1a
     status: 200 OK
     code: 200
     duration: ""
@@ -4145,19 +3056,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://936f1f4a-cf5a-421d-bae6-c209e68bdf5c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.731242Z","created_at":"2023-10-18T16:35:45.731242Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.936f1f4a-cf5a-421d-bae6-c209e68bdf5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-10-18T16:43:02.405696Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:28.068472Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1514"
+      - "668"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:12 GMT
+      - Tue, 07 Nov 2023 15:54:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4167,7 +3078,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 513041bd-6204-47fe-be97-5cc4abac65c3
+      - b09babe5-8c20-42dd-93fd-c6f0bd714cef
     status: 200 OK
     code: 200
     duration: ""
@@ -4178,19 +3089,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://936f1f4a-cf5a-421d-bae6-c209e68bdf5c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.731242Z","created_at":"2023-10-18T16:35:45.731242Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.936f1f4a-cf5a-421d-bae6-c209e68bdf5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-10-18T16:43:02.405696Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.541146Z","id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-upgrade-policy","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"updated_at":"2023-11-07T15:54:28.068472Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1514"
+      - "668"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:17 GMT
+      - Tue, 07 Nov 2023 15:54:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4200,7 +3111,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d73ea62-bf8e-4750-85ea-337e5a5ee234
+      - 143dae80-35f8-48c0-8a7c-fd185b7d1f17
     status: 200 OK
     code: 200
     duration: ""
@@ -4211,19 +3122,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f2906988-2cb9-4253-bc59-d0cc0c91a6a2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://936f1f4a-cf5a-421d-bae6-c209e68bdf5c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.731242Z","created_at":"2023-10-18T16:35:45.731242Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.936f1f4a-cf5a-421d-bae6-c209e68bdf5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-10-18T16:43:02.405696Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"f2906988-2cb9-4253-bc59-d0cc0c91a6a2","type":"not_found"}'
     headers:
       Content-Length:
-      - "1514"
+      - "125"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:22 GMT
+      - Tue, 07 Nov 2023 15:54:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4233,106 +3144,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69f6c231-721e-429e-b5d8-15f21aeaf8f3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://936f1f4a-cf5a-421d-bae6-c209e68bdf5c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.731242Z","created_at":"2023-10-18T16:35:45.731242Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.936f1f4a-cf5a-421d-bae6-c209e68bdf5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-10-18T16:43:02.405696Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1514"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 895322fe-b9c5-4f07-a3cd-0513dd202f79
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://936f1f4a-cf5a-421d-bae6-c209e68bdf5c.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.731242Z","created_at":"2023-10-18T16:35:45.731242Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.936f1f4a-cf5a-421d-bae6-c209e68bdf5c.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-10-18T16:43:02.405696Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1514"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5effed0b-3101-45b7-933b-c680bd93908b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "128"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bb7ac07a-b575-402a-a723-938526dfb63c
+      - a6cfc4e5-61c0-4b55-9230-b47def6ed2cf
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4343,10 +3155,142 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/07c1b4c0-aa12-4485-b99a-358f4db4ea36
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"07c1b4c0-aa12-4485-b99a-358f4db4ea36","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:54:48.376430655Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1472"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:54:48 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c27726ce-f6b5-4d95-968d-a55cab0afcc6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:54:48.376431Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1469"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:54:48 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2c99c735-cb22-474c-bd20-b12eecadf3e1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T15:49:53.097025Z","created_at":"2023-11-07T15:49:53.097025Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.517f76de-4e13-4b7a-b65a-41bc4ba9ea4a.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","ingress":"none","name":"test-pool-upgrade-policy","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","upgrade_policy"],"type":"kapsule","updated_at":"2023-11-07T15:54:48.376431Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1469"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:54:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 68c9191a-1e21-4665-a052-05ff476f3978
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 15:54:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1a344887-a164-4482-9c9c-575f4e893e9c
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/4f3402c1-6ce1-4a28-ac04-c22019bece2f
+    method: DELETE
+  response:
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"4f3402c1-6ce1-4a28-ac04-c22019bece2f","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -4355,7 +3299,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:38 GMT
+      - Tue, 07 Nov 2023 15:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4365,7 +3309,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54e102c6-4053-458e-acb1-2497f56c5aa6
+      - 13fdfb35-9a5d-4f51-b0ba-944565d3a8ee
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4376,10 +3320,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/936f1f4a-cf5a-421d-bae6-c209e68bdf5c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/517f76de-4e13-4b7a-b65a-41bc4ba9ea4a
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"936f1f4a-cf5a-421d-bae6-c209e68bdf5c","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"517f76de-4e13-4b7a-b65a-41bc4ba9ea4a","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -4388,7 +3332,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:38 GMT
+      - Tue, 07 Nov 2023 15:54:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4398,7 +3342,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46e326e2-1109-4a59-9b95-e0a636bfb38e
+      - c5719170-acbf-4506-b764-1ac2e62f19e1
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-wait.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-wait.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:34:40 GMT
+      - Tue, 07 Nov 2023 15:49:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,12 +34,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb138bfe-332b-496f-859b-f6573b7288f6
+      - 01e0bb02-5868-48f5-bd27-6938fb757e03
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-wait","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"test-pool-wait","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-19T16:34:41.054613Z","dhcp_enabled":true,"id":"882a0149-d4f0-470c-8a36-650eb9f9c627","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-19T16:34:41.054613Z","id":"29e823e2-bb1a-4e49-b0e6-726aeafb43b6","subnet":"172.16.4.0/22","updated_at":"2023-10-19T16:34:41.054613Z"},{"created_at":"2023-10-19T16:34:41.054613Z","id":"57b44457-ecb1-48e2-86a5-5d7cf356e438","subnet":"fd63:256c:45f7:d0e7::/64","updated_at":"2023-10-19T16:34:41.054613Z"}],"tags":[],"updated_at":"2023-10-19T16:34:41.054613Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T15:49:50.750080Z","dhcp_enabled":true,"id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","name":"test-pool-wait","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.750080Z","id":"0ba95cf8-45ba-4034-a2d0-045b3eb427fa","subnet":"172.16.60.0/22","updated_at":"2023-11-07T15:49:50.750080Z"},{"created_at":"2023-11-07T15:49:50.750080Z","id":"118694f9-3fe6-4789-b1fd-522e5b081392","subnet":"fd5f:519c:6d46:6cdc::/64","updated_at":"2023-11-07T15:49:50.750080Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.750080Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "714"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:34:42 GMT
+      - Tue, 07 Nov 2023 15:49:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09aef2d5-1a21-4f91-bbd5-8ea4c4f11c28
+      - 24559032-3996-40d8-9cd9-deee7b7f7ed5
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/882a0149-d4f0-470c-8a36-650eb9f9c627
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/adb8e568-6480-4b18-8b5c-3657e59e7a65
     method: GET
   response:
-    body: '{"created_at":"2023-10-19T16:34:41.054613Z","dhcp_enabled":true,"id":"882a0149-d4f0-470c-8a36-650eb9f9c627","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-19T16:34:41.054613Z","id":"29e823e2-bb1a-4e49-b0e6-726aeafb43b6","subnet":"172.16.4.0/22","updated_at":"2023-10-19T16:34:41.054613Z"},{"created_at":"2023-10-19T16:34:41.054613Z","id":"57b44457-ecb1-48e2-86a5-5d7cf356e438","subnet":"fd63:256c:45f7:d0e7::/64","updated_at":"2023-10-19T16:34:41.054613Z"}],"tags":[],"updated_at":"2023-10-19T16:34:41.054613Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T15:49:50.750080Z","dhcp_enabled":true,"id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","name":"test-pool-wait","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.750080Z","id":"0ba95cf8-45ba-4034-a2d0-045b3eb427fa","subnet":"172.16.60.0/22","updated_at":"2023-11-07T15:49:50.750080Z"},{"created_at":"2023-11-07T15:49:50.750080Z","id":"118694f9-3fe6-4789-b1fd-522e5b081392","subnet":"fd5f:519c:6d46:6cdc::/64","updated_at":"2023-11-07T15:49:50.750080Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.750080Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "714"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:34:42 GMT
+      - Tue, 07 Nov 2023 15:49:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49cba4f9-82ad-431c-b9cb-8fd22f7728a8
+      - 40177934-0356-4711-9351-942234c2661a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-wait","description":"","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627"}'
+    body: '{"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","type":"","name":"test-pool-wait","description":"","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65"}'
     form: {}
     headers:
       Content-Type:
@@ -118,16 +118,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900975539Z","created_at":"2023-10-19T16:34:42.900975539Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:34:42.915672437Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393484Z","created_at":"2023-11-07T15:49:52.856393484Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:49:52.868916169Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1506"
+      - "1461"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:34:42 GMT
+      - Tue, 07 Nov 2023 15:49:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e1e1f97-5054-4f88-b31e-3cc230c03a00
+      - 4cc55ff8-d33f-470c-9c9d-5a1b2271b713
     status: 200 OK
     code: 200
     duration: ""
@@ -148,19 +148,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900976Z","created_at":"2023-10-19T16:34:42.900976Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:34:42.915672Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:49:52.868916Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1497"
+      - "1452"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:34:43 GMT
+      - Tue, 07 Nov 2023 15:49:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d333e64b-abe7-4119-a895-e6dce00946ff
+      - 3e575cf1-a919-4291-9701-00bed879f907
     status: 200 OK
     code: 200
     duration: ""
@@ -181,19 +181,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900976Z","created_at":"2023-10-19T16:34:42.900976Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:34:44.442417Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:49:54.921399Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1502"
+      - "1457"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:34:48 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3eb30ad5-f981-4ac9-b971-decad42401de
+      - 0e6473aa-825f-4816-add5-0db10cadeafe
     status: 200 OK
     code: 200
     duration: ""
@@ -214,19 +214,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900976Z","created_at":"2023-10-19T16:34:42.900976Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:34:44.442417Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:49:54.921399Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1502"
+      - "1457"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:34:48 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb41c973-d9cb-4498-906f-e4a54ae0f945
+      - 03817c0f-d09c-41ac-952f-6028ac257680
     status: 200 OK
     code: 200
     duration: ""
@@ -247,19 +247,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaFBSRVV5VFhwUk1FNUdiMWhFVkUxNlRWUkJlRTlFUlRKTmVsRXdUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyWnpDa05OZEVoTlNETm9lRW96Tm0xNlJtVjBlbWhXVlRKNE5WbHhlWGhvVEZsMGVtSkRjR0ZQYUhKRGIwdzVhREpQU2xoMlpraFVUbkk1SzNka1RESjVSM2dLTmxKVEwyWmtVMmQxVm5WWGFtTmhTVkZYVkVaMWFFSlJaMWxFVERGdWVIZFVXbXRvVTBoVGR6RmhORzVIUzBzNWRpdDNObU0zYlVWaGFYWlNZWElyVUFwbmJrWlpjSEU1WkZGNmRXSXJZbGRKY1ROcE1XOVZjblpKYjNKNE5XeGhZV2cxY0VObWRHSllWMFpXTkVNMVRYQlRXa00yVTNCdldFaFdPR3gzVFRWQkNsVjNSSGRzV0c1UVQyNHdTVEJMVFV3MFpFNUtVVmxaVlU5UlEzTmFSVmsyYmpoNGVUSm1iMGwyUVZWbFYwbG5UR2xNV1V0SWJrUXZWRmg2VUhGRFIyWUtlVUk1V1ZkTWEzQnhhREZTT1hrMVRrOXNOWEYwUlVSSk9GRkZNMDlyWm10cEswbFJSVVZCU0VablVYUkVRbGRUTDJ4QlkydFNkVmd2Yms5WFJsVndiQXB4WW1RMEx6QjBZbWRZVEU1TVdYQTBSbEpyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGUkdKb1JXSTBiVnBJYVVGMmVIbHhUSGcyWnpaNE5YcGxUM3BOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEWkdGT2VGTnBiV05pVDNsdGQza3dUVWczV25CT05XNXZWRll6U2xKT2MxRjFhamROTURkeVEyaFdORVpuYmpSM1V3cE5UMnRxYUhkcFZVcGlLMDU2YVVoMVoxWjRjSGxLT0RCeVNVOUhWMFE0VWxCTmNGSndUMlUxWTBOalZuVlJlbEI0YXpJNVZFVnRUVmt2UWxSc1pGTlhDbUo0YTNkVmJVNDVkV1JaZUcweWNsRjRWbGxtY2toTFRrZ3lhamxJTUdkak9XMHdVbFpMVld3NFRVeHZOM3BMYVhjMGNsSnZjVUk0UVcxUFdqWkRMMElLUm1OR2RUSlJjM1JwU1VOamRqazBVME5YVmpGdGMwSTFUVFF4YVhSdGFFdHJZVVp4VEd0M1IzbG5SemxLSzJZeldEaGFVVEJHUW1oVGVqQTVkak5KY3dwck4yWnVhRlpQUkRaTGNHdHVWa1kyZW1wNldGWk5VbTgxUW5wUk55OVpNVXREVVdsdWNVRkJlU3RFUjB4RFl6TkdkV28xWm5WcE5HaDNkRlZSVW1VekNqaHJhV29yUkN0bWJVeDRiMDUyYUU4M1dFd3JUMDVPYTI5UFFpODJRVmx4T0VWYVRRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly83MGRlMDY0Yi1kZDZkLTQxZDEtYjk5Ny03MDVlMTE1NmRiZjEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBGZ1VqUGRuem5pWE1GajFHN0V3MzdtZXdqY0pyNTZqS0EyVTVvRm5YQ2tMaFB4a0l5Wkk3U2diSQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6TTJDbnBhVlU4eWRWVlpkMVIxYTB4QlEzRnhZMWhsYmxaTWNtaHVOMEozV0ZreGNFcHNiRVJhVFRCbFIyeERhMlZRTUhaMVRFbEJWbmhDYlhkRWEySk9VRm9LUldaMWFHZGlZbXgyZGtkUmIyZHRjVzk2UVZGTU9HNVNVRk5wYVZGblEwNHdRM2t6VjJ4Q05sUTRhV3RRT0hkV1JtdG5ZV2h6VjJoTldISnJSWEpyZFFvclJVUlNPR2h2TVhSSFJTOUdZemxQV1VKc1lYQXJSMDQyTTJGMU4wVlVZVFkzVkhGdVJVUnhhakZ1VlM5blpuTkhSMHMxTTFsSlEyaDNNbGxuVWtOMkNrSjVWSGxZSzJkS01FazBhMGgyYVRGR1F6QmFNME54UjNkblJHeFBibmQzWmt0NVJEbElkMGhETkZkTWMyWmxTVkJDVkZaS2JVMUhjbnA2ZUhkaVZUQUtkVVZOVHpoNkt6aFpWRzU1WW5Rek9FcE1hMEozWkdORk9UVnFiREZFWnpZM2IwbGlPRzVPWmt0ME4xWlpWa1YwVW5GWlZXcFZLM1VyWVhkUFVtVXhLd3A2ZW5wV1ZETnllWG80V2xoUFlYVXJPVU00UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIWVhKaGRqTlNSbTV2VURKRldXbGFWVTlGWkVKTFJrVjZia1pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCUjJ4dmIydFJUVE5rV1V4RE5tNHJhRUpaYjBoS1pEVkZOVlZyUzJkVEt6WktRMUJ4TW14aVozWmFOR2xxUVRWMGRncG5VWFpNYVUxclFqaGpaR3hvYW1wWUwwTlNNbTFPWkhKTmNFUjBjRlpqVmxoV1kwTnpWM0F2ZHk5blFtTk9kbnA1ZUROaVkybFJkVEp3V25kWFpTdDRDbXBhVDNCYVMzbEpObmhOUnpKdGEzRndNSGhVSzI5TFFpODJNblpVTjJGVGNHZzNWemc1TWpjeVQzaERSR2haUkd0U1RrTkJZMFkyV1dJNVZGTjBWamtLV0RkMVFXZHJNRE16VWpNd1NYUXJiSGhoVlRsalRIaEpWMHh1VGxGTVYwdzJMM3BTVERkcWMyYzJiR1pvUkZvNWVqSXpkRkZ3WlZGVWVtZDZSa1phYmdwek4xaFdlalIwT1RaRk1rSnFPRzh5VG5KcFMwZHZhbXcxTUZkRk5sVjFUM2xvUm5CTGNtMHhSMmxRU205blNqVXZhMUpqU2xoTmNWRllORUZWYWxjM0NrSjZVbU5WUW1Od1dsRllialJRVEV0alYzSmxSakZzUm1GTVMyeE5lVkpCVW5KWVVBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xNTAzZTYyOS04ZGJhLTRlOTktODk2MC1lNmY4MDhmNmM4MTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBQemZ3Um9Qc2V0aDA2MEdnOXpOcnYyT1E4OG5zVlF6Sm9TNDdTY3RtVVlxVkl4YTFuZEFXQ3NMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2606"
+      - "2604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:34:48 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a7dbcc8-da27-4cf6-b92c-5e47f2446b9f
+      - 8b53d15d-a895-42af-b50a-b7dfe3b4a882
     status: 200 OK
     code: 200
     duration: ""
@@ -280,19 +280,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900976Z","created_at":"2023-10-19T16:34:42.900976Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:34:44.442417Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:49:54.921399Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1502"
+      - "1457"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:34:48 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,12 +302,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a22d757-b06f-402e-b44f-1f129d484478
+      - c16ca7e2-16d1-4ead-bdcf-fecd24a4f48e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"upgrade_policy":null,"zone":"fr-par-1","root_volume_type":"default_volume_type","root_volume_size":null,"public_ip_disabled":false}'
+    body: '{"name":"test-pool-wait","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"zone":"fr-par-1","root_volume_type":"default_volume_type","public_ip_disabled":false}'
     form: {}
     headers:
       Content-Type:
@@ -315,19 +315,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/pools
     method: POST
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399876644Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342692758Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "629"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:34:48 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -337,7 +337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8fb817b2-c5dc-4e6e-98ea-a3a7c20e82af
+      - 4704cecd-4846-4cb1-a1d1-847742590fc1
     status: 200 OK
     code: 200
     duration: ""
@@ -348,19 +348,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:34:48 GMT
+      - Tue, 07 Nov 2023 15:49:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -370,7 +370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3195ec9-f22e-42c5-bc3e-67c3b05815cf
+      - e19dc9c6-8919-4f9b-bb8e-8891af68cd60
     status: 200 OK
     code: 200
     duration: ""
@@ -381,19 +381,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:34:53 GMT
+      - Tue, 07 Nov 2023 15:50:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -403,7 +403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8aaf0f2c-f4a8-41da-bfdc-d9e9916fd710
+      - 3dffc0ee-47cd-49bc-a86e-751d5a1e04e3
     status: 200 OK
     code: 200
     duration: ""
@@ -414,19 +414,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:34:58 GMT
+      - Tue, 07 Nov 2023 15:50:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -436,7 +436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - edfb29b3-0f70-4519-8569-87a805a61a68
+      - 2e95efbc-d2d4-4a6e-8c59-6fafb0c59996
     status: 200 OK
     code: 200
     duration: ""
@@ -447,19 +447,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:35:03 GMT
+      - Tue, 07 Nov 2023 15:50:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -469,7 +469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ba68966-5a95-4188-998e-eb40401df3ee
+      - f237bb0f-1c9f-4697-972d-83ed8e7a8913
     status: 200 OK
     code: 200
     duration: ""
@@ -480,19 +480,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:35:08 GMT
+      - Tue, 07 Nov 2023 15:50:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dad56560-d1e4-4c98-bc36-b9c7c1c31c21
+      - def8e7d1-4ed7-478c-8d33-0b8b8f68359b
     status: 200 OK
     code: 200
     duration: ""
@@ -513,19 +513,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:35:14 GMT
+      - Tue, 07 Nov 2023 15:50:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8575b4bb-68ec-4e0e-9ded-238fca678af1
+      - 8d2ef50c-5bdb-43ec-9425-2512baf78f5e
     status: 200 OK
     code: 200
     duration: ""
@@ -546,19 +546,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:35:19 GMT
+      - Tue, 07 Nov 2023 15:50:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1100a991-c969-4ce2-9501-34d4b77ff0c0
+      - d1a4bc90-9c40-48fa-a0dc-af4f4ee2051d
     status: 200 OK
     code: 200
     duration: ""
@@ -579,19 +579,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:35:24 GMT
+      - Tue, 07 Nov 2023 15:50:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d87e9df-3ffd-41da-9fbf-ac56b47158b5
+      - e8d478d9-cc2a-4831-9789-83781bc01bc8
     status: 200 OK
     code: 200
     duration: ""
@@ -612,19 +612,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:35:29 GMT
+      - Tue, 07 Nov 2023 15:50:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 447a3d7b-78b8-4881-a77c-8fa6f0bdb311
+      - 4e033a88-0cfe-460e-a8c7-b5b748487141
     status: 200 OK
     code: 200
     duration: ""
@@ -645,19 +645,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:35:34 GMT
+      - Tue, 07 Nov 2023 15:50:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6b16555-6a50-4c59-8352-af8ddac6c2e6
+      - 7a350b6d-32fd-4379-9999-0b6a03528b3a
     status: 200 OK
     code: 200
     duration: ""
@@ -678,19 +678,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:35:39 GMT
+      - Tue, 07 Nov 2023 15:50:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dff82689-e497-486b-88f6-77ad78bc2de2
+      - f78cd00b-1121-4949-8ee2-9175e1b798c7
     status: 200 OK
     code: 200
     duration: ""
@@ -711,19 +711,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:35:44 GMT
+      - Tue, 07 Nov 2023 15:50:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2bcbe00-b967-47f3-b2d0-51f616f31c7c
+      - 52297e1c-f3fe-413a-9a51-ff57e7c7c69c
     status: 200 OK
     code: 200
     duration: ""
@@ -744,19 +744,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:35:49 GMT
+      - Tue, 07 Nov 2023 15:51:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cce69c11-c8d8-4568-8d7a-ef0920f95d6e
+      - 1b2b4b39-2710-4949-8eab-d463f24cca09
     status: 200 OK
     code: 200
     duration: ""
@@ -777,19 +777,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:35:54 GMT
+      - Tue, 07 Nov 2023 15:51:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 424c859e-aacf-470d-9da3-5133c420725d
+      - 9e8b5fcf-2c36-4620-b0cd-dc0156115f68
     status: 200 OK
     code: 200
     duration: ""
@@ -810,19 +810,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:35:59 GMT
+      - Tue, 07 Nov 2023 15:51:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24649dd8-8c37-4c69-9615-3794bac467a2
+      - 7cda6119-147f-43db-8610-2ef9c7aca96b
     status: 200 OK
     code: 200
     duration: ""
@@ -843,19 +843,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:04 GMT
+      - Tue, 07 Nov 2023 15:51:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b65d3ffb-d361-410b-afe6-0aed3858df69
+      - cf6eb20c-46ca-4e4b-b6d2-8c060721040a
     status: 200 OK
     code: 200
     duration: ""
@@ -876,19 +876,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:09 GMT
+      - Tue, 07 Nov 2023 15:51:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70575e36-42b8-4147-b540-bf8958e3b9f2
+      - 8da99df2-70e0-4d9e-9924-9a3b1ee0c6bd
     status: 200 OK
     code: 200
     duration: ""
@@ -909,19 +909,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:14 GMT
+      - Tue, 07 Nov 2023 15:51:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f470866-b33b-4763-b61f-a99e26486eed
+      - cbd7ca64-1639-4da7-b62e-6c3c9746af90
     status: 200 OK
     code: 200
     duration: ""
@@ -942,19 +942,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:19 GMT
+      - Tue, 07 Nov 2023 15:51:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9aded35-eee3-409b-832f-64c243a3115d
+      - 9deeead3-1cb3-4976-8d91-b33f45fcc6ec
     status: 200 OK
     code: 200
     duration: ""
@@ -975,19 +975,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:24 GMT
+      - Tue, 07 Nov 2023 15:51:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9af27c1d-d3de-49fd-b71f-531e9b201c69
+      - 90e0d800-2360-476b-a047-d6f70d08a891
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,19 +1008,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:29 GMT
+      - Tue, 07 Nov 2023 15:51:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85df6903-0123-4f64-a14e-ee5d39bfbe88
+      - 2d5ba2e6-b41f-4fe9-ac87-084de48c39e9
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,19 +1041,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:34 GMT
+      - Tue, 07 Nov 2023 15:51:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c77b2c30-0ec9-48f0-8674-f5779bedd42e
+      - e7e78499-fc2a-4cba-b672-1b5a5dfcd9f1
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,19 +1074,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:39 GMT
+      - Tue, 07 Nov 2023 15:51:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 517ee171-cc08-4546-a1c5-8a2b61f0e6bb
+      - cf04bf85-48cf-43c0-8a9d-08720b5743b3
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,19 +1107,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:44 GMT
+      - Tue, 07 Nov 2023 15:51:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1129,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f8aa8b9-2122-4f6d-8a9c-697dea790d2a
+      - 51f93fe7-e163-481c-b2f2-a16fb04e387a
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,19 +1140,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:50 GMT
+      - Tue, 07 Nov 2023 15:52:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e900305-95c9-413c-a8a7-f6951c8e23d7
+      - 7992e0b0-2a51-4f54-9e6d-782b0b101ae5
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,19 +1173,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:36:55 GMT
+      - Tue, 07 Nov 2023 15:52:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb3f68a8-e428-4124-ae91-7b0d676d6ea4
+      - 04e756e8-7ce1-4aba-806b-86f37da77343
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,19 +1206,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:37:00 GMT
+      - Tue, 07 Nov 2023 15:52:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d991a186-0ed2-4e14-8d5b-deed8517329b
+      - 1b048609-39b0-4cc3-8f8a-1f6f64e93558
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,19 +1239,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:37:05 GMT
+      - Tue, 07 Nov 2023 15:52:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc9a777d-cac7-47ec-a6d5-135b6e333685
+      - 3c3d2a9c-9456-4afc-8bf2-248569f8b3c8
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,19 +1272,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:37:10 GMT
+      - Tue, 07 Nov 2023 15:52:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e81622f-9128-42bb-84e9-60dfdef15c7f
+      - bb03340b-8fc9-49cd-9da3-866b3611dbb5
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,19 +1305,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:37:15 GMT
+      - Tue, 07 Nov 2023 15:52:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd8c3be6-947c-4e33-9b1f-57c1075a5273
+      - 2a46b3ff-9ffe-470d-a8f1-4a5ee5f8b133
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,19 +1338,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:37:20 GMT
+      - Tue, 07 Nov 2023 15:52:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1360,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c87a88f-374f-48b9-afa0-9f9304331f77
+      - 022c41a7-0f3e-465d-80bd-911b2d3fe565
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,19 +1371,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:37:25 GMT
+      - Tue, 07 Nov 2023 15:52:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1393,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 939faa57-af1b-407a-b651-3dba6e789181
+      - 0ba560be-db7d-4c84-a22a-ff6d0b94f416
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,19 +1404,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:37:30 GMT
+      - Tue, 07 Nov 2023 15:52:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1426,7 +1426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8e36323-4c5d-4079-9d55-22b1fcc37fd7
+      - e7487b51-9197-4b06-9683-4c8a0eba4873
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,19 +1437,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:37:35 GMT
+      - Tue, 07 Nov 2023 15:52:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1459,7 +1459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b88b212e-e424-4568-b031-b6cc1791aaef
+      - 20b468e3-4a16-4a14-8cc6-9f2148a13af3
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,19 +1470,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:37:40 GMT
+      - Tue, 07 Nov 2023 15:52:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1492,7 +1492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6688ecb0-5bab-4b81-8c0d-49886e77bd7a
+      - 33fde6b4-06a2-44a1-a8fb-407ccbef35af
     status: 200 OK
     code: 200
     duration: ""
@@ -1503,19 +1503,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:37:45 GMT
+      - Tue, 07 Nov 2023 15:52:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46ac6493-ddab-423b-9c72-86dfef109e83
+      - 7b7752a4-e1df-4ccb-bc7e-4100437f58e8
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,19 +1536,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:37:50 GMT
+      - Tue, 07 Nov 2023 15:53:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1558,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f04b2247-7947-4465-9869-a0f4695d40db
+      - d10ffd2e-3ea0-49d1-afd5-681630234037
     status: 200 OK
     code: 200
     duration: ""
@@ -1569,19 +1569,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:37:55 GMT
+      - Tue, 07 Nov 2023 15:53:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1591,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43025918-39ee-4728-b1f7-2b534d322e19
+      - be006c70-c10c-4f11-9825-33047eec7b8e
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,19 +1602,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:38:00 GMT
+      - Tue, 07 Nov 2023 15:53:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 756f4f52-48c9-4ee8-aa1e-1140d9c96457
+      - 199fcf78-d0ed-42fa-8893-405eef72d8e1
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,19 +1635,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:38:05 GMT
+      - Tue, 07 Nov 2023 15:53:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1657,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56e5f5b2-a367-4d67-bfaf-23a2042495d2
+      - 1c6ca505-c566-4ffb-b813-a85b10ca81f7
     status: 200 OK
     code: 200
     duration: ""
@@ -1668,19 +1668,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:38:10 GMT
+      - Tue, 07 Nov 2023 15:53:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1690,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 631bae88-507a-4bc8-9a05-dabe6d9fe7a0
+      - 7954b6ba-cfaa-402b-a888-1ca537f5c1dc
     status: 200 OK
     code: 200
     duration: ""
@@ -1701,19 +1701,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:38:15 GMT
+      - Tue, 07 Nov 2023 15:53:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1723,7 +1723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad5fd4f0-482e-40bd-8f51-bea514a519c4
+      - 0da2ef17-820d-4e58-8998-338559aa9098
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,19 +1734,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:38:20 GMT
+      - Tue, 07 Nov 2023 15:53:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1756,7 +1756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 562d005f-3f26-4bf2-be0e-c06b5894166d
+      - b1b94b5f-49ca-4f10-a6ba-38cced9aa8e0
     status: 200 OK
     code: 200
     duration: ""
@@ -1767,19 +1767,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:38:26 GMT
+      - Tue, 07 Nov 2023 15:53:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1789,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b770354-1312-42f1-88ca-0b346fa669ed
+      - 53b3acb6-9df5-4541-8674-ff96f35967ed
     status: 200 OK
     code: 200
     duration: ""
@@ -1800,19 +1800,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:38:31 GMT
+      - Tue, 07 Nov 2023 15:53:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1822,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 382921f3-0580-4f5e-abee-dc184b364dab
+      - 82801bca-9de9-47e3-aedc-a21fbfd6fbdc
     status: 200 OK
     code: 200
     duration: ""
@@ -1833,19 +1833,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:38:36 GMT
+      - Tue, 07 Nov 2023 15:53:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1855,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54925957-4864-4910-89d4-7b306a46cbee
+      - 9d5af4ac-62f0-4d7c-8a79-5ab5dd97405d
     status: 200 OK
     code: 200
     duration: ""
@@ -1866,19 +1866,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:38:41 GMT
+      - Tue, 07 Nov 2023 15:53:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1888,7 +1888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56500118-374f-4c04-92dc-400c75cb14aa
+      - c9495ced-26b5-4575-b451-8a256a23a10d
     status: 200 OK
     code: 200
     duration: ""
@@ -1899,19 +1899,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:38:46 GMT
+      - Tue, 07 Nov 2023 15:53:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1921,7 +1921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0b0f27c-eefd-4f9e-b0d9-b89c59a9a0f2
+      - 0dafa23d-5b6c-43da-9300-d441f04371a8
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,19 +1932,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:49:58.342693Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:38:51 GMT
+      - Tue, 07 Nov 2023 15:54:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1954,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4a9fb03-3431-4445-9054-da589aa4e472
+      - d629c838-54a2-44b3-8a1b-d82573d1adf1
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,19 +1965,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:04.880743Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "601"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:38:56 GMT
+      - Tue, 07 Nov 2023 15:54:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1987,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f4f45c3-2fd0-4898-8e72-362a0f36d421
+      - f56abe6c-e613-445c-a268-64efa7eb8bf6
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,19 +1998,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "626"
+      - "1449"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:39:01 GMT
+      - Tue, 07 Nov 2023 15:54:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2020,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67354190-79bb-458c-8312-a330c2aa5dd9
+      - 41de0c41-db67-485b-9871-90d2a85bad35
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,19 +2031,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:04.880743Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "601"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:39:06 GMT
+      - Tue, 07 Nov 2023 15:54:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2053,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aac51e42-8cad-4dde-ac6c-1ab8e83b8bd0
+      - 1be02c55-cd73-4eea-b005-5d1bd6231686
     status: 200 OK
     code: 200
     duration: ""
@@ -2064,19 +2064,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=183e6c65-4884-4dd9-8252-5d4e66a2172f&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:46.900209Z","error_message":null,"id":"fce7c559-26ef-4f5d-9d15-b3eb6fb9a512","name":"scw-test-pool-wait-test-pool-wait-fce7c55926ef","pool_id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","provider_id":"scaleway://instance/fr-par-1/0b2e1b88-152b-43d2-980b-40f8d38acf79","public_ip_v4":"51.15.204.118","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:04.868347Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "626"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:39:11 GMT
+      - Tue, 07 Nov 2023 15:54:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2086,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c54ecc45-7e21-4ebe-b3a8-3e85828c2b8f
+      - 09620a8f-6bbb-40c4-828d-2c3765641b2d
     status: 200 OK
     code: 200
     duration: ""
@@ -2097,19 +2097,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "626"
+      - "1449"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:39:16 GMT
+      - Tue, 07 Nov 2023 15:54:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2119,7 +2119,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8d9c13b-660f-45cc-8644-2ece92e9d464
+      - 1f1aa057-fe65-4cdd-b01f-dc8d153cdc47
     status: 200 OK
     code: 200
     duration: ""
@@ -2130,19 +2130,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:04.880743Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "601"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:39:21 GMT
+      - Tue, 07 Nov 2023 15:54:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2152,7 +2152,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5cf26b3-c169-46c9-9cfd-534599a6fc5b
+      - 6976d16d-0e92-453f-9147-9ee426fb1d70
     status: 200 OK
     code: 200
     duration: ""
@@ -2163,19 +2163,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/adb8e568-6480-4b18-8b5c-3657e59e7a65
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-07T15:49:50.750080Z","dhcp_enabled":true,"id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","name":"test-pool-wait","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.750080Z","id":"0ba95cf8-45ba-4034-a2d0-045b3eb427fa","subnet":"172.16.60.0/22","updated_at":"2023-11-07T15:49:50.750080Z"},{"created_at":"2023-11-07T15:49:50.750080Z","id":"118694f9-3fe6-4789-b1fd-522e5b081392","subnet":"fd5f:519c:6d46:6cdc::/64","updated_at":"2023-11-07T15:49:50.750080Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.750080Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "626"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:39:26 GMT
+      - Tue, 07 Nov 2023 15:54:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2185,7 +2185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b464c783-b1ce-4893-8155-157f4973d23c
+      - e9544a56-36ea-4a25-830a-5de74edbe774
     status: 200 OK
     code: 200
     duration: ""
@@ -2196,19 +2196,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "626"
+      - "1449"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:39:31 GMT
+      - Tue, 07 Nov 2023 15:54:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2218,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0148e1da-d82c-49bf-854c-5f78d78a4bac
+      - 5ccc84d4-d14e-4b14-af9c-b584b75159e5
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,19 +2229,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6TTJDbnBhVlU4eWRWVlpkMVIxYTB4QlEzRnhZMWhsYmxaTWNtaHVOMEozV0ZreGNFcHNiRVJhVFRCbFIyeERhMlZRTUhaMVRFbEJWbmhDYlhkRWEySk9VRm9LUldaMWFHZGlZbXgyZGtkUmIyZHRjVzk2UVZGTU9HNVNVRk5wYVZGblEwNHdRM2t6VjJ4Q05sUTRhV3RRT0hkV1JtdG5ZV2h6VjJoTldISnJSWEpyZFFvclJVUlNPR2h2TVhSSFJTOUdZemxQV1VKc1lYQXJSMDQyTTJGMU4wVlVZVFkzVkhGdVJVUnhhakZ1VlM5blpuTkhSMHMxTTFsSlEyaDNNbGxuVWtOMkNrSjVWSGxZSzJkS01FazBhMGgyYVRGR1F6QmFNME54UjNkblJHeFBibmQzWmt0NVJEbElkMGhETkZkTWMyWmxTVkJDVkZaS2JVMUhjbnA2ZUhkaVZUQUtkVVZOVHpoNkt6aFpWRzU1WW5Rek9FcE1hMEozWkdORk9UVnFiREZFWnpZM2IwbGlPRzVPWmt0ME4xWlpWa1YwVW5GWlZXcFZLM1VyWVhkUFVtVXhLd3A2ZW5wV1ZETnllWG80V2xoUFlYVXJPVU00UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIWVhKaGRqTlNSbTV2VURKRldXbGFWVTlGWkVKTFJrVjZia1pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCUjJ4dmIydFJUVE5rV1V4RE5tNHJhRUpaYjBoS1pEVkZOVlZyUzJkVEt6WktRMUJ4TW14aVozWmFOR2xxUVRWMGRncG5VWFpNYVUxclFqaGpaR3hvYW1wWUwwTlNNbTFPWkhKTmNFUjBjRlpqVmxoV1kwTnpWM0F2ZHk5blFtTk9kbnA1ZUROaVkybFJkVEp3V25kWFpTdDRDbXBhVDNCYVMzbEpObmhOUnpKdGEzRndNSGhVSzI5TFFpODJNblpVTjJGVGNHZzNWemc1TWpjeVQzaERSR2haUkd0U1RrTkJZMFkyV1dJNVZGTjBWamtLV0RkMVFXZHJNRE16VWpNd1NYUXJiSGhoVlRsalRIaEpWMHh1VGxGTVYwdzJMM3BTVERkcWMyYzJiR1pvUkZvNWVqSXpkRkZ3WlZGVWVtZDZSa1phYmdwek4xaFdlalIwT1RaRk1rSnFPRzh5VG5KcFMwZHZhbXcxTUZkRk5sVjFUM2xvUm5CTGNtMHhSMmxRU205blNqVXZhMUpqU2xoTmNWRllORUZWYWxjM0NrSjZVbU5WUW1Od1dsRllialJRVEV0alYzSmxSakZzUm1GTVMyeE5lVkpCVW5KWVVBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xNTAzZTYyOS04ZGJhLTRlOTktODk2MC1lNmY4MDhmNmM4MTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBQemZ3Um9Qc2V0aDA2MEdnOXpOcnYyT1E4OG5zVlF6Sm9TNDdTY3RtVVlxVkl4YTFuZEFXQ3NMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "626"
+      - "2604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:39:36 GMT
+      - Tue, 07 Nov 2023 15:54:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2251,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2636b0f8-a22d-4451-b75c-5cf451a5bf65
+      - f4048b70-8904-4495-b4ed-5a2dd00297a4
     status: 200 OK
     code: 200
     duration: ""
@@ -2262,19 +2262,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:04.880743Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "601"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:39:41 GMT
+      - Tue, 07 Nov 2023 15:54:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2284,7 +2284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7921348-fb87-42b7-978f-22e0e568948c
+      - 75ce8c46-cef3-4147-88d5-68426739833b
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,19 +2295,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=183e6c65-4884-4dd9-8252-5d4e66a2172f&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:46.900209Z","error_message":null,"id":"fce7c559-26ef-4f5d-9d15-b3eb6fb9a512","name":"scw-test-pool-wait-test-pool-wait-fce7c55926ef","pool_id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","provider_id":"scaleway://instance/fr-par-1/0b2e1b88-152b-43d2-980b-40f8d38acf79","public_ip_v4":"51.15.204.118","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:04.868347Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "626"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:39:46 GMT
+      - Tue, 07 Nov 2023 15:54:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2317,7 +2317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73fba1f8-098a-469b-9e1f-13aebe08d9f5
+      - 93684b6e-64d8-462c-b302-d7e6a0d4f425
     status: 200 OK
     code: 200
     duration: ""
@@ -2328,19 +2328,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/adb8e568-6480-4b18-8b5c-3657e59e7a65
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-07T15:49:50.750080Z","dhcp_enabled":true,"id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","name":"test-pool-wait","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.750080Z","id":"0ba95cf8-45ba-4034-a2d0-045b3eb427fa","subnet":"172.16.60.0/22","updated_at":"2023-11-07T15:49:50.750080Z"},{"created_at":"2023-11-07T15:49:50.750080Z","id":"118694f9-3fe6-4789-b1fd-522e5b081392","subnet":"fd5f:519c:6d46:6cdc::/64","updated_at":"2023-11-07T15:49:50.750080Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.750080Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "626"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:39:51 GMT
+      - Tue, 07 Nov 2023 15:54:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2350,7 +2350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5400ffc4-daa0-4234-b72f-ec48cd87d531
+      - ca6d1c3d-26cf-4e75-b560-d75b4e1b173e
     status: 200 OK
     code: 200
     duration: ""
@@ -2361,19 +2361,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "626"
+      - "1449"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:39:57 GMT
+      - Tue, 07 Nov 2023 15:54:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2383,7 +2383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af42df51-5a0e-4ed0-acc6-fa8b431a8398
+      - 5db6a193-c5e9-40e1-baff-43db519e6aad
     status: 200 OK
     code: 200
     duration: ""
@@ -2394,19 +2394,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6TTJDbnBhVlU4eWRWVlpkMVIxYTB4QlEzRnhZMWhsYmxaTWNtaHVOMEozV0ZreGNFcHNiRVJhVFRCbFIyeERhMlZRTUhaMVRFbEJWbmhDYlhkRWEySk9VRm9LUldaMWFHZGlZbXgyZGtkUmIyZHRjVzk2UVZGTU9HNVNVRk5wYVZGblEwNHdRM2t6VjJ4Q05sUTRhV3RRT0hkV1JtdG5ZV2h6VjJoTldISnJSWEpyZFFvclJVUlNPR2h2TVhSSFJTOUdZemxQV1VKc1lYQXJSMDQyTTJGMU4wVlVZVFkzVkhGdVJVUnhhakZ1VlM5blpuTkhSMHMxTTFsSlEyaDNNbGxuVWtOMkNrSjVWSGxZSzJkS01FazBhMGgyYVRGR1F6QmFNME54UjNkblJHeFBibmQzWmt0NVJEbElkMGhETkZkTWMyWmxTVkJDVkZaS2JVMUhjbnA2ZUhkaVZUQUtkVVZOVHpoNkt6aFpWRzU1WW5Rek9FcE1hMEozWkdORk9UVnFiREZFWnpZM2IwbGlPRzVPWmt0ME4xWlpWa1YwVW5GWlZXcFZLM1VyWVhkUFVtVXhLd3A2ZW5wV1ZETnllWG80V2xoUFlYVXJPVU00UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIWVhKaGRqTlNSbTV2VURKRldXbGFWVTlGWkVKTFJrVjZia1pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCUjJ4dmIydFJUVE5rV1V4RE5tNHJhRUpaYjBoS1pEVkZOVlZyUzJkVEt6WktRMUJ4TW14aVozWmFOR2xxUVRWMGRncG5VWFpNYVUxclFqaGpaR3hvYW1wWUwwTlNNbTFPWkhKTmNFUjBjRlpqVmxoV1kwTnpWM0F2ZHk5blFtTk9kbnA1ZUROaVkybFJkVEp3V25kWFpTdDRDbXBhVDNCYVMzbEpObmhOUnpKdGEzRndNSGhVSzI5TFFpODJNblpVTjJGVGNHZzNWemc1TWpjeVQzaERSR2haUkd0U1RrTkJZMFkyV1dJNVZGTjBWamtLV0RkMVFXZHJNRE16VWpNd1NYUXJiSGhoVlRsalRIaEpWMHh1VGxGTVYwdzJMM3BTVERkcWMyYzJiR1pvUkZvNWVqSXpkRkZ3WlZGVWVtZDZSa1phYmdwek4xaFdlalIwT1RaRk1rSnFPRzh5VG5KcFMwZHZhbXcxTUZkRk5sVjFUM2xvUm5CTGNtMHhSMmxRU205blNqVXZhMUpqU2xoTmNWRllORUZWYWxjM0NrSjZVbU5WUW1Od1dsRllialJRVEV0alYzSmxSakZzUm1GTVMyeE5lVkpCVW5KWVVBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xNTAzZTYyOS04ZGJhLTRlOTktODk2MC1lNmY4MDhmNmM4MTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBQemZ3Um9Qc2V0aDA2MEdnOXpOcnYyT1E4OG5zVlF6Sm9TNDdTY3RtVVlxVkl4YTFuZEFXQ3NMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "626"
+      - "2604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:40:02 GMT
+      - Tue, 07 Nov 2023 15:54:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2416,7 +2416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6bb8315-1f50-4c31-ad14-480431fe2670
+      - 5d38076a-8bad-4a74-adee-030bff5e475f
     status: 200 OK
     code: 200
     duration: ""
@@ -2427,19 +2427,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:04.880743Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "601"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:40:07 GMT
+      - Tue, 07 Nov 2023 15:54:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2449,7 +2449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31fc83da-44db-4df0-9c0f-db1e7aeb283a
+      - 9030a5e3-8498-4c6b-89e9-d534e22bbaf5
     status: 200 OK
     code: 200
     duration: ""
@@ -2460,19 +2460,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=183e6c65-4884-4dd9-8252-5d4e66a2172f&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:46.900209Z","error_message":null,"id":"fce7c559-26ef-4f5d-9d15-b3eb6fb9a512","name":"scw-test-pool-wait-test-pool-wait-fce7c55926ef","pool_id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","provider_id":"scaleway://instance/fr-par-1/0b2e1b88-152b-43d2-980b-40f8d38acf79","public_ip_v4":"51.15.204.118","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:54:04.868347Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "626"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:40:12 GMT
+      - Tue, 07 Nov 2023 15:54:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2482,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 304051ac-21c1-4f37-8ce3-4a4a83cb369c
+      - 1bb75f4d-55e4-4e3d-8e49-074d36f5e62c
     status: 200 OK
     code: 200
     duration: ""
@@ -2493,19 +2493,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "626"
+      - "1449"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:40:17 GMT
+      - Tue, 07 Nov 2023 15:54:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2515,936 +2515,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f525486-7b72-4a2a-a5ca-07500cae5096
+      - 6c5b8163-fc9d-4f59-878a-2f9b2714ac3a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:40:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 832fcd17-0029-4f3b-a8a8-26fc123e0a92
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:40:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d2db45be-1f15-44ed-9016-2cb066bfb675
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:40:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 25c7cd3e-9cf3-4eba-9f02-d3e5de6fd9f4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:40:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 85850b83-8b3a-4b5c-b14c-166c7cd7e6f9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:40:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b79d9fe3-e055-4dda-807d-ad24dda2f76b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:40:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ea8e74b2-2240-45bf-b65a-77bbe60e5d65
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:40:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e4a6b870-9243-426c-8d82-469ab6c0200c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:40:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 95ebb1e6-c437-464e-abcd-763fc4136655
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:41:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 488ed35d-46e3-424f-b4ff-32710ea1dfbb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:41:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7e177e0a-c7fe-46fb-90d0-9b7fb5df30b9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:34:48.399877Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:41:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a153f07e-ecdd-490e-b869-722ea0e26ed1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:41:12.895030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "624"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:41:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f5e4c6a0-8e88-4409-a471-562792b9ada5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900976Z","created_at":"2023-10-19T16:34:42.900976Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:36:09.161891Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1494"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:41:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ae340d92-43ca-430a-bc92-51cf4f751421
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:41:12.895030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "624"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:41:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b574cab1-fc14-4263-b211-02c698aae32c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/nodes?order_by=created_at_asc&page=1&pool_id=34a36b69-f6e4-4279-8f74-c49a6213083c&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:36:27.777812Z","error_message":null,"id":"b0a9dc5d-be0e-41bf-b5ce-e13680526495","name":"scw-test-pool-wait-test-pool-wait-b0a9dc5dbe0e","pool_id":"34a36b69-f6e4-4279-8f74-c49a6213083c","provider_id":"scaleway://instance/fr-par-1/456dcdc2-0d49-445e-ba9c-5a4039a43c73","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:41:12.880621Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "659"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:41:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e8287b88-a34e-403b-b6be-179ccf435c6c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900976Z","created_at":"2023-10-19T16:34:42.900976Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:36:09.161891Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1494"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:41:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b4b515eb-4f26-4b0d-8159-66a02e484fb0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:41:12.895030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "624"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:41:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9de97d78-a10c-406a-ad42-e56bbc281a8e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/882a0149-d4f0-470c-8a36-650eb9f9c627
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-19T16:34:41.054613Z","dhcp_enabled":true,"id":"882a0149-d4f0-470c-8a36-650eb9f9c627","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-19T16:34:41.054613Z","id":"29e823e2-bb1a-4e49-b0e6-726aeafb43b6","subnet":"172.16.4.0/22","updated_at":"2023-10-19T16:34:41.054613Z"},{"created_at":"2023-10-19T16:34:41.054613Z","id":"57b44457-ecb1-48e2-86a5-5d7cf356e438","subnet":"fd63:256c:45f7:d0e7::/64","updated_at":"2023-10-19T16:34:41.054613Z"}],"tags":[],"updated_at":"2023-10-19T16:34:41.054613Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "714"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:41:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bc1ad376-36a7-4e98-9303-ba3e3f452256
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900976Z","created_at":"2023-10-19T16:34:42.900976Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:36:09.161891Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1494"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:41:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e3eda050-c747-42e9-af76-16fac5f690fb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaFBSRVV5VFhwUk1FNUdiMWhFVkUxNlRWUkJlRTlFUlRKTmVsRXdUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyWnpDa05OZEVoTlNETm9lRW96Tm0xNlJtVjBlbWhXVlRKNE5WbHhlWGhvVEZsMGVtSkRjR0ZQYUhKRGIwdzVhREpQU2xoMlpraFVUbkk1SzNka1RESjVSM2dLTmxKVEwyWmtVMmQxVm5WWGFtTmhTVkZYVkVaMWFFSlJaMWxFVERGdWVIZFVXbXRvVTBoVGR6RmhORzVIUzBzNWRpdDNObU0zYlVWaGFYWlNZWElyVUFwbmJrWlpjSEU1WkZGNmRXSXJZbGRKY1ROcE1XOVZjblpKYjNKNE5XeGhZV2cxY0VObWRHSllWMFpXTkVNMVRYQlRXa00yVTNCdldFaFdPR3gzVFRWQkNsVjNSSGRzV0c1UVQyNHdTVEJMVFV3MFpFNUtVVmxaVlU5UlEzTmFSVmsyYmpoNGVUSm1iMGwyUVZWbFYwbG5UR2xNV1V0SWJrUXZWRmg2VUhGRFIyWUtlVUk1V1ZkTWEzQnhhREZTT1hrMVRrOXNOWEYwUlVSSk9GRkZNMDlyWm10cEswbFJSVVZCU0VablVYUkVRbGRUTDJ4QlkydFNkVmd2Yms5WFJsVndiQXB4WW1RMEx6QjBZbWRZVEU1TVdYQTBSbEpyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGUkdKb1JXSTBiVnBJYVVGMmVIbHhUSGcyWnpaNE5YcGxUM3BOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEWkdGT2VGTnBiV05pVDNsdGQza3dUVWczV25CT05XNXZWRll6U2xKT2MxRjFhamROTURkeVEyaFdORVpuYmpSM1V3cE5UMnRxYUhkcFZVcGlLMDU2YVVoMVoxWjRjSGxLT0RCeVNVOUhWMFE0VWxCTmNGSndUMlUxWTBOalZuVlJlbEI0YXpJNVZFVnRUVmt2UWxSc1pGTlhDbUo0YTNkVmJVNDVkV1JaZUcweWNsRjRWbGxtY2toTFRrZ3lhamxJTUdkak9XMHdVbFpMVld3NFRVeHZOM3BMYVhjMGNsSnZjVUk0UVcxUFdqWkRMMElLUm1OR2RUSlJjM1JwU1VOamRqazBVME5YVmpGdGMwSTFUVFF4YVhSdGFFdHJZVVp4VEd0M1IzbG5SemxLSzJZeldEaGFVVEJHUW1oVGVqQTVkak5KY3dwck4yWnVhRlpQUkRaTGNHdHVWa1kyZW1wNldGWk5VbTgxUW5wUk55OVpNVXREVVdsdWNVRkJlU3RFUjB4RFl6TkdkV28xWm5WcE5HaDNkRlZSVW1VekNqaHJhV29yUkN0bWJVeDRiMDUyYUU4M1dFd3JUMDVPYTI5UFFpODJRVmx4T0VWYVRRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly83MGRlMDY0Yi1kZDZkLTQxZDEtYjk5Ny03MDVlMTE1NmRiZjEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBGZ1VqUGRuem5pWE1GajFHN0V3MzdtZXdqY0pyNTZqS0EyVTVvRm5YQ2tMaFB4a0l5Wkk3U2diSQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2606"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:41:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a44efa2f-788a-4bb2-a645-0c454ec967dd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:41:12.895030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "624"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:41:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fa0ba9aa-d1f6-48b8-8187-812a1304c192
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/nodes?order_by=created_at_asc&page=1&pool_id=34a36b69-f6e4-4279-8f74-c49a6213083c&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:36:27.777812Z","error_message":null,"id":"b0a9dc5d-be0e-41bf-b5ce-e13680526495","name":"scw-test-pool-wait-test-pool-wait-b0a9dc5dbe0e","pool_id":"34a36b69-f6e4-4279-8f74-c49a6213083c","provider_id":"scaleway://instance/fr-par-1/456dcdc2-0d49-445e-ba9c-5a4039a43c73","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:41:12.880621Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "659"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:41:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 25a16cbd-4333-43dc-b099-0a2ac7018934
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/882a0149-d4f0-470c-8a36-650eb9f9c627
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-19T16:34:41.054613Z","dhcp_enabled":true,"id":"882a0149-d4f0-470c-8a36-650eb9f9c627","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-19T16:34:41.054613Z","id":"29e823e2-bb1a-4e49-b0e6-726aeafb43b6","subnet":"172.16.4.0/22","updated_at":"2023-10-19T16:34:41.054613Z"},{"created_at":"2023-10-19T16:34:41.054613Z","id":"57b44457-ecb1-48e2-86a5-5d7cf356e438","subnet":"fd63:256c:45f7:d0e7::/64","updated_at":"2023-10-19T16:34:41.054613Z"}],"tags":[],"updated_at":"2023-10-19T16:34:41.054613Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "714"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:41:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c8eb843a-9292-4916-9b63-c4cfc37434a0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900976Z","created_at":"2023-10-19T16:34:42.900976Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:36:09.161891Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1494"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:41:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3254b51b-74e9-4412-9b2d-05ffbd6bba94
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaFBSRVV5VFhwUk1FNUdiMWhFVkUxNlRWUkJlRTlFUlRKTmVsRXdUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyWnpDa05OZEVoTlNETm9lRW96Tm0xNlJtVjBlbWhXVlRKNE5WbHhlWGhvVEZsMGVtSkRjR0ZQYUhKRGIwdzVhREpQU2xoMlpraFVUbkk1SzNka1RESjVSM2dLTmxKVEwyWmtVMmQxVm5WWGFtTmhTVkZYVkVaMWFFSlJaMWxFVERGdWVIZFVXbXRvVTBoVGR6RmhORzVIUzBzNWRpdDNObU0zYlVWaGFYWlNZWElyVUFwbmJrWlpjSEU1WkZGNmRXSXJZbGRKY1ROcE1XOVZjblpKYjNKNE5XeGhZV2cxY0VObWRHSllWMFpXTkVNMVRYQlRXa00yVTNCdldFaFdPR3gzVFRWQkNsVjNSSGRzV0c1UVQyNHdTVEJMVFV3MFpFNUtVVmxaVlU5UlEzTmFSVmsyYmpoNGVUSm1iMGwyUVZWbFYwbG5UR2xNV1V0SWJrUXZWRmg2VUhGRFIyWUtlVUk1V1ZkTWEzQnhhREZTT1hrMVRrOXNOWEYwUlVSSk9GRkZNMDlyWm10cEswbFJSVVZCU0VablVYUkVRbGRUTDJ4QlkydFNkVmd2Yms5WFJsVndiQXB4WW1RMEx6QjBZbWRZVEU1TVdYQTBSbEpyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGUkdKb1JXSTBiVnBJYVVGMmVIbHhUSGcyWnpaNE5YcGxUM3BOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEWkdGT2VGTnBiV05pVDNsdGQza3dUVWczV25CT05XNXZWRll6U2xKT2MxRjFhamROTURkeVEyaFdORVpuYmpSM1V3cE5UMnRxYUhkcFZVcGlLMDU2YVVoMVoxWjRjSGxLT0RCeVNVOUhWMFE0VWxCTmNGSndUMlUxWTBOalZuVlJlbEI0YXpJNVZFVnRUVmt2UWxSc1pGTlhDbUo0YTNkVmJVNDVkV1JaZUcweWNsRjRWbGxtY2toTFRrZ3lhamxJTUdkak9XMHdVbFpMVld3NFRVeHZOM3BMYVhjMGNsSnZjVUk0UVcxUFdqWkRMMElLUm1OR2RUSlJjM1JwU1VOamRqazBVME5YVmpGdGMwSTFUVFF4YVhSdGFFdHJZVVp4VEd0M1IzbG5SemxLSzJZeldEaGFVVEJHUW1oVGVqQTVkak5KY3dwck4yWnVhRlpQUkRaTGNHdHVWa1kyZW1wNldGWk5VbTgxUW5wUk55OVpNVXREVVdsdWNVRkJlU3RFUjB4RFl6TkdkV28xWm5WcE5HaDNkRlZSVW1VekNqaHJhV29yUkN0bWJVeDRiMDUyYUU4M1dFd3JUMDVPYTI5UFFpODJRVmx4T0VWYVRRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly83MGRlMDY0Yi1kZDZkLTQxZDEtYjk5Ny03MDVlMTE1NmRiZjEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBGZ1VqUGRuem5pWE1GajFHN0V3MzdtZXdqY0pyNTZqS0EyVTVvRm5YQ2tMaFB4a0l5Wkk3U2diSQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2606"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:41:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a4b2c699-fcba-4ef5-ac77-b3a9f5f9bde1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:41:12.895030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "624"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:41:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b17425e9-9464-4549-991a-6f0e2272882e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/nodes?order_by=created_at_asc&page=1&pool_id=34a36b69-f6e4-4279-8f74-c49a6213083c&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:36:27.777812Z","error_message":null,"id":"b0a9dc5d-be0e-41bf-b5ce-e13680526495","name":"scw-test-pool-wait-test-pool-wait-b0a9dc5dbe0e","pool_id":"34a36b69-f6e4-4279-8f74-c49a6213083c","provider_id":"scaleway://instance/fr-par-1/456dcdc2-0d49-445e-ba9c-5a4039a43c73","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:41:12.880621Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "659"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:41:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 55bf322b-4d91-4b9e-9a09-e66442e3f829
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900976Z","created_at":"2023-10-19T16:34:42.900976Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:36:09.161891Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1494"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:41:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - add4de13-9718-4e51-92da-a2a1018505bf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"upgrade_policy":null,"zone":"fr-par-1","root_volume_type":"default_volume_type","root_volume_size":null,"public_ip_disabled":false}'
+    body: '{"name":"test-pool-wait-2","node_type":"gp1_xs","autoscaling":false,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":false,"tags":null,"kubelet_args":{},"zone":"fr-par-1","root_volume_type":"default_volume_type","public_ip_disabled":false}'
     form: {}
     headers:
       Content-Type:
@@ -3452,19 +2528,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/pools
     method: POST
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095406Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130860643Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "631"
+      - "608"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:41:20 GMT
+      - Tue, 07 Nov 2023 15:54:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3474,7 +2550,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa63f33b-3f95-456a-b29d-818b7733c536
+      - 822d6b1a-3420-40a0-a1ad-5ef7e3a33bb9
     status: 200 OK
     code: 200
     duration: ""
@@ -3485,19 +2561,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:41:20 GMT
+      - Tue, 07 Nov 2023 15:54:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3507,7 +2583,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a892360c-1d77-4b0b-ab1b-13a7e9f7f993
+      - 467cd6bd-cdaf-441e-8a46-8000ac29203d
     status: 200 OK
     code: 200
     duration: ""
@@ -3518,19 +2594,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:41:25 GMT
+      - Tue, 07 Nov 2023 15:54:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3540,7 +2616,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86d9bac6-24bb-4af1-81a4-ed4ef337ed00
+      - 5c3becb3-2130-400c-9d70-93f73f67e9c7
     status: 200 OK
     code: 200
     duration: ""
@@ -3551,19 +2627,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:41:30 GMT
+      - Tue, 07 Nov 2023 15:54:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3573,7 +2649,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ff4f55e-f020-481e-903a-ba1bc0d980ae
+      - d988b97e-dd19-454d-8f0f-84c7c4f3098e
     status: 200 OK
     code: 200
     duration: ""
@@ -3584,19 +2660,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:41:35 GMT
+      - Tue, 07 Nov 2023 15:54:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3606,7 +2682,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3c44ff4-3a97-4f81-972c-2478fb861d44
+      - a1e8fcc8-6aad-42d0-a20d-a4d673d89da1
     status: 200 OK
     code: 200
     duration: ""
@@ -3617,19 +2693,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:41:40 GMT
+      - Tue, 07 Nov 2023 15:54:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3639,7 +2715,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12ad30ce-53bf-4145-8ae2-1ceaa5ca049f
+      - 6be19537-3198-433d-9c50-92cd2f50ae9a
     status: 200 OK
     code: 200
     duration: ""
@@ -3650,19 +2726,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:41:45 GMT
+      - Tue, 07 Nov 2023 15:54:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3672,7 +2748,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 922536dd-5acb-4d79-acd9-3c83da20d89f
+      - f8294d09-e65b-45b6-93f2-ec3a628ea83a
     status: 200 OK
     code: 200
     duration: ""
@@ -3683,19 +2759,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:41:51 GMT
+      - Tue, 07 Nov 2023 15:54:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3705,7 +2781,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc7efd92-bdb6-452e-97f8-db5742826f5e
+      - a4af5647-d449-46ac-941c-48fdcc99ffa4
     status: 200 OK
     code: 200
     duration: ""
@@ -3716,19 +2792,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:41:56 GMT
+      - Tue, 07 Nov 2023 15:54:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3738,7 +2814,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ad96a3f-47b6-4763-9a46-fca2147537dc
+      - 0b04d5d0-d2c0-467d-aac2-2474b890b78c
     status: 200 OK
     code: 200
     duration: ""
@@ -3749,19 +2825,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:42:01 GMT
+      - Tue, 07 Nov 2023 15:54:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3771,7 +2847,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1264768b-87ca-4503-8620-b9b48ef27e32
+      - dd0d3fdc-03a8-4691-8193-2ab495fbdd92
     status: 200 OK
     code: 200
     duration: ""
@@ -3782,19 +2858,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:42:06 GMT
+      - Tue, 07 Nov 2023 15:54:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3804,7 +2880,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9998e53-7213-4e0c-b6eb-5d9282dba458
+      - 82424cd4-5bd0-4785-a390-1dbad4eb7714
     status: 200 OK
     code: 200
     duration: ""
@@ -3815,19 +2891,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:42:11 GMT
+      - Tue, 07 Nov 2023 15:55:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3837,7 +2913,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d57b4938-cb7f-4bbc-bfce-88ca650918e1
+      - 5a08ff07-479e-48b1-8350-12eee8ee05a3
     status: 200 OK
     code: 200
     duration: ""
@@ -3848,19 +2924,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:42:16 GMT
+      - Tue, 07 Nov 2023 15:55:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3870,7 +2946,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 136d1356-5a6a-4c60-b8c7-5f1d776defb3
+      - aa084ab7-494c-4248-8f9a-abe04549c6e3
     status: 200 OK
     code: 200
     duration: ""
@@ -3881,19 +2957,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:42:21 GMT
+      - Tue, 07 Nov 2023 15:55:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3903,7 +2979,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4177e9ac-e98d-4f0f-8f4c-dd78a43946ef
+      - 69b8d107-9445-482b-999c-da8f7b0c7d34
     status: 200 OK
     code: 200
     duration: ""
@@ -3914,19 +2990,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:42:26 GMT
+      - Tue, 07 Nov 2023 15:55:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3936,7 +3012,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72e59998-97bc-446e-b246-8b62a364d52d
+      - ec3bd6f3-5571-4281-b06d-b7ae94deb480
     status: 200 OK
     code: 200
     duration: ""
@@ -3947,19 +3023,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:42:31 GMT
+      - Tue, 07 Nov 2023 15:55:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3969,7 +3045,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22219061-9fb0-4001-8b19-35802b414bd7
+      - e7bc1c5b-458b-4eb8-99d6-a6eb4edcc456
     status: 200 OK
     code: 200
     duration: ""
@@ -3980,19 +3056,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:42:36 GMT
+      - Tue, 07 Nov 2023 15:55:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4002,7 +3078,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b3d04b2-5208-4d4d-95cf-1652a154e977
+      - 5629aaa4-6363-449b-bfcc-1d5974afd3bf
     status: 200 OK
     code: 200
     duration: ""
@@ -4013,19 +3089,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:42:41 GMT
+      - Tue, 07 Nov 2023 15:55:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4035,7 +3111,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 960c846f-29f4-4242-b83d-f3d24970e079
+      - 165e1cd9-f88d-4859-98df-333bcbb61230
     status: 200 OK
     code: 200
     duration: ""
@@ -4046,19 +3122,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:42:46 GMT
+      - Tue, 07 Nov 2023 15:55:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4068,7 +3144,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84a03986-435d-46e0-8b8c-574d69df7e04
+      - c1611fbb-1f9a-4e54-87d1-02110ee952d6
     status: 200 OK
     code: 200
     duration: ""
@@ -4079,19 +3155,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:42:51 GMT
+      - Tue, 07 Nov 2023 15:55:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4101,7 +3177,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22c218d0-a530-49e2-a84c-e919db79976d
+      - 91f9d93a-a7de-4262-95ba-b1e318c1f6fb
     status: 200 OK
     code: 200
     duration: ""
@@ -4112,19 +3188,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:42:56 GMT
+      - Tue, 07 Nov 2023 15:55:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4134,7 +3210,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95f0d30d-4852-468e-a0cb-b6e4810c2fd8
+      - 1da6d508-2902-4c9b-b83a-e36534f00719
     status: 200 OK
     code: 200
     duration: ""
@@ -4145,19 +3221,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:01 GMT
+      - Tue, 07 Nov 2023 15:55:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4167,7 +3243,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79041529-99e9-40af-841e-da0a6d83ecc9
+      - de865b64-7258-47c6-8fa0-3dbb990ae890
     status: 200 OK
     code: 200
     duration: ""
@@ -4178,19 +3254,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:06 GMT
+      - Tue, 07 Nov 2023 15:55:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4200,7 +3276,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 294ec510-4ba2-4795-b6a8-0838a1e7a84e
+      - bf92e297-12c8-49af-b421-06912464cae1
     status: 200 OK
     code: 200
     duration: ""
@@ -4211,19 +3287,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:11 GMT
+      - Tue, 07 Nov 2023 15:56:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4233,7 +3309,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fbc9d623-ced5-4e63-8611-52d4258f399e
+      - 20f910b1-ae70-4a59-ba76-45acfd2fc97c
     status: 200 OK
     code: 200
     duration: ""
@@ -4244,19 +3320,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:17 GMT
+      - Tue, 07 Nov 2023 15:56:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4266,7 +3342,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a8fd688-5b80-4420-acc5-294318651ae1
+      - ab7bdd82-bff8-4a52-9ca8-9a28d76a0827
     status: 200 OK
     code: 200
     duration: ""
@@ -4277,19 +3353,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:22 GMT
+      - Tue, 07 Nov 2023 15:56:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4299,7 +3375,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e52f1f28-2868-4a90-b4f3-1b630a1f6385
+      - 860d836a-7942-4d82-89f3-b4dd0cdfb500
     status: 200 OK
     code: 200
     duration: ""
@@ -4310,19 +3386,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:27 GMT
+      - Tue, 07 Nov 2023 15:56:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4332,7 +3408,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0888e736-aff6-4a8e-825f-135614a555d0
+      - f3b9bf3d-da77-4add-8636-15bba7044eea
     status: 200 OK
     code: 200
     duration: ""
@@ -4343,19 +3419,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:32 GMT
+      - Tue, 07 Nov 2023 15:56:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4365,7 +3441,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f1dc25ad-3662-4324-a382-230c6529a5d5
+      - 71cabedd-b691-4e14-abb6-73453bf9a932
     status: 200 OK
     code: 200
     duration: ""
@@ -4376,19 +3452,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:37 GMT
+      - Tue, 07 Nov 2023 15:56:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4398,7 +3474,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 357f2184-0e7d-4a83-954a-132a92165667
+      - 58af6cd3-2467-4836-aa36-37d5c44b852e
     status: 200 OK
     code: 200
     duration: ""
@@ -4409,19 +3485,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:42 GMT
+      - Tue, 07 Nov 2023 15:56:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4431,7 +3507,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97d9b9a9-8220-403a-b615-ace19e5609bf
+      - afb9d038-057a-4337-9d9d-7276e7f66e49
     status: 200 OK
     code: 200
     duration: ""
@@ -4442,19 +3518,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:47 GMT
+      - Tue, 07 Nov 2023 15:56:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4464,7 +3540,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 999c2803-d580-48c3-85fd-6db2c792644d
+      - ef73ab6c-8d38-43a6-9d6f-71caa16c4c65
     status: 200 OK
     code: 200
     duration: ""
@@ -4475,19 +3551,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:52 GMT
+      - Tue, 07 Nov 2023 15:56:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4497,7 +3573,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2525330d-a6de-462f-8e31-f49d26a2708b
+      - a3b86d5f-a08c-46dc-92d9-9b898e496a48
     status: 200 OK
     code: 200
     duration: ""
@@ -4508,19 +3584,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:43:57 GMT
+      - Tue, 07 Nov 2023 15:56:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4530,7 +3606,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1df5b574-c65b-4b77-bf3c-d7ad945acc98
+      - a0fc3b81-fd35-492c-9d66-209f341a0c2d
     status: 200 OK
     code: 200
     duration: ""
@@ -4541,19 +3617,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:54:10.130861Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:02 GMT
+      - Tue, 07 Nov 2023 15:56:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4563,7 +3639,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb78c502-c019-49dd-81a7-b47fa42e3e72
+      - 5a8c6eb4-ba97-4f96-b0b5-2a354ae60cb8
     status: 200 OK
     code: 200
     duration: ""
@@ -4574,19 +3650,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:56:54.878199Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:07 GMT
+      - Tue, 07 Nov 2023 15:56:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4596,7 +3672,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3af131ec-821a-4b50-81c7-02ba885e3954
+      - baed0024-a3f2-476e-9b54-16556823a719
     status: 200 OK
     code: 200
     duration: ""
@@ -4607,19 +3683,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:56:54.878199Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:12 GMT
+      - Tue, 07 Nov 2023 15:56:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4629,7 +3705,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 469557e0-bbe0-4eb2-ace2-3213c55808b2
+      - 3292e9d5-4625-4244-a0b5-65be636f4ac4
     status: 200 OK
     code: 200
     duration: ""
@@ -4640,19 +3716,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=f1ca093a-20e5-4b4c-a4f9-d813489a65f2&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:54:10.603081Z","error_message":null,"id":"9ff54354-1ce7-4896-9313-5142f745c072","name":"scw-test-pool-wait-test-pool-wait-2-9ff543541c","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/09c29c57-d383-4480-be2c-6ca76739d4ef","public_ip_v4":"51.158.103.0","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:56:54.863718Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "628"
+      - "640"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:17 GMT
+      - Tue, 07 Nov 2023 15:56:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4662,7 +3738,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc11ee13-1ed1-403c-9c22-58e6c962352d
+      - a7f1dfcd-e7d0-442a-a6ce-bd8536f6c5ab
     status: 200 OK
     code: 200
     duration: ""
@@ -4673,19 +3749,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "628"
+      - "1449"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:22 GMT
+      - Tue, 07 Nov 2023 15:56:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4695,7 +3771,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1618e40-4e2b-4af8-b226-1376452b567a
+      - 3b1054b7-403e-4a39-8652-b96d454ffc87
     status: 200 OK
     code: 200
     duration: ""
@@ -4706,19 +3782,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:56:54.878199Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:27 GMT
+      - Tue, 07 Nov 2023 15:56:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4728,7 +3804,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - efe0a924-54c5-435b-b72f-569a12b265e1
+      - 7a6635a7-0319-4619-a8bb-6d129da4fe78
     status: 200 OK
     code: 200
     duration: ""
@@ -4739,19 +3815,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/adb8e568-6480-4b18-8b5c-3657e59e7a65
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-07T15:49:50.750080Z","dhcp_enabled":true,"id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","name":"test-pool-wait","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.750080Z","id":"0ba95cf8-45ba-4034-a2d0-045b3eb427fa","subnet":"172.16.60.0/22","updated_at":"2023-11-07T15:49:50.750080Z"},{"created_at":"2023-11-07T15:49:50.750080Z","id":"118694f9-3fe6-4789-b1fd-522e5b081392","subnet":"fd5f:519c:6d46:6cdc::/64","updated_at":"2023-11-07T15:49:50.750080Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.750080Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "628"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:32 GMT
+      - Tue, 07 Nov 2023 15:56:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4761,7 +3837,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4137b61-5f8c-47fe-ad75-2532fa466821
+      - f66eed45-7c3d-4bbc-8792-a36e97a423da
     status: 200 OK
     code: 200
     duration: ""
@@ -4772,19 +3848,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "628"
+      - "1449"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:37 GMT
+      - Tue, 07 Nov 2023 15:56:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4794,7 +3870,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87a83907-3bd2-4adc-80c5-1a39ea78c9a1
+      - 32d8f530-d9c1-46a8-a1ed-f72849225264
     status: 200 OK
     code: 200
     duration: ""
@@ -4805,19 +3881,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6TTJDbnBhVlU4eWRWVlpkMVIxYTB4QlEzRnhZMWhsYmxaTWNtaHVOMEozV0ZreGNFcHNiRVJhVFRCbFIyeERhMlZRTUhaMVRFbEJWbmhDYlhkRWEySk9VRm9LUldaMWFHZGlZbXgyZGtkUmIyZHRjVzk2UVZGTU9HNVNVRk5wYVZGblEwNHdRM2t6VjJ4Q05sUTRhV3RRT0hkV1JtdG5ZV2h6VjJoTldISnJSWEpyZFFvclJVUlNPR2h2TVhSSFJTOUdZemxQV1VKc1lYQXJSMDQyTTJGMU4wVlVZVFkzVkhGdVJVUnhhakZ1VlM5blpuTkhSMHMxTTFsSlEyaDNNbGxuVWtOMkNrSjVWSGxZSzJkS01FazBhMGgyYVRGR1F6QmFNME54UjNkblJHeFBibmQzWmt0NVJEbElkMGhETkZkTWMyWmxTVkJDVkZaS2JVMUhjbnA2ZUhkaVZUQUtkVVZOVHpoNkt6aFpWRzU1WW5Rek9FcE1hMEozWkdORk9UVnFiREZFWnpZM2IwbGlPRzVPWmt0ME4xWlpWa1YwVW5GWlZXcFZLM1VyWVhkUFVtVXhLd3A2ZW5wV1ZETnllWG80V2xoUFlYVXJPVU00UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIWVhKaGRqTlNSbTV2VURKRldXbGFWVTlGWkVKTFJrVjZia1pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCUjJ4dmIydFJUVE5rV1V4RE5tNHJhRUpaYjBoS1pEVkZOVlZyUzJkVEt6WktRMUJ4TW14aVozWmFOR2xxUVRWMGRncG5VWFpNYVUxclFqaGpaR3hvYW1wWUwwTlNNbTFPWkhKTmNFUjBjRlpqVmxoV1kwTnpWM0F2ZHk5blFtTk9kbnA1ZUROaVkybFJkVEp3V25kWFpTdDRDbXBhVDNCYVMzbEpObmhOUnpKdGEzRndNSGhVSzI5TFFpODJNblpVTjJGVGNHZzNWemc1TWpjeVQzaERSR2haUkd0U1RrTkJZMFkyV1dJNVZGTjBWamtLV0RkMVFXZHJNRE16VWpNd1NYUXJiSGhoVlRsalRIaEpWMHh1VGxGTVYwdzJMM3BTVERkcWMyYzJiR1pvUkZvNWVqSXpkRkZ3WlZGVWVtZDZSa1phYmdwek4xaFdlalIwT1RaRk1rSnFPRzh5VG5KcFMwZHZhbXcxTUZkRk5sVjFUM2xvUm5CTGNtMHhSMmxRU205blNqVXZhMUpqU2xoTmNWRllORUZWYWxjM0NrSjZVbU5WUW1Od1dsRllialJRVEV0alYzSmxSakZzUm1GTVMyeE5lVkpCVW5KWVVBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xNTAzZTYyOS04ZGJhLTRlOTktODk2MC1lNmY4MDhmNmM4MTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBQemZ3Um9Qc2V0aDA2MEdnOXpOcnYyT1E4OG5zVlF6Sm9TNDdTY3RtVVlxVkl4YTFuZEFXQ3NMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "628"
+      - "2604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:42 GMT
+      - Tue, 07 Nov 2023 15:56:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4827,7 +3903,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72b94fdf-4ec4-43e9-90fd-1050b663e4c3
+      - e9035a91-14a1-4c18-93d8-4749be50e4e3
     status: 200 OK
     code: 200
     duration: ""
@@ -4838,19 +3914,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:04.880743Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "601"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:47 GMT
+      - Tue, 07 Nov 2023 15:56:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4860,7 +3936,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0839c127-7ef6-4192-9bdc-0b9cb9772af1
+      - dcdbac11-9d7a-46fa-bae5-4a07e0af6802
     status: 200 OK
     code: 200
     duration: ""
@@ -4871,19 +3947,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:56:54.878199Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:53 GMT
+      - Tue, 07 Nov 2023 15:56:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4893,7 +3969,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91db3d3f-8a91-406f-b05a-9a6e3159d3d8
+      - e590bfc5-5d58-4224-b008-0693ea650f52
     status: 200 OK
     code: 200
     duration: ""
@@ -4904,19 +3980,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=183e6c65-4884-4dd9-8252-5d4e66a2172f&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:46.900209Z","error_message":null,"id":"fce7c559-26ef-4f5d-9d15-b3eb6fb9a512","name":"scw-test-pool-wait-test-pool-wait-fce7c55926ef","pool_id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","provider_id":"scaleway://instance/fr-par-1/0b2e1b88-152b-43d2-980b-40f8d38acf79","public_ip_v4":"51.15.204.118","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:56:54.823191Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "628"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:44:58 GMT
+      - Tue, 07 Nov 2023 15:56:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4926,7 +4002,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca369d84-379f-4e36-8323-fc6b51317059
+      - 3469f668-f6e5-456d-8cc9-f3e73e53a5b3
     status: 200 OK
     code: 200
     duration: ""
@@ -4937,19 +4013,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=f1ca093a-20e5-4b4c-a4f9-d813489a65f2&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:54:10.603081Z","error_message":null,"id":"9ff54354-1ce7-4896-9313-5142f745c072","name":"scw-test-pool-wait-test-pool-wait-2-9ff543541c","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/09c29c57-d383-4480-be2c-6ca76739d4ef","public_ip_v4":"51.158.103.0","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:56:54.863718Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "628"
+      - "640"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:45:03 GMT
+      - Tue, 07 Nov 2023 15:56:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4959,7 +4035,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc85621e-1280-4e2c-8c59-9bf959f152d4
+      - 5fc2b9ec-616c-4131-96cb-7b86ce40ebb6
     status: 200 OK
     code: 200
     duration: ""
@@ -4970,19 +4046,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/adb8e568-6480-4b18-8b5c-3657e59e7a65
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-07T15:49:50.750080Z","dhcp_enabled":true,"id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","name":"test-pool-wait","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.750080Z","id":"0ba95cf8-45ba-4034-a2d0-045b3eb427fa","subnet":"172.16.60.0/22","updated_at":"2023-11-07T15:49:50.750080Z"},{"created_at":"2023-11-07T15:49:50.750080Z","id":"118694f9-3fe6-4789-b1fd-522e5b081392","subnet":"fd5f:519c:6d46:6cdc::/64","updated_at":"2023-11-07T15:49:50.750080Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.750080Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "628"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:45:08 GMT
+      - Tue, 07 Nov 2023 15:56:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4992,7 +4068,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a95413c-8b6e-4a0b-a1b3-c2b6bf6db536
+      - 1c11b455-e60e-473c-b7b2-3568f133d604
     status: 200 OK
     code: 200
     duration: ""
@@ -5003,19 +4079,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "628"
+      - "1449"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:45:13 GMT
+      - Tue, 07 Nov 2023 15:56:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5025,7 +4101,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d51864a-0870-4470-a15f-4a9a4cf93ad0
+      - f3553896-3e7a-42a6-b14e-b299f8aefe6a
     status: 200 OK
     code: 200
     duration: ""
@@ -5036,19 +4112,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6TTJDbnBhVlU4eWRWVlpkMVIxYTB4QlEzRnhZMWhsYmxaTWNtaHVOMEozV0ZreGNFcHNiRVJhVFRCbFIyeERhMlZRTUhaMVRFbEJWbmhDYlhkRWEySk9VRm9LUldaMWFHZGlZbXgyZGtkUmIyZHRjVzk2UVZGTU9HNVNVRk5wYVZGblEwNHdRM2t6VjJ4Q05sUTRhV3RRT0hkV1JtdG5ZV2h6VjJoTldISnJSWEpyZFFvclJVUlNPR2h2TVhSSFJTOUdZemxQV1VKc1lYQXJSMDQyTTJGMU4wVlVZVFkzVkhGdVJVUnhhakZ1VlM5blpuTkhSMHMxTTFsSlEyaDNNbGxuVWtOMkNrSjVWSGxZSzJkS01FazBhMGgyYVRGR1F6QmFNME54UjNkblJHeFBibmQzWmt0NVJEbElkMGhETkZkTWMyWmxTVkJDVkZaS2JVMUhjbnA2ZUhkaVZUQUtkVVZOVHpoNkt6aFpWRzU1WW5Rek9FcE1hMEozWkdORk9UVnFiREZFWnpZM2IwbGlPRzVPWmt0ME4xWlpWa1YwVW5GWlZXcFZLM1VyWVhkUFVtVXhLd3A2ZW5wV1ZETnllWG80V2xoUFlYVXJPVU00UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIWVhKaGRqTlNSbTV2VURKRldXbGFWVTlGWkVKTFJrVjZia1pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCUjJ4dmIydFJUVE5rV1V4RE5tNHJhRUpaYjBoS1pEVkZOVlZyUzJkVEt6WktRMUJ4TW14aVozWmFOR2xxUVRWMGRncG5VWFpNYVUxclFqaGpaR3hvYW1wWUwwTlNNbTFPWkhKTmNFUjBjRlpqVmxoV1kwTnpWM0F2ZHk5blFtTk9kbnA1ZUROaVkybFJkVEp3V25kWFpTdDRDbXBhVDNCYVMzbEpObmhOUnpKdGEzRndNSGhVSzI5TFFpODJNblpVTjJGVGNHZzNWemc1TWpjeVQzaERSR2haUkd0U1RrTkJZMFkyV1dJNVZGTjBWamtLV0RkMVFXZHJNRE16VWpNd1NYUXJiSGhoVlRsalRIaEpWMHh1VGxGTVYwdzJMM3BTVERkcWMyYzJiR1pvUkZvNWVqSXpkRkZ3WlZGVWVtZDZSa1phYmdwek4xaFdlalIwT1RaRk1rSnFPRzh5VG5KcFMwZHZhbXcxTUZkRk5sVjFUM2xvUm5CTGNtMHhSMmxRU205blNqVXZhMUpqU2xoTmNWRllORUZWYWxjM0NrSjZVbU5WUW1Od1dsRllialJRVEV0alYzSmxSakZzUm1GTVMyeE5lVkpCVW5KWVVBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xNTAzZTYyOS04ZGJhLTRlOTktODk2MC1lNmY4MDhmNmM4MTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBQemZ3Um9Qc2V0aDA2MEdnOXpOcnYyT1E4OG5zVlF6Sm9TNDdTY3RtVVlxVkl4YTFuZEFXQ3NMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "628"
+      - "2604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:45:18 GMT
+      - Tue, 07 Nov 2023 15:56:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5058,7 +4134,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 721066cd-54db-4597-b730-ea364338bd59
+      - df7af52e-f3c8-401c-a78b-dd5f50880956
     status: 200 OK
     code: 200
     duration: ""
@@ -5069,19 +4145,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:04.880743Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "601"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:45:23 GMT
+      - Tue, 07 Nov 2023 15:56:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5091,7 +4167,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d9158e9-342c-48f6-88d3-4529a4157a8b
+      - c5fe7137-1b54-4458-94f1-c2dd01834ab9
     status: 200 OK
     code: 200
     duration: ""
@@ -5102,19 +4178,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:56:54.878199Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:45:28 GMT
+      - Tue, 07 Nov 2023 15:56:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5124,7 +4200,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 313f5496-5cc3-44f2-8039-23fbbb4c6b22
+      - 97c99332-b186-4414-a248-1571c5f5d0f5
     status: 200 OK
     code: 200
     duration: ""
@@ -5135,19 +4211,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=f1ca093a-20e5-4b4c-a4f9-d813489a65f2&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:54:10.603081Z","error_message":null,"id":"9ff54354-1ce7-4896-9313-5142f745c072","name":"scw-test-pool-wait-test-pool-wait-2-9ff543541c","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/09c29c57-d383-4480-be2c-6ca76739d4ef","public_ip_v4":"51.158.103.0","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:56:54.863718Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "628"
+      - "640"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:45:33 GMT
+      - Tue, 07 Nov 2023 15:56:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5157,7 +4233,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb1ba5f9-f3b6-4fd4-afd4-2f4e28a0e9d7
+      - dabe6dd9-2e92-4b93-bbff-cc095e258acb
     status: 200 OK
     code: 200
     duration: ""
@@ -5168,19 +4244,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=183e6c65-4884-4dd9-8252-5d4e66a2172f&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:46.900209Z","error_message":null,"id":"fce7c559-26ef-4f5d-9d15-b3eb6fb9a512","name":"scw-test-pool-wait-test-pool-wait-fce7c55926ef","pool_id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","provider_id":"scaleway://instance/fr-par-1/0b2e1b88-152b-43d2-980b-40f8d38acf79","public_ip_v4":"51.15.204.118","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:56:54.823191Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "628"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:45:38 GMT
+      - Tue, 07 Nov 2023 15:56:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5190,870 +4266,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dbd812b0-94b3-4b92-86da-e5f4c98ff8be
+      - caba84ba-563c-44c5-954c-9e65e347bfc5
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "628"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:45:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 16209cd0-5b53-48c0-afd1-764d4dd2e1fd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "628"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:45:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b4ccbfa0-a9a9-4454-a24d-5a342e39cc2a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "628"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:45:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 15d828b2-49df-40fb-a3f0-88be6286f30b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "628"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:45:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 726c21a8-478f-4750-b664-ebbee4f4326b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "628"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:46:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c4e5b6de-1c91-4353-a040-c378e5799170
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "628"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:46:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ca6ca55a-5d2e-45a7-9ef7-f6486712ecf1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:41:20.407095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "628"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:46:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 04e8fcad-7af9-49d5-b484-d1f1831ccf1a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:46:18.624156Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:46:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4da2cf7d-a296-4878-9fec-9e31256d46f3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:46:18.624156Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:46:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2ddd95c2-49b1-4f0b-8c35-dc9550e739ec
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/nodes?order_by=created_at_asc&page=1&pool_id=d29afef8-724f-493c-ad4c-f3e176e9a0e6&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:41:20.856069Z","error_message":null,"id":"bec60012-8e36-409e-b48f-d00017d8d201","name":"scw-test-pool-wait-test-pool-wait-2-bec600128e","pool_id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","provider_id":"scaleway://instance/fr-par-1/ba6d3b71-abd8-497e-90d6-7041ac2e6679","public_ip_v4":"163.172.141.90","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:46:18.603661Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "659"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:46:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c6db4ae4-754c-4c63-bfb8-76f02e3250db
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900976Z","created_at":"2023-10-19T16:34:42.900976Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:36:09.161891Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1494"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:46:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7273bdcb-a32f-4002-9705-ece0ea03870c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:46:18.624156Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:46:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 857f3bec-0a38-4d4f-9af3-0cd1410fdecd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/882a0149-d4f0-470c-8a36-650eb9f9c627
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-19T16:34:41.054613Z","dhcp_enabled":true,"id":"882a0149-d4f0-470c-8a36-650eb9f9c627","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-19T16:34:41.054613Z","id":"29e823e2-bb1a-4e49-b0e6-726aeafb43b6","subnet":"172.16.4.0/22","updated_at":"2023-10-19T16:34:41.054613Z"},{"created_at":"2023-10-19T16:34:41.054613Z","id":"57b44457-ecb1-48e2-86a5-5d7cf356e438","subnet":"fd63:256c:45f7:d0e7::/64","updated_at":"2023-10-19T16:34:41.054613Z"}],"tags":[],"updated_at":"2023-10-19T16:34:41.054613Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "714"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:46:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c96f56b0-cc54-480c-80bf-5aca4bc0cb9b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900976Z","created_at":"2023-10-19T16:34:42.900976Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:36:09.161891Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1494"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:46:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8d239456-9ab3-4fef-bb06-117fac1b02da
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaFBSRVV5VFhwUk1FNUdiMWhFVkUxNlRWUkJlRTlFUlRKTmVsRXdUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyWnpDa05OZEVoTlNETm9lRW96Tm0xNlJtVjBlbWhXVlRKNE5WbHhlWGhvVEZsMGVtSkRjR0ZQYUhKRGIwdzVhREpQU2xoMlpraFVUbkk1SzNka1RESjVSM2dLTmxKVEwyWmtVMmQxVm5WWGFtTmhTVkZYVkVaMWFFSlJaMWxFVERGdWVIZFVXbXRvVTBoVGR6RmhORzVIUzBzNWRpdDNObU0zYlVWaGFYWlNZWElyVUFwbmJrWlpjSEU1WkZGNmRXSXJZbGRKY1ROcE1XOVZjblpKYjNKNE5XeGhZV2cxY0VObWRHSllWMFpXTkVNMVRYQlRXa00yVTNCdldFaFdPR3gzVFRWQkNsVjNSSGRzV0c1UVQyNHdTVEJMVFV3MFpFNUtVVmxaVlU5UlEzTmFSVmsyYmpoNGVUSm1iMGwyUVZWbFYwbG5UR2xNV1V0SWJrUXZWRmg2VUhGRFIyWUtlVUk1V1ZkTWEzQnhhREZTT1hrMVRrOXNOWEYwUlVSSk9GRkZNMDlyWm10cEswbFJSVVZCU0VablVYUkVRbGRUTDJ4QlkydFNkVmd2Yms5WFJsVndiQXB4WW1RMEx6QjBZbWRZVEU1TVdYQTBSbEpyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGUkdKb1JXSTBiVnBJYVVGMmVIbHhUSGcyWnpaNE5YcGxUM3BOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEWkdGT2VGTnBiV05pVDNsdGQza3dUVWczV25CT05XNXZWRll6U2xKT2MxRjFhamROTURkeVEyaFdORVpuYmpSM1V3cE5UMnRxYUhkcFZVcGlLMDU2YVVoMVoxWjRjSGxLT0RCeVNVOUhWMFE0VWxCTmNGSndUMlUxWTBOalZuVlJlbEI0YXpJNVZFVnRUVmt2UWxSc1pGTlhDbUo0YTNkVmJVNDVkV1JaZUcweWNsRjRWbGxtY2toTFRrZ3lhamxJTUdkak9XMHdVbFpMVld3NFRVeHZOM3BMYVhjMGNsSnZjVUk0UVcxUFdqWkRMMElLUm1OR2RUSlJjM1JwU1VOamRqazBVME5YVmpGdGMwSTFUVFF4YVhSdGFFdHJZVVp4VEd0M1IzbG5SemxLSzJZeldEaGFVVEJHUW1oVGVqQTVkak5KY3dwck4yWnVhRlpQUkRaTGNHdHVWa1kyZW1wNldGWk5VbTgxUW5wUk55OVpNVXREVVdsdWNVRkJlU3RFUjB4RFl6TkdkV28xWm5WcE5HaDNkRlZSVW1VekNqaHJhV29yUkN0bWJVeDRiMDUyYUU4M1dFd3JUMDVPYTI5UFFpODJRVmx4T0VWYVRRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly83MGRlMDY0Yi1kZDZkLTQxZDEtYjk5Ny03MDVlMTE1NmRiZjEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBGZ1VqUGRuem5pWE1GajFHN0V3MzdtZXdqY0pyNTZqS0EyVTVvRm5YQ2tMaFB4a0l5Wkk3U2diSQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2606"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:46:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e509783a-efc0-4458-9296-2aa64f52aa4b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:46:18.624156Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:46:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6597f07a-eabb-4610-95ad-689728198121
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:41:12.895030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "624"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:46:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ff6e5c71-f7f4-47bc-a05c-1105747fa3bb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/nodes?order_by=created_at_asc&page=1&pool_id=d29afef8-724f-493c-ad4c-f3e176e9a0e6&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:41:20.856069Z","error_message":null,"id":"bec60012-8e36-409e-b48f-d00017d8d201","name":"scw-test-pool-wait-test-pool-wait-2-bec600128e","pool_id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","provider_id":"scaleway://instance/fr-par-1/ba6d3b71-abd8-497e-90d6-7041ac2e6679","public_ip_v4":"163.172.141.90","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:46:18.603661Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "659"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:46:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - efcd3d89-e615-439c-8f0a-15e91101f42c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/nodes?order_by=created_at_asc&page=1&pool_id=34a36b69-f6e4-4279-8f74-c49a6213083c&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:36:27.777812Z","error_message":null,"id":"b0a9dc5d-be0e-41bf-b5ce-e13680526495","name":"scw-test-pool-wait-test-pool-wait-b0a9dc5dbe0e","pool_id":"34a36b69-f6e4-4279-8f74-c49a6213083c","provider_id":"scaleway://instance/fr-par-1/456dcdc2-0d49-445e-ba9c-5a4039a43c73","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:46:18.568289Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "689"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:46:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0f6cbcc1-1b74-443e-b30e-d4c2f551a7d1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/882a0149-d4f0-470c-8a36-650eb9f9c627
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-19T16:34:41.054613Z","dhcp_enabled":true,"id":"882a0149-d4f0-470c-8a36-650eb9f9c627","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-19T16:34:41.054613Z","id":"29e823e2-bb1a-4e49-b0e6-726aeafb43b6","subnet":"172.16.4.0/22","updated_at":"2023-10-19T16:34:41.054613Z"},{"created_at":"2023-10-19T16:34:41.054613Z","id":"57b44457-ecb1-48e2-86a5-5d7cf356e438","subnet":"fd63:256c:45f7:d0e7::/64","updated_at":"2023-10-19T16:34:41.054613Z"}],"tags":[],"updated_at":"2023-10-19T16:34:41.054613Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "714"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:46:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1c831b30-c43c-47b2-b4a1-b9b4a88e26dc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900976Z","created_at":"2023-10-19T16:34:42.900976Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:36:09.161891Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1494"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:46:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8e851df4-4efa-428c-92bd-2c3e2f081573
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaFBSRVV5VFhwUk1FNUdiMWhFVkUxNlRWUkJlRTlFUlRKTmVsRXdUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyWnpDa05OZEVoTlNETm9lRW96Tm0xNlJtVjBlbWhXVlRKNE5WbHhlWGhvVEZsMGVtSkRjR0ZQYUhKRGIwdzVhREpQU2xoMlpraFVUbkk1SzNka1RESjVSM2dLTmxKVEwyWmtVMmQxVm5WWGFtTmhTVkZYVkVaMWFFSlJaMWxFVERGdWVIZFVXbXRvVTBoVGR6RmhORzVIUzBzNWRpdDNObU0zYlVWaGFYWlNZWElyVUFwbmJrWlpjSEU1WkZGNmRXSXJZbGRKY1ROcE1XOVZjblpKYjNKNE5XeGhZV2cxY0VObWRHSllWMFpXTkVNMVRYQlRXa00yVTNCdldFaFdPR3gzVFRWQkNsVjNSSGRzV0c1UVQyNHdTVEJMVFV3MFpFNUtVVmxaVlU5UlEzTmFSVmsyYmpoNGVUSm1iMGwyUVZWbFYwbG5UR2xNV1V0SWJrUXZWRmg2VUhGRFIyWUtlVUk1V1ZkTWEzQnhhREZTT1hrMVRrOXNOWEYwUlVSSk9GRkZNMDlyWm10cEswbFJSVVZCU0VablVYUkVRbGRUTDJ4QlkydFNkVmd2Yms5WFJsVndiQXB4WW1RMEx6QjBZbWRZVEU1TVdYQTBSbEpyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGUkdKb1JXSTBiVnBJYVVGMmVIbHhUSGcyWnpaNE5YcGxUM3BOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEWkdGT2VGTnBiV05pVDNsdGQza3dUVWczV25CT05XNXZWRll6U2xKT2MxRjFhamROTURkeVEyaFdORVpuYmpSM1V3cE5UMnRxYUhkcFZVcGlLMDU2YVVoMVoxWjRjSGxLT0RCeVNVOUhWMFE0VWxCTmNGSndUMlUxWTBOalZuVlJlbEI0YXpJNVZFVnRUVmt2UWxSc1pGTlhDbUo0YTNkVmJVNDVkV1JaZUcweWNsRjRWbGxtY2toTFRrZ3lhamxJTUdkak9XMHdVbFpMVld3NFRVeHZOM3BMYVhjMGNsSnZjVUk0UVcxUFdqWkRMMElLUm1OR2RUSlJjM1JwU1VOamRqazBVME5YVmpGdGMwSTFUVFF4YVhSdGFFdHJZVVp4VEd0M1IzbG5SemxLSzJZeldEaGFVVEJHUW1oVGVqQTVkak5KY3dwck4yWnVhRlpQUkRaTGNHdHVWa1kyZW1wNldGWk5VbTgxUW5wUk55OVpNVXREVVdsdWNVRkJlU3RFUjB4RFl6TkdkV28xWm5WcE5HaDNkRlZSVW1VekNqaHJhV29yUkN0bWJVeDRiMDUyYUU4M1dFd3JUMDVPYTI5UFFpODJRVmx4T0VWYVRRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly83MGRlMDY0Yi1kZDZkLTQxZDEtYjk5Ny03MDVlMTE1NmRiZjEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBGZ1VqUGRuem5pWE1GajFHN0V3MzdtZXdqY0pyNTZqS0EyVTVvRm5YQ2tMaFB4a0l5Wkk3U2diSQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2606"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:46:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5d2e2a4d-ccf5-4ac9-b51f-f6affedb0ed6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:46:18.624156Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:46:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b3d52a6c-7f43-4951-b2f2-aaae5d32da40
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:41:12.895030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "624"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:46:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4fefa140-a6d8-4268-abd9-4b34c2ddcceb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/nodes?order_by=created_at_asc&page=1&pool_id=d29afef8-724f-493c-ad4c-f3e176e9a0e6&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:41:20.856069Z","error_message":null,"id":"bec60012-8e36-409e-b48f-d00017d8d201","name":"scw-test-pool-wait-test-pool-wait-2-bec600128e","pool_id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","provider_id":"scaleway://instance/fr-par-1/ba6d3b71-abd8-497e-90d6-7041ac2e6679","public_ip_v4":"163.172.141.90","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:46:18.603661Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "659"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:46:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 844b9afe-2f3a-4773-a5bf-e448245a64f4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/nodes?order_by=created_at_asc&page=1&pool_id=34a36b69-f6e4-4279-8f74-c49a6213083c&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:36:27.777812Z","error_message":null,"id":"b0a9dc5d-be0e-41bf-b5ce-e13680526495","name":"scw-test-pool-wait-test-pool-wait-b0a9dc5dbe0e","pool_id":"34a36b69-f6e4-4279-8f74-c49a6213083c","provider_id":"scaleway://instance/fr-par-1/456dcdc2-0d49-445e-ba9c-5a4039a43c73","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:46:18.568289Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "689"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:46:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4e793fc3-686d-41f0-a177-271ea42f0977
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"autoscaling":null,"size":2,"min_size":null,"max_size":2,"autohealing":null,"tags":null,"kubelet_args":null,"upgrade_policy":{"max_unavailable":null,"max_surge":null}}'
+    body: '{"size":2,"max_size":2,"upgrade_policy":{"max_unavailable":null,"max_surge":null}}'
     form: {}
     headers:
       Content-Type:
@@ -6061,19 +4279,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: PATCH
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996365Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205440Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "631"
+      - "608"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:46:21 GMT
+      - Tue, 07 Nov 2023 15:57:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6083,7 +4301,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e401eed2-5c8d-4b4f-bdab-cc13297d20f7
+      - 6797ab3d-c6d9-4b73-9de6-140a79fc4b26
     status: 200 OK
     code: 200
     duration: ""
@@ -6094,19 +4312,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:46:21 GMT
+      - Tue, 07 Nov 2023 15:57:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6116,7 +4334,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60ae45f6-db07-4580-adbc-c4dc6ee0f42e
+      - aad72bac-8bc2-46e6-9c95-1b52ac76a140
     status: 200 OK
     code: 200
     duration: ""
@@ -6127,19 +4345,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:46:26 GMT
+      - Tue, 07 Nov 2023 15:57:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6149,7 +4367,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - baada17f-e937-4a92-82cb-5082ceb2ab05
+      - f3f05bc7-5f9b-4452-84f4-a13f2be91a33
     status: 200 OK
     code: 200
     duration: ""
@@ -6160,19 +4378,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:46:31 GMT
+      - Tue, 07 Nov 2023 15:57:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6182,7 +4400,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - edaf858c-6dce-4689-a3aa-678c83a99533
+      - a9d6b8c5-a6c1-4d4d-bb23-86eb0c8ad0cf
     status: 200 OK
     code: 200
     duration: ""
@@ -6193,19 +4411,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:46:36 GMT
+      - Tue, 07 Nov 2023 15:57:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6215,7 +4433,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8362a45f-e48b-42cf-9c1c-cb455d3ad0ee
+      - c28f4c3c-c586-47d5-88ec-434778bb07b5
     status: 200 OK
     code: 200
     duration: ""
@@ -6226,19 +4444,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:46:41 GMT
+      - Tue, 07 Nov 2023 15:57:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6248,7 +4466,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2a956ea-b119-4efe-85c8-035120feaa78
+      - 5c340624-f354-4dad-87e9-7824048ae0e6
     status: 200 OK
     code: 200
     duration: ""
@@ -6259,19 +4477,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:46:47 GMT
+      - Tue, 07 Nov 2023 15:57:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6281,7 +4499,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 476ab48b-a1b5-4354-8061-16cd75942ef0
+      - 0817e542-4336-4804-8253-b4edfd2be9f4
     status: 200 OK
     code: 200
     duration: ""
@@ -6292,19 +4510,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:46:52 GMT
+      - Tue, 07 Nov 2023 15:57:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6314,7 +4532,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2e48f98-dd74-4326-906e-922255ef9328
+      - 5c1ce8cb-611a-4a8d-9944-cfac35922d33
     status: 200 OK
     code: 200
     duration: ""
@@ -6325,19 +4543,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:46:57 GMT
+      - Tue, 07 Nov 2023 15:57:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6347,7 +4565,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afb9fab7-c1f9-4235-89ba-f71157f59152
+      - 43007b27-6792-4efc-8d3d-923be42f1dd0
     status: 200 OK
     code: 200
     duration: ""
@@ -6358,19 +4576,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:47:02 GMT
+      - Tue, 07 Nov 2023 15:57:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6380,7 +4598,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 341fefbd-67c9-4f7a-bdd8-0f540193d61e
+      - 9b827224-0754-4bdd-ba0f-7a5e6931669b
     status: 200 OK
     code: 200
     duration: ""
@@ -6391,19 +4609,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:47:07 GMT
+      - Tue, 07 Nov 2023 15:57:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6413,7 +4631,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50995582-77c5-4300-bf7b-a95b30326e52
+      - e2e55f6b-b883-4aa3-84fc-8f64e2eff0aa
     status: 200 OK
     code: 200
     duration: ""
@@ -6424,19 +4642,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:47:12 GMT
+      - Tue, 07 Nov 2023 15:57:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6446,7 +4664,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e236f0df-2ed5-4a38-84d2-10e40c4c36b1
+      - 7a68f236-5580-4b30-8900-7b31a3ac34e7
     status: 200 OK
     code: 200
     duration: ""
@@ -6457,19 +4675,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:47:17 GMT
+      - Tue, 07 Nov 2023 15:57:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6479,7 +4697,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 036a57c3-b922-4723-a74c-1435b6e0759a
+      - 6f737eb1-73aa-4e79-a1fe-a87c3ed509fa
     status: 200 OK
     code: 200
     duration: ""
@@ -6490,19 +4708,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:47:22 GMT
+      - Tue, 07 Nov 2023 15:58:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6512,7 +4730,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94515723-43ab-4969-a900-ca5512306194
+      - e018779f-0b92-4652-808f-0258260a8cb3
     status: 200 OK
     code: 200
     duration: ""
@@ -6523,19 +4741,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:47:27 GMT
+      - Tue, 07 Nov 2023 15:58:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6545,7 +4763,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5903ecf-f15d-48bf-924d-974b19c729d7
+      - 1803e3dd-c887-4dfe-98fa-0bdbb836fe31
     status: 200 OK
     code: 200
     duration: ""
@@ -6556,19 +4774,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:47:32 GMT
+      - Tue, 07 Nov 2023 15:58:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6578,7 +4796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8db5132-53f6-4258-b10b-322c192eb7a0
+      - 0a96c145-df5e-47f5-999d-f17e7b19cda9
     status: 200 OK
     code: 200
     duration: ""
@@ -6589,19 +4807,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:47:37 GMT
+      - Tue, 07 Nov 2023 15:58:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6611,7 +4829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4859cd2-361c-4f5b-9122-42a2b48bd497
+      - bae30696-9576-40a3-bc7a-70dce1ab1e44
     status: 200 OK
     code: 200
     duration: ""
@@ -6622,19 +4840,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:47:42 GMT
+      - Tue, 07 Nov 2023 15:58:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6644,7 +4862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f5fe1e3-ff0b-48ab-942b-df7391dabe00
+      - a06bbc20-8272-4a37-8b36-9f05197972b1
     status: 200 OK
     code: 200
     duration: ""
@@ -6655,19 +4873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:47:47 GMT
+      - Tue, 07 Nov 2023 15:58:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6677,7 +4895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8fb7486-da4e-4d71-b790-d9b5bb29e4cc
+      - 508e76b6-ea18-401c-8cfb-86321545f498
     status: 200 OK
     code: 200
     duration: ""
@@ -6688,19 +4906,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:47:52 GMT
+      - Tue, 07 Nov 2023 15:58:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6710,7 +4928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62e1b244-c7bc-4adb-8175-acc51da3391e
+      - 35b05845-08c2-4c21-99e7-21bdb9a32817
     status: 200 OK
     code: 200
     duration: ""
@@ -6721,19 +4939,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:47:57 GMT
+      - Tue, 07 Nov 2023 15:58:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6743,7 +4961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18eb420f-4e88-42c3-adc8-ad722bfdea97
+      - 432a1542-c5e6-4514-ada9-a4002c0cd0c3
     status: 200 OK
     code: 200
     duration: ""
@@ -6754,19 +4972,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:48:02 GMT
+      - Tue, 07 Nov 2023 15:58:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6776,7 +4994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 992c42ca-b318-4c0c-b53c-47d547e533c4
+      - 7e895b64-0ac7-44f9-b5f2-65f84bd3687a
     status: 200 OK
     code: 200
     duration: ""
@@ -6787,19 +5005,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:48:07 GMT
+      - Tue, 07 Nov 2023 15:58:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6809,7 +5027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df31c899-2fe0-4fcb-9a46-9ce7be10c073
+      - 96905223-2400-4ff4-b24b-bfca3ec8765f
     status: 200 OK
     code: 200
     duration: ""
@@ -6820,19 +5038,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:48:12 GMT
+      - Tue, 07 Nov 2023 15:58:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6842,7 +5060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6288a848-8237-42d1-870e-a62dac33daa6
+      - c9a53397-232f-48a2-b3a0-001621757702
     status: 200 OK
     code: 200
     duration: ""
@@ -6853,19 +5071,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:48:17 GMT
+      - Tue, 07 Nov 2023 15:58:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6875,7 +5093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ed04aa2-910f-4c11-96cb-13f479d14023
+      - a2d382e7-6362-4ac2-baa3-b92cb1578f88
     status: 200 OK
     code: 200
     duration: ""
@@ -6886,19 +5104,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:48:23 GMT
+      - Tue, 07 Nov 2023 15:59:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6908,7 +5126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e9b214b-3615-49cd-a210-f2ea5a0da226
+      - fcee67ec-7834-48db-8580-95863b1c72b4
     status: 200 OK
     code: 200
     duration: ""
@@ -6919,19 +5137,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:48:28 GMT
+      - Tue, 07 Nov 2023 15:59:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6941,7 +5159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22cba363-f9e6-41e9-9cb5-392481120989
+      - 81c9b2e3-d861-4b08-baf3-7a69fe97327e
     status: 200 OK
     code: 200
     duration: ""
@@ -6952,19 +5170,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:48:33 GMT
+      - Tue, 07 Nov 2023 15:59:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6974,7 +5192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6100324-b6e9-446b-ba86-12ec04650d6f
+      - 19b005eb-7d85-473a-a6ab-4cacffd46eb7
     status: 200 OK
     code: 200
     duration: ""
@@ -6985,19 +5203,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:48:38 GMT
+      - Tue, 07 Nov 2023 15:59:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7007,7 +5225,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4fcdba1-afd6-4297-94ee-a5a8b3c9d190
+      - faa95776-f0fc-49bf-8901-39b4e3b81525
     status: 200 OK
     code: 200
     duration: ""
@@ -7018,19 +5236,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:48:43 GMT
+      - Tue, 07 Nov 2023 15:59:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7040,7 +5258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c74f6fd-a9d9-48fa-aefd-d5630fb7fb6b
+      - 36c5b1bc-f932-4b4e-8d0c-ba13b83a402e
     status: 200 OK
     code: 200
     duration: ""
@@ -7051,19 +5269,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:48:48 GMT
+      - Tue, 07 Nov 2023 15:59:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7073,7 +5291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89fe99ae-29b6-46cf-b9b3-985ab06c7bb9
+      - f764488f-8835-4d03-93f5-174cb3b6115f
     status: 200 OK
     code: 200
     duration: ""
@@ -7084,19 +5302,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:48:53 GMT
+      - Tue, 07 Nov 2023 15:59:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7106,7 +5324,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dfae1959-bb69-408e-b0b7-db42b31b5466
+      - c2c75594-d97e-40f0-b8af-50326a44aad5
     status: 200 OK
     code: 200
     duration: ""
@@ -7117,19 +5335,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:48:58 GMT
+      - Tue, 07 Nov 2023 15:59:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7139,7 +5357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1145e3bb-77b4-4987-a7db-f2fba8587af6
+      - 09a3af0c-15d6-4acd-b395-7b8833dace27
     status: 200 OK
     code: 200
     duration: ""
@@ -7150,19 +5368,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:49:03 GMT
+      - Tue, 07 Nov 2023 15:59:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7172,7 +5390,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6b0418a-df7d-49b2-a6b2-3e1e18d97f27
+      - c7b88a67-8e49-4de0-8fde-9ead5e5b6d71
     status: 200 OK
     code: 200
     duration: ""
@@ -7183,19 +5401,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:49:08 GMT
+      - Tue, 07 Nov 2023 15:59:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7205,7 +5423,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 863e75de-d27d-4972-8f64-d5f675a7006e
+      - 72622db3-a2bf-466a-9f6b-c450a78f005e
     status: 200 OK
     code: 200
     duration: ""
@@ -7216,19 +5434,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:49:13 GMT
+      - Tue, 07 Nov 2023 15:59:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7238,7 +5456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f01f7d73-b8eb-4204-a127-7db386ac7fa1
+      - 37acfcf6-c1e6-4fad-b57c-cf285e7ef6fc
     status: 200 OK
     code: 200
     duration: ""
@@ -7249,19 +5467,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-11-07T15:57:00.008205Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:49:18 GMT
+      - Tue, 07 Nov 2023 15:59:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7271,7 +5489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e37e4322-bb97-467f-a8da-e2132166cd2a
+      - 5a10146a-8d26-4b13-948b-34715540e6ba
     status: 200 OK
     code: 200
     duration: ""
@@ -7282,19 +5500,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-07T15:59:57.352561Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:49:23 GMT
+      - Tue, 07 Nov 2023 16:00:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7304,7 +5522,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e5cc671-5ec2-445e-a713-3b89b478c2f5
+      - 6bce613e-1563-4032-9285-b1b8a8524ace
     status: 200 OK
     code: 200
     duration: ""
@@ -7315,19 +5533,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-07T15:59:57.352561Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:49:28 GMT
+      - Tue, 07 Nov 2023 16:00:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7337,7 +5555,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52e1e511-ea71-4b2d-952f-97c39c1e9a52
+      - 07ffaecc-65c9-4bae-89ad-69fe16678307
     status: 200 OK
     code: 200
     duration: ""
@@ -7348,19 +5566,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=f1ca093a-20e5-4b4c-a4f9-d813489a65f2&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:54:10.603081Z","error_message":null,"id":"9ff54354-1ce7-4896-9313-5142f745c072","name":"scw-test-pool-wait-test-pool-wait-2-9ff543541c","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/09c29c57-d383-4480-be2c-6ca76739d4ef","public_ip_v4":"51.158.103.0","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:59:57.337789Z"},{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:57:00.507854Z","error_message":null,"id":"7f04dc1b-819c-4dea-a5d9-5ccf4b3aef51","name":"scw-test-pool-wait-test-pool-wait-2-7f04dc1b81","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/51839c89-cedd-47b6-bef1-3e074ba2a6b2","public_ip_v4":"163.172.142.33","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:59:57.315067Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "628"
+      - "1284"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:49:33 GMT
+      - Tue, 07 Nov 2023 16:00:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7370,7 +5588,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 082f80a0-0c93-4840-a8dd-d5ca62b0d931
+      - 9c6a71b4-d45d-4af7-9fde-a04d59cdacc4
     status: 200 OK
     code: 200
     duration: ""
@@ -7381,19 +5599,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "628"
+      - "1449"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:49:38 GMT
+      - Tue, 07 Nov 2023 16:00:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7403,7 +5621,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54c694a7-4be1-4228-b8ce-e5514415333f
+      - 1dfdbd6f-ff60-4ff3-b333-87ea7bff661c
     status: 200 OK
     code: 200
     duration: ""
@@ -7414,19 +5632,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-07T15:59:57.352561Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:49:43 GMT
+      - Tue, 07 Nov 2023 16:00:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7436,7 +5654,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01b257d2-9d77-419d-9bd4-817c59530563
+      - 8091c6d0-0370-4048-93ee-d5f9e021aced
     status: 200 OK
     code: 200
     duration: ""
@@ -7447,19 +5665,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/adb8e568-6480-4b18-8b5c-3657e59e7a65
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-07T15:49:50.750080Z","dhcp_enabled":true,"id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","name":"test-pool-wait","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.750080Z","id":"0ba95cf8-45ba-4034-a2d0-045b3eb427fa","subnet":"172.16.60.0/22","updated_at":"2023-11-07T15:49:50.750080Z"},{"created_at":"2023-11-07T15:49:50.750080Z","id":"118694f9-3fe6-4789-b1fd-522e5b081392","subnet":"fd5f:519c:6d46:6cdc::/64","updated_at":"2023-11-07T15:49:50.750080Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.750080Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "628"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:49:48 GMT
+      - Tue, 07 Nov 2023 16:00:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7469,7 +5687,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 863b0359-7c00-44c6-873f-2ccba2f14682
+      - 4a81807e-8e64-4c43-b8d5-1b1653fbf6f4
     status: 200 OK
     code: 200
     duration: ""
@@ -7480,19 +5698,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "628"
+      - "1449"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:49:54 GMT
+      - Tue, 07 Nov 2023 16:00:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7502,7 +5720,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01cf6bd1-0b41-4e27-8104-508916900f8e
+      - 6bde4c28-124f-4dd0-9a02-50a940e62eae
     status: 200 OK
     code: 200
     duration: ""
@@ -7513,19 +5731,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6TTJDbnBhVlU4eWRWVlpkMVIxYTB4QlEzRnhZMWhsYmxaTWNtaHVOMEozV0ZreGNFcHNiRVJhVFRCbFIyeERhMlZRTUhaMVRFbEJWbmhDYlhkRWEySk9VRm9LUldaMWFHZGlZbXgyZGtkUmIyZHRjVzk2UVZGTU9HNVNVRk5wYVZGblEwNHdRM2t6VjJ4Q05sUTRhV3RRT0hkV1JtdG5ZV2h6VjJoTldISnJSWEpyZFFvclJVUlNPR2h2TVhSSFJTOUdZemxQV1VKc1lYQXJSMDQyTTJGMU4wVlVZVFkzVkhGdVJVUnhhakZ1VlM5blpuTkhSMHMxTTFsSlEyaDNNbGxuVWtOMkNrSjVWSGxZSzJkS01FazBhMGgyYVRGR1F6QmFNME54UjNkblJHeFBibmQzWmt0NVJEbElkMGhETkZkTWMyWmxTVkJDVkZaS2JVMUhjbnA2ZUhkaVZUQUtkVVZOVHpoNkt6aFpWRzU1WW5Rek9FcE1hMEozWkdORk9UVnFiREZFWnpZM2IwbGlPRzVPWmt0ME4xWlpWa1YwVW5GWlZXcFZLM1VyWVhkUFVtVXhLd3A2ZW5wV1ZETnllWG80V2xoUFlYVXJPVU00UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIWVhKaGRqTlNSbTV2VURKRldXbGFWVTlGWkVKTFJrVjZia1pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCUjJ4dmIydFJUVE5rV1V4RE5tNHJhRUpaYjBoS1pEVkZOVlZyUzJkVEt6WktRMUJ4TW14aVozWmFOR2xxUVRWMGRncG5VWFpNYVUxclFqaGpaR3hvYW1wWUwwTlNNbTFPWkhKTmNFUjBjRlpqVmxoV1kwTnpWM0F2ZHk5blFtTk9kbnA1ZUROaVkybFJkVEp3V25kWFpTdDRDbXBhVDNCYVMzbEpObmhOUnpKdGEzRndNSGhVSzI5TFFpODJNblpVTjJGVGNHZzNWemc1TWpjeVQzaERSR2haUkd0U1RrTkJZMFkyV1dJNVZGTjBWamtLV0RkMVFXZHJNRE16VWpNd1NYUXJiSGhoVlRsalRIaEpWMHh1VGxGTVYwdzJMM3BTVERkcWMyYzJiR1pvUkZvNWVqSXpkRkZ3WlZGVWVtZDZSa1phYmdwek4xaFdlalIwT1RaRk1rSnFPRzh5VG5KcFMwZHZhbXcxTUZkRk5sVjFUM2xvUm5CTGNtMHhSMmxRU205blNqVXZhMUpqU2xoTmNWRllORUZWYWxjM0NrSjZVbU5WUW1Od1dsRllialJRVEV0alYzSmxSakZzUm1GTVMyeE5lVkpCVW5KWVVBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xNTAzZTYyOS04ZGJhLTRlOTktODk2MC1lNmY4MDhmNmM4MTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBQemZ3Um9Qc2V0aDA2MEdnOXpOcnYyT1E4OG5zVlF6Sm9TNDdTY3RtVVlxVkl4YTFuZEFXQ3NMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "628"
+      - "2604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:49:59 GMT
+      - Tue, 07 Nov 2023 16:00:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7535,7 +5753,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88f46c9a-f359-4d0d-bb43-47f1407a8e75
+      - 131a179d-fba8-4356-89ac-2ab6da587ecc
     status: 200 OK
     code: 200
     duration: ""
@@ -7546,19 +5764,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:04.880743Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "601"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:04 GMT
+      - Tue, 07 Nov 2023 16:00:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7568,7 +5786,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e34e896b-23de-4101-8371-68e1c300518d
+      - 755245cd-d64c-4ce4-a5bd-fc73441d01f3
     status: 200 OK
     code: 200
     duration: ""
@@ -7579,19 +5797,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-07T15:59:57.352561Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:09 GMT
+      - Tue, 07 Nov 2023 16:00:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7601,7 +5819,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85fbdf54-1a60-403c-927f-711a850a6eb3
+      - b0eee677-6f18-403b-a844-e3dbef5f7ac9
     status: 200 OK
     code: 200
     duration: ""
@@ -7612,19 +5830,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=183e6c65-4884-4dd9-8252-5d4e66a2172f&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:46.900209Z","error_message":null,"id":"fce7c559-26ef-4f5d-9d15-b3eb6fb9a512","name":"scw-test-pool-wait-test-pool-wait-fce7c55926ef","pool_id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","provider_id":"scaleway://instance/fr-par-1/0b2e1b88-152b-43d2-980b-40f8d38acf79","public_ip_v4":"51.15.204.118","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:59:57.283032Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "628"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:14 GMT
+      - Tue, 07 Nov 2023 16:00:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7634,7 +5852,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 556da04f-113b-48ba-a24a-0e2baed7f1ef
+      - 559f3e72-86ba-422d-8a3b-b802c2720017
     status: 200 OK
     code: 200
     duration: ""
@@ -7645,19 +5863,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=f1ca093a-20e5-4b4c-a4f9-d813489a65f2&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:54:10.603081Z","error_message":null,"id":"9ff54354-1ce7-4896-9313-5142f745c072","name":"scw-test-pool-wait-test-pool-wait-2-9ff543541c","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/09c29c57-d383-4480-be2c-6ca76739d4ef","public_ip_v4":"51.158.103.0","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:59:57.337789Z"},{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:57:00.507854Z","error_message":null,"id":"7f04dc1b-819c-4dea-a5d9-5ccf4b3aef51","name":"scw-test-pool-wait-test-pool-wait-2-7f04dc1b81","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/51839c89-cedd-47b6-bef1-3e074ba2a6b2","public_ip_v4":"163.172.142.33","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:59:57.315067Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "628"
+      - "1284"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:19 GMT
+      - Tue, 07 Nov 2023 16:00:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7667,7 +5885,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c303d41-1992-4f81-9fcb-ef36997e7855
+      - bce3841e-823c-475d-ad08-07ede84c7766
     status: 200 OK
     code: 200
     duration: ""
@@ -7678,19 +5896,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/adb8e568-6480-4b18-8b5c-3657e59e7a65
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"created_at":"2023-11-07T15:49:50.750080Z","dhcp_enabled":true,"id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","name":"test-pool-wait","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.750080Z","id":"0ba95cf8-45ba-4034-a2d0-045b3eb427fa","subnet":"172.16.60.0/22","updated_at":"2023-11-07T15:49:50.750080Z"},{"created_at":"2023-11-07T15:49:50.750080Z","id":"118694f9-3fe6-4789-b1fd-522e5b081392","subnet":"fd5f:519c:6d46:6cdc::/64","updated_at":"2023-11-07T15:49:50.750080Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.750080Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "628"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:24 GMT
+      - Tue, 07 Nov 2023 16:00:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7700,7 +5918,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 557b5f06-5247-49c2-87d4-3d0c5b6f3145
+      - 97d91e6b-fa36-4759-b6ea-6c0a7fba37ea
     status: 200 OK
     code: 200
     duration: ""
@@ -7711,19 +5929,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:46:21.407996Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "628"
+      - "1449"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:29 GMT
+      - Tue, 07 Nov 2023 16:00:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7733,7 +5951,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9ef825e-2431-466d-b94f-7647e4a94edf
+      - 224aeb25-d700-4ada-8ba1-1b7396d2cc85
     status: 200 OK
     code: 200
     duration: ""
@@ -7744,19 +5962,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-10-19T16:50:33.485804Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6TTJDbnBhVlU4eWRWVlpkMVIxYTB4QlEzRnhZMWhsYmxaTWNtaHVOMEozV0ZreGNFcHNiRVJhVFRCbFIyeERhMlZRTUhaMVRFbEJWbmhDYlhkRWEySk9VRm9LUldaMWFHZGlZbXgyZGtkUmIyZHRjVzk2UVZGTU9HNVNVRk5wYVZGblEwNHdRM2t6VjJ4Q05sUTRhV3RRT0hkV1JtdG5ZV2h6VjJoTldISnJSWEpyZFFvclJVUlNPR2h2TVhSSFJTOUdZemxQV1VKc1lYQXJSMDQyTTJGMU4wVlVZVFkzVkhGdVJVUnhhakZ1VlM5blpuTkhSMHMxTTFsSlEyaDNNbGxuVWtOMkNrSjVWSGxZSzJkS01FazBhMGgyYVRGR1F6QmFNME54UjNkblJHeFBibmQzWmt0NVJEbElkMGhETkZkTWMyWmxTVkJDVkZaS2JVMUhjbnA2ZUhkaVZUQUtkVVZOVHpoNkt6aFpWRzU1WW5Rek9FcE1hMEozWkdORk9UVnFiREZFWnpZM2IwbGlPRzVPWmt0ME4xWlpWa1YwVW5GWlZXcFZLM1VyWVhkUFVtVXhLd3A2ZW5wV1ZETnllWG80V2xoUFlYVXJPVU00UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIWVhKaGRqTlNSbTV2VURKRldXbGFWVTlGWkVKTFJrVjZia1pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCUjJ4dmIydFJUVE5rV1V4RE5tNHJhRUpaYjBoS1pEVkZOVlZyUzJkVEt6WktRMUJ4TW14aVozWmFOR2xxUVRWMGRncG5VWFpNYVUxclFqaGpaR3hvYW1wWUwwTlNNbTFPWkhKTmNFUjBjRlpqVmxoV1kwTnpWM0F2ZHk5blFtTk9kbnA1ZUROaVkybFJkVEp3V25kWFpTdDRDbXBhVDNCYVMzbEpObmhOUnpKdGEzRndNSGhVSzI5TFFpODJNblpVTjJGVGNHZzNWemc1TWpjeVQzaERSR2haUkd0U1RrTkJZMFkyV1dJNVZGTjBWamtLV0RkMVFXZHJNRE16VWpNd1NYUXJiSGhoVlRsalRIaEpWMHh1VGxGTVYwdzJMM3BTVERkcWMyYzJiR1pvUkZvNWVqSXpkRkZ3WlZGVWVtZDZSa1phYmdwek4xaFdlalIwT1RaRk1rSnFPRzh5VG5KcFMwZHZhbXcxTUZkRk5sVjFUM2xvUm5CTGNtMHhSMmxRU205blNqVXZhMUpqU2xoTmNWRllORUZWYWxjM0NrSjZVbU5WUW1Od1dsRllialJRVEV0alYzSmxSakZzUm1GTVMyeE5lVkpCVW5KWVVBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xNTAzZTYyOS04ZGJhLTRlOTktODk2MC1lNmY4MDhmNmM4MTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBQemZ3Um9Qc2V0aDA2MEdnOXpOcnYyT1E4OG5zVlF6Sm9TNDdTY3RtVVlxVkl4YTFuZEFXQ3NMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "626"
+      - "2604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:34 GMT
+      - Tue, 07 Nov 2023 16:00:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7766,7 +5984,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac0e6b54-9132-40c3-8804-e9afdfae83ec
+      - b4bb8bca-ce08-428e-96c9-606a094c361c
     status: 200 OK
     code: 200
     duration: ""
@@ -7777,19 +5995,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-10-19T16:50:33.485804Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:04.880743Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "601"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:34 GMT
+      - Tue, 07 Nov 2023 16:00:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7799,7 +6017,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e76ae99-af1d-410d-bd5c-43c4aec06fd7
+      - 91a88272-a290-4d37-8b2c-eb9e89fca414
     status: 200 OK
     code: 200
     duration: ""
@@ -7810,19 +6028,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/nodes?order_by=created_at_asc&page=1&pool_id=d29afef8-724f-493c-ad4c-f3e176e9a0e6&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:41:20.856069Z","error_message":null,"id":"bec60012-8e36-409e-b48f-d00017d8d201","name":"scw-test-pool-wait-test-pool-wait-2-bec600128e","pool_id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","provider_id":"scaleway://instance/fr-par-1/ba6d3b71-abd8-497e-90d6-7041ac2e6679","public_ip_v4":"163.172.141.90","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:50:33.446076Z"},{"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:46:21.965829Z","error_message":null,"id":"d5ba2835-2da7-4d71-9623-e11a52e57d3c","name":"scw-test-pool-wait-test-pool-wait-2-d5ba28352d","pool_id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","provider_id":"scaleway://instance/fr-par-1/0e6d7db5-8984-4294-bf08-4f8f12c6e14b","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:50:33.464550Z"}],"total_count":2}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-11-07T15:59:57.352561Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1322"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:34 GMT
+      - Tue, 07 Nov 2023 16:00:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7832,7 +6050,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d7deaa4-9fd0-489b-9f20-4efdc6a79a99
+      - c178d091-7119-4feb-9209-40a714e44647
     status: 200 OK
     code: 200
     duration: ""
@@ -7843,19 +6061,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=f1ca093a-20e5-4b4c-a4f9-d813489a65f2&status=unknown
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900976Z","created_at":"2023-10-19T16:34:42.900976Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:36:09.161891Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:54:10.603081Z","error_message":null,"id":"9ff54354-1ce7-4896-9313-5142f745c072","name":"scw-test-pool-wait-test-pool-wait-2-9ff543541c","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/09c29c57-d383-4480-be2c-6ca76739d4ef","public_ip_v4":"51.158.103.0","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:59:57.337789Z"},{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:57:00.507854Z","error_message":null,"id":"7f04dc1b-819c-4dea-a5d9-5ccf4b3aef51","name":"scw-test-pool-wait-test-pool-wait-2-7f04dc1b81","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/51839c89-cedd-47b6-bef1-3e074ba2a6b2","public_ip_v4":"163.172.142.33","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:59:57.315067Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1494"
+      - "1284"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:34 GMT
+      - Tue, 07 Nov 2023 16:00:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7865,7 +6083,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f52a0c57-8660-4352-9d44-ce428350943e
+      - 2f8094e3-7e7d-4ba2-9c79-bb69dadf4d7d
     status: 200 OK
     code: 200
     duration: ""
@@ -7876,19 +6094,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=183e6c65-4884-4dd9-8252-5d4e66a2172f&status=unknown
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-10-19T16:50:33.485804Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:46.900209Z","error_message":null,"id":"fce7c559-26ef-4f5d-9d15-b3eb6fb9a512","name":"scw-test-pool-wait-test-pool-wait-fce7c55926ef","pool_id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","provider_id":"scaleway://instance/fr-par-1/0b2e1b88-152b-43d2-980b-40f8d38acf79","public_ip_v4":"51.15.204.118","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T15:59:57.283032Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "626"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:34 GMT
+      - Tue, 07 Nov 2023 16:00:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7898,474 +6116,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6d84392-4a0a-43aa-9573-5a9b248f0994
+      - 4b53482e-1b3a-491d-9eee-a9898dc11f98
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/882a0149-d4f0-470c-8a36-650eb9f9c627
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-19T16:34:41.054613Z","dhcp_enabled":true,"id":"882a0149-d4f0-470c-8a36-650eb9f9c627","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-19T16:34:41.054613Z","id":"29e823e2-bb1a-4e49-b0e6-726aeafb43b6","subnet":"172.16.4.0/22","updated_at":"2023-10-19T16:34:41.054613Z"},{"created_at":"2023-10-19T16:34:41.054613Z","id":"57b44457-ecb1-48e2-86a5-5d7cf356e438","subnet":"fd63:256c:45f7:d0e7::/64","updated_at":"2023-10-19T16:34:41.054613Z"}],"tags":[],"updated_at":"2023-10-19T16:34:41.054613Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "714"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5573bc72-5f28-43ef-8f9d-b852383c7581
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900976Z","created_at":"2023-10-19T16:34:42.900976Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:36:09.161891Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1494"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 85b5f137-21bd-44ca-a888-56c69abe40e2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaFBSRVV5VFhwUk1FNUdiMWhFVkUxNlRWUkJlRTlFUlRKTmVsRXdUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyWnpDa05OZEVoTlNETm9lRW96Tm0xNlJtVjBlbWhXVlRKNE5WbHhlWGhvVEZsMGVtSkRjR0ZQYUhKRGIwdzVhREpQU2xoMlpraFVUbkk1SzNka1RESjVSM2dLTmxKVEwyWmtVMmQxVm5WWGFtTmhTVkZYVkVaMWFFSlJaMWxFVERGdWVIZFVXbXRvVTBoVGR6RmhORzVIUzBzNWRpdDNObU0zYlVWaGFYWlNZWElyVUFwbmJrWlpjSEU1WkZGNmRXSXJZbGRKY1ROcE1XOVZjblpKYjNKNE5XeGhZV2cxY0VObWRHSllWMFpXTkVNMVRYQlRXa00yVTNCdldFaFdPR3gzVFRWQkNsVjNSSGRzV0c1UVQyNHdTVEJMVFV3MFpFNUtVVmxaVlU5UlEzTmFSVmsyYmpoNGVUSm1iMGwyUVZWbFYwbG5UR2xNV1V0SWJrUXZWRmg2VUhGRFIyWUtlVUk1V1ZkTWEzQnhhREZTT1hrMVRrOXNOWEYwUlVSSk9GRkZNMDlyWm10cEswbFJSVVZCU0VablVYUkVRbGRUTDJ4QlkydFNkVmd2Yms5WFJsVndiQXB4WW1RMEx6QjBZbWRZVEU1TVdYQTBSbEpyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGUkdKb1JXSTBiVnBJYVVGMmVIbHhUSGcyWnpaNE5YcGxUM3BOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEWkdGT2VGTnBiV05pVDNsdGQza3dUVWczV25CT05XNXZWRll6U2xKT2MxRjFhamROTURkeVEyaFdORVpuYmpSM1V3cE5UMnRxYUhkcFZVcGlLMDU2YVVoMVoxWjRjSGxLT0RCeVNVOUhWMFE0VWxCTmNGSndUMlUxWTBOalZuVlJlbEI0YXpJNVZFVnRUVmt2UWxSc1pGTlhDbUo0YTNkVmJVNDVkV1JaZUcweWNsRjRWbGxtY2toTFRrZ3lhamxJTUdkak9XMHdVbFpMVld3NFRVeHZOM3BMYVhjMGNsSnZjVUk0UVcxUFdqWkRMMElLUm1OR2RUSlJjM1JwU1VOamRqazBVME5YVmpGdGMwSTFUVFF4YVhSdGFFdHJZVVp4VEd0M1IzbG5SemxLSzJZeldEaGFVVEJHUW1oVGVqQTVkak5KY3dwck4yWnVhRlpQUkRaTGNHdHVWa1kyZW1wNldGWk5VbTgxUW5wUk55OVpNVXREVVdsdWNVRkJlU3RFUjB4RFl6TkdkV28xWm5WcE5HaDNkRlZSVW1VekNqaHJhV29yUkN0bWJVeDRiMDUyYUU4M1dFd3JUMDVPYTI5UFFpODJRVmx4T0VWYVRRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly83MGRlMDY0Yi1kZDZkLTQxZDEtYjk5Ny03MDVlMTE1NmRiZjEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBGZ1VqUGRuem5pWE1GajFHN0V3MzdtZXdqY0pyNTZqS0EyVTVvRm5YQ2tMaFB4a0l5Wkk3U2diSQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2606"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - af4c7e82-94e9-4d93-9746-e4d965f04556
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-10-19T16:50:33.485804Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a94af5d3-f0fc-4e3e-8ecb-7c8a37f40bce
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:41:12.895030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "624"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0ce61b28-db46-409c-a6d8-5897af66cc8d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/nodes?order_by=created_at_asc&page=1&pool_id=34a36b69-f6e4-4279-8f74-c49a6213083c&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:36:27.777812Z","error_message":null,"id":"b0a9dc5d-be0e-41bf-b5ce-e13680526495","name":"scw-test-pool-wait-test-pool-wait-b0a9dc5dbe0e","pool_id":"34a36b69-f6e4-4279-8f74-c49a6213083c","provider_id":"scaleway://instance/fr-par-1/456dcdc2-0d49-445e-ba9c-5a4039a43c73","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:50:33.413263Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "689"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0fd5f45b-3a1d-4fa6-97b4-d8aae5140688
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/nodes?order_by=created_at_asc&page=1&pool_id=d29afef8-724f-493c-ad4c-f3e176e9a0e6&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:41:20.856069Z","error_message":null,"id":"bec60012-8e36-409e-b48f-d00017d8d201","name":"scw-test-pool-wait-test-pool-wait-2-bec600128e","pool_id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","provider_id":"scaleway://instance/fr-par-1/ba6d3b71-abd8-497e-90d6-7041ac2e6679","public_ip_v4":"163.172.141.90","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:50:33.446076Z"},{"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:46:21.965829Z","error_message":null,"id":"d5ba2835-2da7-4d71-9623-e11a52e57d3c","name":"scw-test-pool-wait-test-pool-wait-2-d5ba28352d","pool_id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","provider_id":"scaleway://instance/fr-par-1/0e6d7db5-8984-4294-bf08-4f8f12c6e14b","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:50:33.464550Z"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "1322"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fed17bb2-47ac-40dd-9683-cface5a2f926
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/882a0149-d4f0-470c-8a36-650eb9f9c627
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-19T16:34:41.054613Z","dhcp_enabled":true,"id":"882a0149-d4f0-470c-8a36-650eb9f9c627","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-19T16:34:41.054613Z","id":"29e823e2-bb1a-4e49-b0e6-726aeafb43b6","subnet":"172.16.4.0/22","updated_at":"2023-10-19T16:34:41.054613Z"},{"created_at":"2023-10-19T16:34:41.054613Z","id":"57b44457-ecb1-48e2-86a5-5d7cf356e438","subnet":"fd63:256c:45f7:d0e7::/64","updated_at":"2023-10-19T16:34:41.054613Z"}],"tags":[],"updated_at":"2023-10-19T16:34:41.054613Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "714"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d757792d-6562-49ec-a81a-04d37687c6cb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900976Z","created_at":"2023-10-19T16:34:42.900976Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:36:09.161891Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1494"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5c6be01c-a1f8-43a3-8843-098da4ecf98d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaFBSRVV5VFhwUk1FNUdiMWhFVkUxNlRWUkJlRTlFUlRKTmVsRXdUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyWnpDa05OZEVoTlNETm9lRW96Tm0xNlJtVjBlbWhXVlRKNE5WbHhlWGhvVEZsMGVtSkRjR0ZQYUhKRGIwdzVhREpQU2xoMlpraFVUbkk1SzNka1RESjVSM2dLTmxKVEwyWmtVMmQxVm5WWGFtTmhTVkZYVkVaMWFFSlJaMWxFVERGdWVIZFVXbXRvVTBoVGR6RmhORzVIUzBzNWRpdDNObU0zYlVWaGFYWlNZWElyVUFwbmJrWlpjSEU1WkZGNmRXSXJZbGRKY1ROcE1XOVZjblpKYjNKNE5XeGhZV2cxY0VObWRHSllWMFpXTkVNMVRYQlRXa00yVTNCdldFaFdPR3gzVFRWQkNsVjNSSGRzV0c1UVQyNHdTVEJMVFV3MFpFNUtVVmxaVlU5UlEzTmFSVmsyYmpoNGVUSm1iMGwyUVZWbFYwbG5UR2xNV1V0SWJrUXZWRmg2VUhGRFIyWUtlVUk1V1ZkTWEzQnhhREZTT1hrMVRrOXNOWEYwUlVSSk9GRkZNMDlyWm10cEswbFJSVVZCU0VablVYUkVRbGRUTDJ4QlkydFNkVmd2Yms5WFJsVndiQXB4WW1RMEx6QjBZbWRZVEU1TVdYQTBSbEpyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGUkdKb1JXSTBiVnBJYVVGMmVIbHhUSGcyWnpaNE5YcGxUM3BOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEWkdGT2VGTnBiV05pVDNsdGQza3dUVWczV25CT05XNXZWRll6U2xKT2MxRjFhamROTURkeVEyaFdORVpuYmpSM1V3cE5UMnRxYUhkcFZVcGlLMDU2YVVoMVoxWjRjSGxLT0RCeVNVOUhWMFE0VWxCTmNGSndUMlUxWTBOalZuVlJlbEI0YXpJNVZFVnRUVmt2UWxSc1pGTlhDbUo0YTNkVmJVNDVkV1JaZUcweWNsRjRWbGxtY2toTFRrZ3lhamxJTUdkak9XMHdVbFpMVld3NFRVeHZOM3BMYVhjMGNsSnZjVUk0UVcxUFdqWkRMMElLUm1OR2RUSlJjM1JwU1VOamRqazBVME5YVmpGdGMwSTFUVFF4YVhSdGFFdHJZVVp4VEd0M1IzbG5SemxLSzJZeldEaGFVVEJHUW1oVGVqQTVkak5KY3dwck4yWnVhRlpQUkRaTGNHdHVWa1kyZW1wNldGWk5VbTgxUW5wUk55OVpNVXREVVdsdWNVRkJlU3RFUjB4RFl6TkdkV28xWm5WcE5HaDNkRlZSVW1VekNqaHJhV29yUkN0bWJVeDRiMDUyYUU4M1dFd3JUMDVPYTI5UFFpODJRVmx4T0VWYVRRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly83MGRlMDY0Yi1kZDZkLTQxZDEtYjk5Ny03MDVlMTE1NmRiZjEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBGZ1VqUGRuem5pWE1GajFHN0V3MzdtZXdqY0pyNTZqS0EyVTVvRm5YQ2tMaFB4a0l5Wkk3U2diSQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2606"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1fa5b301-340d-4610-b7e8-2370de77ff23
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":2,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":2,"status":"ready","tags":[],"updated_at":"2023-10-19T16:50:33.485804Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "626"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1118a832-18ac-47f7-8404-a3abc13a4ae1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:41:12.895030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "624"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a8c44388-e608-4560-8a12-b1281f7a57af
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/nodes?order_by=created_at_asc&page=1&pool_id=d29afef8-724f-493c-ad4c-f3e176e9a0e6&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:41:20.856069Z","error_message":null,"id":"bec60012-8e36-409e-b48f-d00017d8d201","name":"scw-test-pool-wait-test-pool-wait-2-bec600128e","pool_id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","provider_id":"scaleway://instance/fr-par-1/ba6d3b71-abd8-497e-90d6-7041ac2e6679","public_ip_v4":"163.172.141.90","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:50:33.446076Z"},{"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:46:21.965829Z","error_message":null,"id":"d5ba2835-2da7-4d71-9623-e11a52e57d3c","name":"scw-test-pool-wait-test-pool-wait-2-d5ba28352d","pool_id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","provider_id":"scaleway://instance/fr-par-1/0e6d7db5-8984-4294-bf08-4f8f12c6e14b","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:50:33.464550Z"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "1322"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8bc3ed26-b576-481b-b13a-fc99c2eb7a13
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/nodes?order_by=created_at_asc&page=1&pool_id=34a36b69-f6e4-4279-8f74-c49a6213083c&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:36:27.777812Z","error_message":null,"id":"b0a9dc5d-be0e-41bf-b5ce-e13680526495","name":"scw-test-pool-wait-test-pool-wait-b0a9dc5dbe0e","pool_id":"34a36b69-f6e4-4279-8f74-c49a6213083c","provider_id":"scaleway://instance/fr-par-1/456dcdc2-0d49-445e-ba9c-5a4039a43c73","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:50:33.413263Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "689"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cd648544-08d9-4237-983b-821de6342469
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"autoscaling":null,"size":1,"min_size":null,"max_size":1,"autohealing":null,"tags":null,"kubelet_args":null,"upgrade_policy":{"max_unavailable":null,"max_surge":null}}'
+    body: '{"size":1,"max_size":1,"upgrade_policy":{"max_unavailable":null,"max_surge":null}}'
     form: {}
     headers:
       Content-Type:
@@ -8373,19 +6129,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: PATCH
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:50:36.902301613Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:00:05.546535340Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "631"
+      - "608"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:37 GMT
+      - Tue, 07 Nov 2023 16:00:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8395,7 +6151,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73cae1fa-fc6c-441c-9d95-9e47cdc1d3b1
+      - 7eba7107-02e1-4c6d-b930-c9ab8452c289
     status: 200 OK
     code: 200
     duration: ""
@@ -8406,19 +6162,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-10-19T16:50:36.902302Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":[],"updated_at":"2023-11-07T16:00:05.546535Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "628"
+      - "605"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:37 GMT
+      - Tue, 07 Nov 2023 16:00:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8428,7 +6184,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3e06f97-2ace-42c9-bddf-3b3abc40d86e
+      - 62cd6ac1-8b1e-48cf-910a-828f50450c3d
     status: 200 OK
     code: 200
     duration: ""
@@ -8439,19 +6195,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:50:38.103012Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:00:06.709931Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:42 GMT
+      - Tue, 07 Nov 2023 16:00:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8461,7 +6217,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 180704d2-e71a-4397-b20d-0b95a9f37e15
+      - 198ef8bc-cc73-49e0-87f1-34d14ef27624
     status: 200 OK
     code: 200
     duration: ""
@@ -8472,19 +6228,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:50:38.103012Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:00:06.709931Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:42 GMT
+      - Tue, 07 Nov 2023 16:00:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8494,7 +6250,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 730834f0-be24-406a-8e15-72c940a5efa5
+      - 9365c041-34e1-4fd1-8074-9dc0794b5868
     status: 200 OK
     code: 200
     duration: ""
@@ -8505,19 +6261,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/nodes?order_by=created_at_asc&page=1&pool_id=d29afef8-724f-493c-ad4c-f3e176e9a0e6&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=f1ca093a-20e5-4b4c-a4f9-d813489a65f2&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:41:20.856069Z","error_message":null,"id":"bec60012-8e36-409e-b48f-d00017d8d201","name":"scw-test-pool-wait-test-pool-wait-2-bec600128e","pool_id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","provider_id":"scaleway://instance/fr-par-1/ba6d3b71-abd8-497e-90d6-7041ac2e6679","public_ip_v4":"163.172.141.90","public_ip_v6":null,"region":"fr-par","status":"deleting","updated_at":"2023-10-19T16:50:37.394144Z"},{"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:46:21.965829Z","error_message":null,"id":"d5ba2835-2da7-4d71-9623-e11a52e57d3c","name":"scw-test-pool-wait-test-pool-wait-2-d5ba28352d","pool_id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","provider_id":"scaleway://instance/fr-par-1/0e6d7db5-8984-4294-bf08-4f8f12c6e14b","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:50:38.006085Z"}],"total_count":2}'
+    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:54:10.603081Z","error_message":null,"id":"9ff54354-1ce7-4896-9313-5142f745c072","name":"scw-test-pool-wait-test-pool-wait-2-9ff543541c","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/09c29c57-d383-4480-be2c-6ca76739d4ef","public_ip_v4":"51.158.103.0","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:00:06.624693Z"},{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:57:00.507854Z","error_message":null,"id":"7f04dc1b-819c-4dea-a5d9-5ccf4b3aef51","name":"scw-test-pool-wait-test-pool-wait-2-7f04dc1b81","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/51839c89-cedd-47b6-bef1-3e074ba2a6b2","public_ip_v4":"163.172.142.33","public_ip_v6":null,"region":"fr-par","status":"deleting","updated_at":"2023-11-07T16:00:06.080164Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1325"
+      - "1287"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:42 GMT
+      - Tue, 07 Nov 2023 16:00:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8527,7 +6283,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c44a6732-9565-4d52-b807-b9c4d27c6e11
+      - 791dfe34-95aa-46c7-9eef-71b60f9b63be
     status: 200 OK
     code: 200
     duration: ""
@@ -8538,19 +6294,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900976Z","created_at":"2023-10-19T16:34:42.900976Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:36:09.161891Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1494"
+      - "1449"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:42 GMT
+      - Tue, 07 Nov 2023 16:00:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8560,7 +6316,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa2a597f-f35b-4ed3-b8e1-a8ed513a3ab1
+      - 16925a86-ce86-43a0-86fa-8e9ea7cc059c
     status: 200 OK
     code: 200
     duration: ""
@@ -8571,19 +6327,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:50:38.103012Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:00:06.709931Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:42 GMT
+      - Tue, 07 Nov 2023 16:00:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8593,7 +6349,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f640cc3-81c0-43c7-b120-2c0c7e587826
+      - 65f21baf-f0e5-493f-aa36-c2ad4279e8bc
     status: 200 OK
     code: 200
     duration: ""
@@ -8604,19 +6360,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/882a0149-d4f0-470c-8a36-650eb9f9c627
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/adb8e568-6480-4b18-8b5c-3657e59e7a65
     method: GET
   response:
-    body: '{"created_at":"2023-10-19T16:34:41.054613Z","dhcp_enabled":true,"id":"882a0149-d4f0-470c-8a36-650eb9f9c627","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-19T16:34:41.054613Z","id":"29e823e2-bb1a-4e49-b0e6-726aeafb43b6","subnet":"172.16.4.0/22","updated_at":"2023-10-19T16:34:41.054613Z"},{"created_at":"2023-10-19T16:34:41.054613Z","id":"57b44457-ecb1-48e2-86a5-5d7cf356e438","subnet":"fd63:256c:45f7:d0e7::/64","updated_at":"2023-10-19T16:34:41.054613Z"}],"tags":[],"updated_at":"2023-10-19T16:34:41.054613Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T15:49:50.750080Z","dhcp_enabled":true,"id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","name":"test-pool-wait","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.750080Z","id":"0ba95cf8-45ba-4034-a2d0-045b3eb427fa","subnet":"172.16.60.0/22","updated_at":"2023-11-07T15:49:50.750080Z"},{"created_at":"2023-11-07T15:49:50.750080Z","id":"118694f9-3fe6-4789-b1fd-522e5b081392","subnet":"fd5f:519c:6d46:6cdc::/64","updated_at":"2023-11-07T15:49:50.750080Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.750080Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "714"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:43 GMT
+      - Tue, 07 Nov 2023 16:00:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8626,7 +6382,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83f0c307-f657-4ae3-8a60-62817c40ac2c
+      - 508efd6b-47df-492a-a84a-91ffaa0e0cff
     status: 200 OK
     code: 200
     duration: ""
@@ -8637,19 +6393,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900976Z","created_at":"2023-10-19T16:34:42.900976Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:36:09.161891Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1494"
+      - "1449"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:43 GMT
+      - Tue, 07 Nov 2023 16:00:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8659,7 +6415,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3bf821a-688a-43bd-ac57-5d141e7d3f76
+      - eed03b31-1eed-4d54-87b7-e94fdade7556
     status: 200 OK
     code: 200
     duration: ""
@@ -8670,19 +6426,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaFBSRVV5VFhwUk1FNUdiMWhFVkUxNlRWUkJlRTlFUlRKTmVsRXdUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyWnpDa05OZEVoTlNETm9lRW96Tm0xNlJtVjBlbWhXVlRKNE5WbHhlWGhvVEZsMGVtSkRjR0ZQYUhKRGIwdzVhREpQU2xoMlpraFVUbkk1SzNka1RESjVSM2dLTmxKVEwyWmtVMmQxVm5WWGFtTmhTVkZYVkVaMWFFSlJaMWxFVERGdWVIZFVXbXRvVTBoVGR6RmhORzVIUzBzNWRpdDNObU0zYlVWaGFYWlNZWElyVUFwbmJrWlpjSEU1WkZGNmRXSXJZbGRKY1ROcE1XOVZjblpKYjNKNE5XeGhZV2cxY0VObWRHSllWMFpXTkVNMVRYQlRXa00yVTNCdldFaFdPR3gzVFRWQkNsVjNSSGRzV0c1UVQyNHdTVEJMVFV3MFpFNUtVVmxaVlU5UlEzTmFSVmsyYmpoNGVUSm1iMGwyUVZWbFYwbG5UR2xNV1V0SWJrUXZWRmg2VUhGRFIyWUtlVUk1V1ZkTWEzQnhhREZTT1hrMVRrOXNOWEYwUlVSSk9GRkZNMDlyWm10cEswbFJSVVZCU0VablVYUkVRbGRUTDJ4QlkydFNkVmd2Yms5WFJsVndiQXB4WW1RMEx6QjBZbWRZVEU1TVdYQTBSbEpyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGUkdKb1JXSTBiVnBJYVVGMmVIbHhUSGcyWnpaNE5YcGxUM3BOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEWkdGT2VGTnBiV05pVDNsdGQza3dUVWczV25CT05XNXZWRll6U2xKT2MxRjFhamROTURkeVEyaFdORVpuYmpSM1V3cE5UMnRxYUhkcFZVcGlLMDU2YVVoMVoxWjRjSGxLT0RCeVNVOUhWMFE0VWxCTmNGSndUMlUxWTBOalZuVlJlbEI0YXpJNVZFVnRUVmt2UWxSc1pGTlhDbUo0YTNkVmJVNDVkV1JaZUcweWNsRjRWbGxtY2toTFRrZ3lhamxJTUdkak9XMHdVbFpMVld3NFRVeHZOM3BMYVhjMGNsSnZjVUk0UVcxUFdqWkRMMElLUm1OR2RUSlJjM1JwU1VOamRqazBVME5YVmpGdGMwSTFUVFF4YVhSdGFFdHJZVVp4VEd0M1IzbG5SemxLSzJZeldEaGFVVEJHUW1oVGVqQTVkak5KY3dwck4yWnVhRlpQUkRaTGNHdHVWa1kyZW1wNldGWk5VbTgxUW5wUk55OVpNVXREVVdsdWNVRkJlU3RFUjB4RFl6TkdkV28xWm5WcE5HaDNkRlZSVW1VekNqaHJhV29yUkN0bWJVeDRiMDUyYUU4M1dFd3JUMDVPYTI5UFFpODJRVmx4T0VWYVRRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly83MGRlMDY0Yi1kZDZkLTQxZDEtYjk5Ny03MDVlMTE1NmRiZjEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBGZ1VqUGRuem5pWE1GajFHN0V3MzdtZXdqY0pyNTZqS0EyVTVvRm5YQ2tMaFB4a0l5Wkk3U2diSQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6TTJDbnBhVlU4eWRWVlpkMVIxYTB4QlEzRnhZMWhsYmxaTWNtaHVOMEozV0ZreGNFcHNiRVJhVFRCbFIyeERhMlZRTUhaMVRFbEJWbmhDYlhkRWEySk9VRm9LUldaMWFHZGlZbXgyZGtkUmIyZHRjVzk2UVZGTU9HNVNVRk5wYVZGblEwNHdRM2t6VjJ4Q05sUTRhV3RRT0hkV1JtdG5ZV2h6VjJoTldISnJSWEpyZFFvclJVUlNPR2h2TVhSSFJTOUdZemxQV1VKc1lYQXJSMDQyTTJGMU4wVlVZVFkzVkhGdVJVUnhhakZ1VlM5blpuTkhSMHMxTTFsSlEyaDNNbGxuVWtOMkNrSjVWSGxZSzJkS01FazBhMGgyYVRGR1F6QmFNME54UjNkblJHeFBibmQzWmt0NVJEbElkMGhETkZkTWMyWmxTVkJDVkZaS2JVMUhjbnA2ZUhkaVZUQUtkVVZOVHpoNkt6aFpWRzU1WW5Rek9FcE1hMEozWkdORk9UVnFiREZFWnpZM2IwbGlPRzVPWmt0ME4xWlpWa1YwVW5GWlZXcFZLM1VyWVhkUFVtVXhLd3A2ZW5wV1ZETnllWG80V2xoUFlYVXJPVU00UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIWVhKaGRqTlNSbTV2VURKRldXbGFWVTlGWkVKTFJrVjZia1pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCUjJ4dmIydFJUVE5rV1V4RE5tNHJhRUpaYjBoS1pEVkZOVlZyUzJkVEt6WktRMUJ4TW14aVozWmFOR2xxUVRWMGRncG5VWFpNYVUxclFqaGpaR3hvYW1wWUwwTlNNbTFPWkhKTmNFUjBjRlpqVmxoV1kwTnpWM0F2ZHk5blFtTk9kbnA1ZUROaVkybFJkVEp3V25kWFpTdDRDbXBhVDNCYVMzbEpObmhOUnpKdGEzRndNSGhVSzI5TFFpODJNblpVTjJGVGNHZzNWemc1TWpjeVQzaERSR2haUkd0U1RrTkJZMFkyV1dJNVZGTjBWamtLV0RkMVFXZHJNRE16VWpNd1NYUXJiSGhoVlRsalRIaEpWMHh1VGxGTVYwdzJMM3BTVERkcWMyYzJiR1pvUkZvNWVqSXpkRkZ3WlZGVWVtZDZSa1phYmdwek4xaFdlalIwT1RaRk1rSnFPRzh5VG5KcFMwZHZhbXcxTUZkRk5sVjFUM2xvUm5CTGNtMHhSMmxRU205blNqVXZhMUpqU2xoTmNWRllORUZWYWxjM0NrSjZVbU5WUW1Od1dsRllialJRVEV0alYzSmxSakZzUm1GTVMyeE5lVkpCVW5KWVVBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xNTAzZTYyOS04ZGJhLTRlOTktODk2MC1lNmY4MDhmNmM4MTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBQemZ3Um9Qc2V0aDA2MEdnOXpOcnYyT1E4OG5zVlF6Sm9TNDdTY3RtVVlxVkl4YTFuZEFXQ3NMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2606"
+      - "2604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:43 GMT
+      - Tue, 07 Nov 2023 16:00:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8692,7 +6448,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce04ea51-e7de-4ad3-be71-192d8d219a3e
+      - ad1f2344-d086-499c-8991-3a06896f71ab
     status: 200 OK
     code: 200
     duration: ""
@@ -8703,19 +6459,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:50:38.103012Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:04.880743Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "601"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:43 GMT
+      - Tue, 07 Nov 2023 16:00:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8725,7 +6481,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f48002e-29d5-4cde-8766-13a0c9030acd
+      - dd187491-968e-4925-8c34-07f36611218f
     status: 200 OK
     code: 200
     duration: ""
@@ -8736,19 +6492,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:41:12.895030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:00:06.709931Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "624"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:43 GMT
+      - Tue, 07 Nov 2023 16:00:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8758,7 +6514,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ee6cfa9-0feb-48be-b09e-b778b04f5983
+      - 71ea0fd1-25bb-4ea7-a5f9-ee6f0d755bdf
     status: 200 OK
     code: 200
     duration: ""
@@ -8769,19 +6525,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/nodes?order_by=created_at_asc&page=1&pool_id=d29afef8-724f-493c-ad4c-f3e176e9a0e6&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=183e6c65-4884-4dd9-8252-5d4e66a2172f&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:41:20.856069Z","error_message":null,"id":"bec60012-8e36-409e-b48f-d00017d8d201","name":"scw-test-pool-wait-test-pool-wait-2-bec600128e","pool_id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","provider_id":"scaleway://instance/fr-par-1/ba6d3b71-abd8-497e-90d6-7041ac2e6679","public_ip_v4":"163.172.141.90","public_ip_v6":null,"region":"fr-par","status":"deleting","updated_at":"2023-10-19T16:50:37.394144Z"},{"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:46:21.965829Z","error_message":null,"id":"d5ba2835-2da7-4d71-9623-e11a52e57d3c","name":"scw-test-pool-wait-test-pool-wait-2-d5ba28352d","pool_id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","provider_id":"scaleway://instance/fr-par-1/0e6d7db5-8984-4294-bf08-4f8f12c6e14b","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:50:38.006085Z"}],"total_count":2}'
+    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:46.900209Z","error_message":null,"id":"fce7c559-26ef-4f5d-9d15-b3eb6fb9a512","name":"scw-test-pool-wait-test-pool-wait-fce7c55926ef","pool_id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","provider_id":"scaleway://instance/fr-par-1/0b2e1b88-152b-43d2-980b-40f8d38acf79","public_ip_v4":"51.15.204.118","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:00:06.585129Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1325"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:43 GMT
+      - Tue, 07 Nov 2023 16:00:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8791,7 +6547,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ff262aa-4381-40b4-8f2c-f1d6f94fab7d
+      - 13805fa5-b066-4cfa-b5b4-ca126ab95e04
     status: 200 OK
     code: 200
     duration: ""
@@ -8802,19 +6558,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/nodes?order_by=created_at_asc&page=1&pool_id=34a36b69-f6e4-4279-8f74-c49a6213083c&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=f1ca093a-20e5-4b4c-a4f9-d813489a65f2&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:36:27.777812Z","error_message":null,"id":"b0a9dc5d-be0e-41bf-b5ce-e13680526495","name":"scw-test-pool-wait-test-pool-wait-b0a9dc5dbe0e","pool_id":"34a36b69-f6e4-4279-8f74-c49a6213083c","provider_id":"scaleway://instance/fr-par-1/456dcdc2-0d49-445e-ba9c-5a4039a43c73","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:50:37.957878Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:54:10.603081Z","error_message":null,"id":"9ff54354-1ce7-4896-9313-5142f745c072","name":"scw-test-pool-wait-test-pool-wait-2-9ff543541c","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/09c29c57-d383-4480-be2c-6ca76739d4ef","public_ip_v4":"51.158.103.0","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:00:06.624693Z"},{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:57:00.507854Z","error_message":null,"id":"7f04dc1b-819c-4dea-a5d9-5ccf4b3aef51","name":"scw-test-pool-wait-test-pool-wait-2-7f04dc1b81","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/51839c89-cedd-47b6-bef1-3e074ba2a6b2","public_ip_v4":"163.172.142.33","public_ip_v6":null,"region":"fr-par","status":"deleting","updated_at":"2023-11-07T16:00:06.080164Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "689"
+      - "1287"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:43 GMT
+      - Tue, 07 Nov 2023 16:00:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8824,7 +6580,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62ebca11-effd-4f1e-acfe-56c2fca35e41
+      - d2025115-6af1-4b93-9956-20d65b91bcb3
     status: 200 OK
     code: 200
     duration: ""
@@ -8835,19 +6591,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/882a0149-d4f0-470c-8a36-650eb9f9c627
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/adb8e568-6480-4b18-8b5c-3657e59e7a65
     method: GET
   response:
-    body: '{"created_at":"2023-10-19T16:34:41.054613Z","dhcp_enabled":true,"id":"882a0149-d4f0-470c-8a36-650eb9f9c627","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-19T16:34:41.054613Z","id":"29e823e2-bb1a-4e49-b0e6-726aeafb43b6","subnet":"172.16.4.0/22","updated_at":"2023-10-19T16:34:41.054613Z"},{"created_at":"2023-10-19T16:34:41.054613Z","id":"57b44457-ecb1-48e2-86a5-5d7cf356e438","subnet":"fd63:256c:45f7:d0e7::/64","updated_at":"2023-10-19T16:34:41.054613Z"}],"tags":[],"updated_at":"2023-10-19T16:34:41.054613Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T15:49:50.750080Z","dhcp_enabled":true,"id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","name":"test-pool-wait","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.750080Z","id":"0ba95cf8-45ba-4034-a2d0-045b3eb427fa","subnet":"172.16.60.0/22","updated_at":"2023-11-07T15:49:50.750080Z"},{"created_at":"2023-11-07T15:49:50.750080Z","id":"118694f9-3fe6-4789-b1fd-522e5b081392","subnet":"fd5f:519c:6d46:6cdc::/64","updated_at":"2023-11-07T15:49:50.750080Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.750080Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "714"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:43 GMT
+      - Tue, 07 Nov 2023 16:00:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8857,7 +6613,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8770af39-d3c6-4f68-b01e-574d1bc20b0f
+      - cf8fe6f3-a3eb-4cca-8abb-09b9dc01b558
     status: 200 OK
     code: 200
     duration: ""
@@ -8868,19 +6624,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:50:38.103012Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T16:00:06.709931Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "626"
+      - "603"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:43 GMT
+      - Tue, 07 Nov 2023 16:00:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8890,7 +6646,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b14d516a-892f-42c4-a7fa-7e9298b19775
+      - 012abab4-6f13-456c-b580-b7921e1994c1
     status: 200 OK
     code: 200
     duration: ""
@@ -8901,19 +6657,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900976Z","created_at":"2023-10-19T16:34:42.900976Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:36:09.161891Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1494"
+      - "1449"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:43 GMT
+      - Tue, 07 Nov 2023 16:00:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8923,7 +6679,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d6329a2-5d89-4299-bfdd-cd7b44cd1bc4
+      - 0efb248e-6aa4-4c1f-9cd4-04756e05afe5
     status: 200 OK
     code: 200
     duration: ""
@@ -8934,19 +6690,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/nodes?order_by=created_at_asc&page=1&pool_id=d29afef8-724f-493c-ad4c-f3e176e9a0e6&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=f1ca093a-20e5-4b4c-a4f9-d813489a65f2&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:41:20.856069Z","error_message":null,"id":"bec60012-8e36-409e-b48f-d00017d8d201","name":"scw-test-pool-wait-test-pool-wait-2-bec600128e","pool_id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","provider_id":"scaleway://instance/fr-par-1/ba6d3b71-abd8-497e-90d6-7041ac2e6679","public_ip_v4":"163.172.141.90","public_ip_v6":null,"region":"fr-par","status":"deleting","updated_at":"2023-10-19T16:50:37.394144Z"},{"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:46:21.965829Z","error_message":null,"id":"d5ba2835-2da7-4d71-9623-e11a52e57d3c","name":"scw-test-pool-wait-test-pool-wait-2-d5ba28352d","pool_id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","provider_id":"scaleway://instance/fr-par-1/0e6d7db5-8984-4294-bf08-4f8f12c6e14b","public_ip_v4":"163.172.161.126","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:50:38.006085Z"}],"total_count":2}'
+    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:54:10.603081Z","error_message":null,"id":"9ff54354-1ce7-4896-9313-5142f745c072","name":"scw-test-pool-wait-test-pool-wait-2-9ff543541c","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/09c29c57-d383-4480-be2c-6ca76739d4ef","public_ip_v4":"51.158.103.0","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:00:06.624693Z"},{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:57:00.507854Z","error_message":null,"id":"7f04dc1b-819c-4dea-a5d9-5ccf4b3aef51","name":"scw-test-pool-wait-test-pool-wait-2-7f04dc1b81","pool_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","provider_id":"scaleway://instance/fr-par-1/51839c89-cedd-47b6-bef1-3e074ba2a6b2","public_ip_v4":"163.172.142.33","public_ip_v6":null,"region":"fr-par","status":"deleting","updated_at":"2023-11-07T16:00:06.080164Z"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1325"
+      - "1287"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:43 GMT
+      - Tue, 07 Nov 2023 16:00:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8956,7 +6712,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d727c22-9c06-4a45-894b-bb134198dbdc
+      - 822bb034-39c9-47e4-961a-1a9046f6398a
     status: 200 OK
     code: 200
     duration: ""
@@ -8967,19 +6723,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaFBSRVV5VFhwUk1FNUdiMWhFVkUxNlRWUkJlRTlFUlRKTmVsRXdUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyWnpDa05OZEVoTlNETm9lRW96Tm0xNlJtVjBlbWhXVlRKNE5WbHhlWGhvVEZsMGVtSkRjR0ZQYUhKRGIwdzVhREpQU2xoMlpraFVUbkk1SzNka1RESjVSM2dLTmxKVEwyWmtVMmQxVm5WWGFtTmhTVkZYVkVaMWFFSlJaMWxFVERGdWVIZFVXbXRvVTBoVGR6RmhORzVIUzBzNWRpdDNObU0zYlVWaGFYWlNZWElyVUFwbmJrWlpjSEU1WkZGNmRXSXJZbGRKY1ROcE1XOVZjblpKYjNKNE5XeGhZV2cxY0VObWRHSllWMFpXTkVNMVRYQlRXa00yVTNCdldFaFdPR3gzVFRWQkNsVjNSSGRzV0c1UVQyNHdTVEJMVFV3MFpFNUtVVmxaVlU5UlEzTmFSVmsyYmpoNGVUSm1iMGwyUVZWbFYwbG5UR2xNV1V0SWJrUXZWRmg2VUhGRFIyWUtlVUk1V1ZkTWEzQnhhREZTT1hrMVRrOXNOWEYwUlVSSk9GRkZNMDlyWm10cEswbFJSVVZCU0VablVYUkVRbGRUTDJ4QlkydFNkVmd2Yms5WFJsVndiQXB4WW1RMEx6QjBZbWRZVEU1TVdYQTBSbEpyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGUkdKb1JXSTBiVnBJYVVGMmVIbHhUSGcyWnpaNE5YcGxUM3BOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEWkdGT2VGTnBiV05pVDNsdGQza3dUVWczV25CT05XNXZWRll6U2xKT2MxRjFhamROTURkeVEyaFdORVpuYmpSM1V3cE5UMnRxYUhkcFZVcGlLMDU2YVVoMVoxWjRjSGxLT0RCeVNVOUhWMFE0VWxCTmNGSndUMlUxWTBOalZuVlJlbEI0YXpJNVZFVnRUVmt2UWxSc1pGTlhDbUo0YTNkVmJVNDVkV1JaZUcweWNsRjRWbGxtY2toTFRrZ3lhamxJTUdkak9XMHdVbFpMVld3NFRVeHZOM3BMYVhjMGNsSnZjVUk0UVcxUFdqWkRMMElLUm1OR2RUSlJjM1JwU1VOamRqazBVME5YVmpGdGMwSTFUVFF4YVhSdGFFdHJZVVp4VEd0M1IzbG5SemxLSzJZeldEaGFVVEJHUW1oVGVqQTVkak5KY3dwck4yWnVhRlpQUkRaTGNHdHVWa1kyZW1wNldGWk5VbTgxUW5wUk55OVpNVXREVVdsdWNVRkJlU3RFUjB4RFl6TkdkV28xWm5WcE5HaDNkRlZSVW1VekNqaHJhV29yUkN0bWJVeDRiMDUyYUU4M1dFd3JUMDVPYTI5UFFpODJRVmx4T0VWYVRRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly83MGRlMDY0Yi1kZDZkLTQxZDEtYjk5Ny03MDVlMTE1NmRiZjEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBGZ1VqUGRuem5pWE1GajFHN0V3MzdtZXdqY0pyNTZqS0EyVTVvRm5YQ2tMaFB4a0l5Wkk3U2diSQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6TTJDbnBhVlU4eWRWVlpkMVIxYTB4QlEzRnhZMWhsYmxaTWNtaHVOMEozV0ZreGNFcHNiRVJhVFRCbFIyeERhMlZRTUhaMVRFbEJWbmhDYlhkRWEySk9VRm9LUldaMWFHZGlZbXgyZGtkUmIyZHRjVzk2UVZGTU9HNVNVRk5wYVZGblEwNHdRM2t6VjJ4Q05sUTRhV3RRT0hkV1JtdG5ZV2h6VjJoTldISnJSWEpyZFFvclJVUlNPR2h2TVhSSFJTOUdZemxQV1VKc1lYQXJSMDQyTTJGMU4wVlVZVFkzVkhGdVJVUnhhakZ1VlM5blpuTkhSMHMxTTFsSlEyaDNNbGxuVWtOMkNrSjVWSGxZSzJkS01FazBhMGgyYVRGR1F6QmFNME54UjNkblJHeFBibmQzWmt0NVJEbElkMGhETkZkTWMyWmxTVkJDVkZaS2JVMUhjbnA2ZUhkaVZUQUtkVVZOVHpoNkt6aFpWRzU1WW5Rek9FcE1hMEozWkdORk9UVnFiREZFWnpZM2IwbGlPRzVPWmt0ME4xWlpWa1YwVW5GWlZXcFZLM1VyWVhkUFVtVXhLd3A2ZW5wV1ZETnllWG80V2xoUFlYVXJPVU00UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIWVhKaGRqTlNSbTV2VURKRldXbGFWVTlGWkVKTFJrVjZia1pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCUjJ4dmIydFJUVE5rV1V4RE5tNHJhRUpaYjBoS1pEVkZOVlZyUzJkVEt6WktRMUJ4TW14aVozWmFOR2xxUVRWMGRncG5VWFpNYVUxclFqaGpaR3hvYW1wWUwwTlNNbTFPWkhKTmNFUjBjRlpqVmxoV1kwTnpWM0F2ZHk5blFtTk9kbnA1ZUROaVkybFJkVEp3V25kWFpTdDRDbXBhVDNCYVMzbEpObmhOUnpKdGEzRndNSGhVSzI5TFFpODJNblpVTjJGVGNHZzNWemc1TWpjeVQzaERSR2haUkd0U1RrTkJZMFkyV1dJNVZGTjBWamtLV0RkMVFXZHJNRE16VWpNd1NYUXJiSGhoVlRsalRIaEpWMHh1VGxGTVYwdzJMM3BTVERkcWMyYzJiR1pvUkZvNWVqSXpkRkZ3WlZGVWVtZDZSa1phYmdwek4xaFdlalIwT1RaRk1rSnFPRzh5VG5KcFMwZHZhbXcxTUZkRk5sVjFUM2xvUm5CTGNtMHhSMmxRU205blNqVXZhMUpqU2xoTmNWRllORUZWYWxjM0NrSjZVbU5WUW1Od1dsRllialJRVEV0alYzSmxSakZzUm1GTVMyeE5lVkpCVW5KWVVBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xNTAzZTYyOS04ZGJhLTRlOTktODk2MC1lNmY4MDhmNmM4MTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBQemZ3Um9Qc2V0aDA2MEdnOXpOcnYyT1E4OG5zVlF6Sm9TNDdTY3RtVVlxVkl4YTFuZEFXQ3NMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2606"
+      - "2604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:43 GMT
+      - Tue, 07 Nov 2023 16:00:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -8989,7 +6745,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed96ba52-8e50-4673-ac46-c6c0a72ae047
+      - ca3a5aa0-8fc4-4a8a-8111-d5aec900e5e4
     status: 200 OK
     code: 200
     duration: ""
@@ -9000,19 +6756,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: GET
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:41:12.895030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:04.880743Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "624"
+      - "601"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:43 GMT
+      - Tue, 07 Nov 2023 16:00:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9022,7 +6778,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9bca726c-52e9-477e-87ed-9b75e1057bf1
+      - d898751d-88ef-4ce7-a00d-54f68c8140b4
     status: 200 OK
     code: 200
     duration: ""
@@ -9033,19 +6789,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/nodes?order_by=created_at_asc&page=1&pool_id=34a36b69-f6e4-4279-8f74-c49a6213083c&status=unknown
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=183e6c65-4884-4dd9-8252-5d4e66a2172f&status=unknown
     method: GET
   response:
-    body: '{"nodes":[{"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:36:27.777812Z","error_message":null,"id":"b0a9dc5d-be0e-41bf-b5ce-e13680526495","name":"scw-test-pool-wait-test-pool-wait-b0a9dc5dbe0e","pool_id":"34a36b69-f6e4-4279-8f74-c49a6213083c","provider_id":"scaleway://instance/fr-par-1/456dcdc2-0d49-445e-ba9c-5a4039a43c73","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:50:37.957878Z"}],"total_count":1}'
+    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:46.900209Z","error_message":null,"id":"fce7c559-26ef-4f5d-9d15-b3eb6fb9a512","name":"scw-test-pool-wait-test-pool-wait-fce7c55926ef","pool_id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","provider_id":"scaleway://instance/fr-par-1/0b2e1b88-152b-43d2-980b-40f8d38acf79","public_ip_v4":"51.15.204.118","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:00:06.585129Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "689"
+      - "670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:44 GMT
+      - Tue, 07 Nov 2023 16:00:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9055,7 +6811,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55afe2a0-d05f-463a-941f-7502f7cd65b5
+      - 8ada9bec-7f7a-46b7-b607-db5acce59fb3
     status: 200 OK
     code: 200
     duration: ""
@@ -9066,19 +6822,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/d29afef8-724f-493c-ad4c-f3e176e9a0e6
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: DELETE
   response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:41:20.399222Z","id":"d29afef8-724f-493c-ad4c-f3e176e9a0e6","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-10-19T16:50:44.588507160Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:00:15.225313332Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "632"
+      - "609"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:44 GMT
+      - Tue, 07 Nov 2023 16:00:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9088,7 +6844,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8bea73e-2814-40de-8bc7-95557638a40f
+      - 0593f85f-a24d-4321-9bd1-d924cbd6b26a
     status: 200 OK
     code: 200
     duration: ""
@@ -9099,19 +6855,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900976Z","created_at":"2023-10-19T16:34:42.900976Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:36:09.161891Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:00:15.225313Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1494"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:44 GMT
+      - Tue, 07 Nov 2023 16:00:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9121,7 +6877,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6dbfcea2-78f3-481f-82b6-2e4a5d495397
+      - 5e30fe6f-2a58-42e2-bebd-5df7ca60a086
     status: 200 OK
     code: 200
     duration: ""
@@ -9132,19 +6888,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/882a0149-d4f0-470c-8a36-650eb9f9c627
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"created_at":"2023-10-19T16:34:41.054613Z","dhcp_enabled":true,"id":"882a0149-d4f0-470c-8a36-650eb9f9c627","name":"test-pool-wait","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-19T16:34:41.054613Z","id":"29e823e2-bb1a-4e49-b0e6-726aeafb43b6","subnet":"172.16.4.0/22","updated_at":"2023-10-19T16:34:41.054613Z"},{"created_at":"2023-10-19T16:34:41.054613Z","id":"57b44457-ecb1-48e2-86a5-5d7cf356e438","subnet":"fd63:256c:45f7:d0e7::/64","updated_at":"2023-10-19T16:34:41.054613Z"}],"tags":[],"updated_at":"2023-10-19T16:34:41.054613Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:00:15.225313Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "714"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:45 GMT
+      - Tue, 07 Nov 2023 16:00:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9154,7 +6910,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4139612b-5fec-4ce2-82e3-6cbcbab6366e
+      - 2f30b27d-db1f-46f9-998a-8403cdf47fef
     status: 200 OK
     code: 200
     duration: ""
@@ -9165,19 +6921,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900976Z","created_at":"2023-10-19T16:34:42.900976Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:36:09.161891Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:54:10.121395Z","id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait-2","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:00:15.225313Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1494"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:45 GMT
+      - Tue, 07 Nov 2023 16:00:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9187,7 +6943,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1c2502b-5f92-4697-8c06-173b0e6b3d75
+      - 53afee9e-d6eb-4678-b838-f4feb3bb4544
     status: 200 OK
     code: 200
     duration: ""
@@ -9198,19 +6954,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f1ca093a-20e5-4b4c-a4f9-d813489a65f2
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaFBSRVV5VFhwUk1FNUdiMWhFVkUxNlRWUkJlRTlFUlRKTmVsRXdUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlQyWnpDa05OZEVoTlNETm9lRW96Tm0xNlJtVjBlbWhXVlRKNE5WbHhlWGhvVEZsMGVtSkRjR0ZQYUhKRGIwdzVhREpQU2xoMlpraFVUbkk1SzNka1RESjVSM2dLTmxKVEwyWmtVMmQxVm5WWGFtTmhTVkZYVkVaMWFFSlJaMWxFVERGdWVIZFVXbXRvVTBoVGR6RmhORzVIUzBzNWRpdDNObU0zYlVWaGFYWlNZWElyVUFwbmJrWlpjSEU1WkZGNmRXSXJZbGRKY1ROcE1XOVZjblpKYjNKNE5XeGhZV2cxY0VObWRHSllWMFpXTkVNMVRYQlRXa00yVTNCdldFaFdPR3gzVFRWQkNsVjNSSGRzV0c1UVQyNHdTVEJMVFV3MFpFNUtVVmxaVlU5UlEzTmFSVmsyYmpoNGVUSm1iMGwyUVZWbFYwbG5UR2xNV1V0SWJrUXZWRmg2VUhGRFIyWUtlVUk1V1ZkTWEzQnhhREZTT1hrMVRrOXNOWEYwUlVSSk9GRkZNMDlyWm10cEswbFJSVVZCU0VablVYUkVRbGRUTDJ4QlkydFNkVmd2Yms5WFJsVndiQXB4WW1RMEx6QjBZbWRZVEU1TVdYQTBSbEpyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpGUkdKb1JXSTBiVnBJYVVGMmVIbHhUSGcyWnpaNE5YcGxUM3BOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEWkdGT2VGTnBiV05pVDNsdGQza3dUVWczV25CT05XNXZWRll6U2xKT2MxRjFhamROTURkeVEyaFdORVpuYmpSM1V3cE5UMnRxYUhkcFZVcGlLMDU2YVVoMVoxWjRjSGxLT0RCeVNVOUhWMFE0VWxCTmNGSndUMlUxWTBOalZuVlJlbEI0YXpJNVZFVnRUVmt2UWxSc1pGTlhDbUo0YTNkVmJVNDVkV1JaZUcweWNsRjRWbGxtY2toTFRrZ3lhamxJTUdkak9XMHdVbFpMVld3NFRVeHZOM3BMYVhjMGNsSnZjVUk0UVcxUFdqWkRMMElLUm1OR2RUSlJjM1JwU1VOamRqazBVME5YVmpGdGMwSTFUVFF4YVhSdGFFdHJZVVp4VEd0M1IzbG5SemxLSzJZeldEaGFVVEJHUW1oVGVqQTVkak5KY3dwck4yWnVhRlpQUkRaTGNHdHVWa1kyZW1wNldGWk5VbTgxUW5wUk55OVpNVXREVVdsdWNVRkJlU3RFUjB4RFl6TkdkV28xWm5WcE5HaDNkRlZSVW1VekNqaHJhV29yUkN0bWJVeDRiMDUyYUU4M1dFd3JUMDVPYTI5UFFpODJRVmx4T0VWYVRRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly83MGRlMDY0Yi1kZDZkLTQxZDEtYjk5Ny03MDVlMTE1NmRiZjEuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBGZ1VqUGRuem5pWE1GajFHN0V3MzdtZXdqY0pyNTZqS0EyVTVvRm5YQ2tMaFB4a0l5Wkk3U2diSQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"f1ca093a-20e5-4b4c-a4f9-d813489a65f2","type":"not_found"}'
     headers:
       Content-Length:
-      - "2606"
+      - "125"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:50:45 GMT
+      - Tue, 07 Nov 2023 16:00:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9220,304 +6976,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af696075-b555-413e-b797-1595399c3ae2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
-    method: GET
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-10-19T16:41:12.895030Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "624"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bee2abb3-e7ea-4693-8794-21b7cbda25c5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1/nodes?order_by=created_at_asc&page=1&pool_id=34a36b69-f6e4-4279-8f74-c49a6213083c&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-19T16:36:27.777812Z","error_message":null,"id":"b0a9dc5d-be0e-41bf-b5ce-e13680526495","name":"scw-test-pool-wait-test-pool-wait-b0a9dc5dbe0e","pool_id":"34a36b69-f6e4-4279-8f74-c49a6213083c","provider_id":"scaleway://instance/fr-par-1/456dcdc2-0d49-445e-ba9c-5a4039a43c73","public_ip_v4":"51.158.117.252","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-19T16:50:45.081910Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "689"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0a523495-49ce-44db-b7b6-01fcfa9ee093
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/34a36b69-f6e4-4279-8f74-c49a6213083c
-    method: DELETE
-  response:
-    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","container_runtime":"containerd","created_at":"2023-10-19T16:34:48.387741Z","id":"34a36b69-f6e4-4279-8f74-c49a6213083c","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-10-19T16:50:46.130256812Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "630"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7c512651-1cb8-40fc-98cd-203536bce548
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1?with_additional_resources=true
-    method: DELETE
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900976Z","created_at":"2023-10-19T16:34:42.900976Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:50:46.219496283Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1500"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 26d2a9c8-b1f4-4ec3-a5b6-c225d6e7c18d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900976Z","created_at":"2023-10-19T16:34:42.900976Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:50:46.219496Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1497"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c0398616-9e14-4485-9ff2-29dabe59bb11
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900976Z","created_at":"2023-10-19T16:34:42.900976Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:50:46.219496Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1497"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 061e526b-c5cb-4656-bb4f-5f823d33af63
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900976Z","created_at":"2023-10-19T16:34:42.900976Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:50:46.219496Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1497"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:50:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0de805c3-b787-4b1e-aa3f-26926196091d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://70de064b-dd6d-41d1-b997-705e1156dbf1.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-19T16:34:42.900976Z","created_at":"2023-10-19T16:34:42.900976Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.70de064b-dd6d-41d1-b997-705e1156dbf1.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"70de064b-dd6d-41d1-b997-705e1156dbf1","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-10-19T16:50:46.219496Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1497"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:51:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8e414647-df1e-489a-a5c4-776a01e4cee0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "128"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 19 Oct 2023 16:51:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fa8964f5-74ef-4355-a7e1-016a4c3264a4
+      - 69cde916-cbce-48f0-8723-c2c676ef1b71
     status: 404 Not Found
     code: 404
     duration: ""
@@ -9528,10 +6987,505 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/882a0149-d4f0-470c-8a36-650eb9f9c627
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1449"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:00:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6214a99b-d770-42fd-ae11-0183f7a05700
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/adb8e568-6480-4b18-8b5c-3657e59e7a65
+    method: GET
+  response:
+    body: '{"created_at":"2023-11-07T15:49:50.750080Z","dhcp_enabled":true,"id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","name":"test-pool-wait","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-07T15:49:50.750080Z","id":"0ba95cf8-45ba-4034-a2d0-045b3eb427fa","subnet":"172.16.60.0/22","updated_at":"2023-11-07T15:49:50.750080Z"},{"created_at":"2023-11-07T15:49:50.750080Z","id":"118694f9-3fe6-4789-b1fd-522e5b081392","subnet":"fd5f:519c:6d46:6cdc::/64","updated_at":"2023-11-07T15:49:50.750080Z"}],"tags":[],"updated_at":"2023-11-07T15:49:50.750080Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "698"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:00:31 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2216ddf9-2578-498f-966c-f015c3b4efbf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T15:51:28.195874Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1449"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:00:31 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0f5d54a1-bd1f-452d-9b98-42bd8fe09deb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC13YWl0IgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V4VGtSck1VNUdiMWhFVkUxNlRWUkZkMDVxUlRGT1JHc3hUa1p2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlR6TTJDbnBhVlU4eWRWVlpkMVIxYTB4QlEzRnhZMWhsYmxaTWNtaHVOMEozV0ZreGNFcHNiRVJhVFRCbFIyeERhMlZRTUhaMVRFbEJWbmhDYlhkRWEySk9VRm9LUldaMWFHZGlZbXgyZGtkUmIyZHRjVzk2UVZGTU9HNVNVRk5wYVZGblEwNHdRM2t6VjJ4Q05sUTRhV3RRT0hkV1JtdG5ZV2h6VjJoTldISnJSWEpyZFFvclJVUlNPR2h2TVhSSFJTOUdZemxQV1VKc1lYQXJSMDQyTTJGMU4wVlVZVFkzVkhGdVJVUnhhakZ1VlM5blpuTkhSMHMxTTFsSlEyaDNNbGxuVWtOMkNrSjVWSGxZSzJkS01FazBhMGgyYVRGR1F6QmFNME54UjNkblJHeFBibmQzWmt0NVJEbElkMGhETkZkTWMyWmxTVkJDVkZaS2JVMUhjbnA2ZUhkaVZUQUtkVVZOVHpoNkt6aFpWRzU1WW5Rek9FcE1hMEozWkdORk9UVnFiREZFWnpZM2IwbGlPRzVPWmt0ME4xWlpWa1YwVW5GWlZXcFZLM1VyWVhkUFVtVXhLd3A2ZW5wV1ZETnllWG80V2xoUFlYVXJPVU00UTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpIWVhKaGRqTlNSbTV2VURKRldXbGFWVTlGWkVKTFJrVjZia1pOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCUjJ4dmIydFJUVE5rV1V4RE5tNHJhRUpaYjBoS1pEVkZOVlZyUzJkVEt6WktRMUJ4TW14aVozWmFOR2xxUVRWMGRncG5VWFpNYVUxclFqaGpaR3hvYW1wWUwwTlNNbTFPWkhKTmNFUjBjRlpqVmxoV1kwTnpWM0F2ZHk5blFtTk9kbnA1ZUROaVkybFJkVEp3V25kWFpTdDRDbXBhVDNCYVMzbEpObmhOUnpKdGEzRndNSGhVSzI5TFFpODJNblpVTjJGVGNHZzNWemc1TWpjeVQzaERSR2haUkd0U1RrTkJZMFkyV1dJNVZGTjBWamtLV0RkMVFXZHJNRE16VWpNd1NYUXJiSGhoVlRsalRIaEpWMHh1VGxGTVYwdzJMM3BTVERkcWMyYzJiR1pvUkZvNWVqSXpkRkZ3WlZGVWVtZDZSa1phYmdwek4xaFdlalIwT1RaRk1rSnFPRzh5VG5KcFMwZHZhbXcxTUZkRk5sVjFUM2xvUm5CTGNtMHhSMmxRU205blNqVXZhMUpqU2xoTmNWRllORUZWYWxjM0NrSjZVbU5WUW1Od1dsRllialJRVEV0alYzSmxSakZzUm1GTVMyeE5lVkpCVW5KWVVBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly8xNTAzZTYyOS04ZGJhLTRlOTktODk2MC1lNmY4MDhmNmM4MTkuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXdhaXQKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC13YWl0IgogICAgdXNlcjogdGVzdC1wb29sLXdhaXQtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtd2FpdApraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC13YWl0LWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBQemZ3Um9Qc2V0aDA2MEdnOXpOcnYyT1E4OG5zVlF6Sm9TNDdTY3RtVVlxVkl4YTFuZEFXQ3NMcQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2604"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:00:31 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8226b92e-2619-4cd5-9266-5ffef9402838
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":[],"updated_at":"2023-11-07T15:54:04.880743Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "601"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:00:31 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 17134064-6aa2-4c3b-900f-8743f3ff869a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819/nodes?order_by=created_at_asc&page=1&pool_id=183e6c65-4884-4dd9-8252-5d4e66a2172f&status=unknown
+    method: GET
+  response:
+    body: '{"nodes":[{"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","conditions":{"DiskPressure":"False","MemoryPressure":"False","NetworkUnavailable":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T15:51:46.900209Z","error_message":null,"id":"fce7c559-26ef-4f5d-9d15-b3eb6fb9a512","name":"scw-test-pool-wait-test-pool-wait-fce7c55926ef","pool_id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","provider_id":"scaleway://instance/fr-par-1/0b2e1b88-152b-43d2-980b-40f8d38acf79","public_ip_v4":"51.15.204.118","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:00:15.784704Z"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "670"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:00:31 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 93d1a95b-9ae4-4cac-9e76-ae4690659517
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"882a0149-d4f0-470c-8a36-650eb9f9c627","type":"not_found"}'
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:00:31.946282098Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "607"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:00:31 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9d85ce3d-0e4d-42dc-8783-5e38e52e387d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:00:31.946282Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "604"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:00:32 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0f1e9209-2f22-4973-b502-6cf764173329
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:00:31.946282Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "604"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:00:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d4da368f-eba8-4aa2-842d-409ac53c095e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:00:31.946282Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "604"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:00:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f6aff95d-70f4-4983-b1cf-65efae1b813a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    method: GET
+  response:
+    body: '{"autohealing":false,"autoscaling":false,"cluster_id":"1503e629-8dba-4e99-8960-e6f808f6c819","container_runtime":"containerd","created_at":"2023-11-07T15:49:58.333551Z","id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-wait","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":[],"updated_at":"2023-11-07T16:00:31.946282Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "604"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:00:47 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 99caef14-9459-4747-b1e9-64838ba00071
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/183e6c65-4884-4dd9-8252-5d4e66a2172f
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"183e6c65-4884-4dd9-8252-5d4e66a2172f","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "125"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:00:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1200c82f-21d4-4aec-aed2-7a6aa1552a33
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819?with_additional_resources=true
+    method: DELETE
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:00:52.259085594Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1455"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:00:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 880c3c58-27cc-407c-8287-12cc73f93371
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://1503e629-8dba-4e99-8960-e6f808f6c819.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T15:49:52.856393Z","created_at":"2023-11-07T15:49:52.856393Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.1503e629-8dba-4e99-8960-e6f808f6c819.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"1503e629-8dba-4e99-8960-e6f808f6c819","ingress":"none","name":"test-pool-wait","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","minimal"],"type":"kapsule","updated_at":"2023-11-07T16:00:52.259086Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1452"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:00:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dd00b7ce-afc9-4bba-8aee-4a3056b08b99
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"1503e629-8dba-4e99-8960-e6f808f6c819","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:00:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6f11b26c-a447-47fa-b5a4-6bb1737a2870
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/adb8e568-6480-4b18-8b5c-3657e59e7a65
+    method: DELETE
+  response:
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"adb8e568-6480-4b18-8b5c-3657e59e7a65","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -9540,7 +7494,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:06 GMT
+      - Tue, 07 Nov 2023 16:00:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9550,7 +7504,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06fb7a82-8e2e-46e8-866c-1d75ae95f04e
+      - 604c35f9-04c4-4de6-abba-b91a0548c7fa
     status: 404 Not Found
     code: 404
     duration: ""
@@ -9561,10 +7515,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/70de064b-dd6d-41d1-b997-705e1156dbf1
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1503e629-8dba-4e99-8960-e6f808f6c819
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"70de064b-dd6d-41d1-b997-705e1156dbf1","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"1503e629-8dba-4e99-8960-e6f808f6c819","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -9573,7 +7527,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 19 Oct 2023 16:51:06 GMT
+      - Tue, 07 Nov 2023 16:00:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -9583,7 +7537,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bc67a70-fb66-41b0-8b64-e69cbeb485e4
+      - e609325a-7943-4d96-9e90-aded8fc478a7
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-pool-zone.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-pool-zone.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:41 GMT
+      - Tue, 07 Nov 2023 16:19:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,12 +34,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03a4c874-5538-4359-8e29-e15d639f01ba
+      - 1e20b14f-1c37-45fd-a910-c256192084c9
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-zone","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"test-pool-zone","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-18T16:35:44.620844Z","dhcp_enabled":true,"id":"bbcadfae-9d75-4dbe-9e9d-7fcfa8ce40c3","name":"test-pool-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:35:44.620844Z","id":"76cf3e27-3a4f-46a7-8873-d5b762f56fc0","subnet":"172.16.32.0/22","updated_at":"2023-10-18T16:35:44.620844Z"},{"created_at":"2023-10-18T16:35:44.620844Z","id":"85a6b9d1-979b-4c8e-84fd-e1f4e1b8b73c","subnet":"fd63:256c:45f7:5a8f::/64","updated_at":"2023-10-18T16:35:44.620844Z"}],"tags":[],"updated_at":"2023-10-18T16:35:44.620844Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:19:59.947696Z","dhcp_enabled":true,"id":"1125c396-3316-458b-8e7f-867455a74b50","name":"test-pool-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.947696Z","id":"2d9eec37-8e62-4435-b050-69ba4ce4b6c5","subnet":"172.16.16.0/22","updated_at":"2023-11-07T16:19:59.947696Z"},{"created_at":"2023-11-07T16:19:59.947696Z","id":"1dbc7251-c7f9-439a-bc11-df0c6cfcf3a2","subnet":"fd63:256c:45f7:10e0::/64","updated_at":"2023-11-07T16:19:59.947696Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.947696Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "715"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:45 GMT
+      - Tue, 07 Nov 2023 16:20:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf8a9ab0-621c-4aea-a664-4c830121bce8
+      - 2aeb15ba-d77f-415f-829e-bad7a3965f05
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bbcadfae-9d75-4dbe-9e9d-7fcfa8ce40c3
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1125c396-3316-458b-8e7f-867455a74b50
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:35:44.620844Z","dhcp_enabled":true,"id":"bbcadfae-9d75-4dbe-9e9d-7fcfa8ce40c3","name":"test-pool-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:35:44.620844Z","id":"76cf3e27-3a4f-46a7-8873-d5b762f56fc0","subnet":"172.16.32.0/22","updated_at":"2023-10-18T16:35:44.620844Z"},{"created_at":"2023-10-18T16:35:44.620844Z","id":"85a6b9d1-979b-4c8e-84fd-e1f4e1b8b73c","subnet":"fd63:256c:45f7:5a8f::/64","updated_at":"2023-10-18T16:35:44.620844Z"}],"tags":[],"updated_at":"2023-10-18T16:35:44.620844Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:19:59.947696Z","dhcp_enabled":true,"id":"1125c396-3316-458b-8e7f-867455a74b50","name":"test-pool-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.947696Z","id":"2d9eec37-8e62-4435-b050-69ba4ce4b6c5","subnet":"172.16.16.0/22","updated_at":"2023-11-07T16:19:59.947696Z"},{"created_at":"2023-11-07T16:19:59.947696Z","id":"1dbc7251-c7f9-439a-bc11-df0c6cfcf3a2","subnet":"fd63:256c:45f7:10e0::/64","updated_at":"2023-11-07T16:19:59.947696Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.947696Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "715"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:45 GMT
+      - Tue, 07 Nov 2023 16:20:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0774433-43ec-4537-bdd9-f6f10037a360
+      - e8cca7a3-804e-4183-9927-017eb7fa589a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-zone","description":"","tags":["terraform-test","scaleway_k8s_cluster","zone"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":"bbcadfae-9d75-4dbe-9e9d-7fcfa8ce40c3"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"test-pool-zone","description":"","tags":["terraform-test","scaleway_k8s_cluster","zone"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"1125c396-3316-458b-8e7f-867455a74b50"}'
     form: {}
     headers:
       Content-Type:
@@ -118,16 +118,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f2b97a1-db52-45b1-97f0-782edf34220e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.787648461Z","created_at":"2023-10-18T16:35:45.787648461Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f2b97a1-db52-45b1-97f0-782edf34220e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f2b97a1-db52-45b1-97f0-782edf34220e","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"bbcadfae-9d75-4dbe-9e9d-7fcfa8ce40c3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-10-18T16:35:45.806719535Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.345686427Z","created_at":"2023-11-07T16:20:01.345686427Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1125c396-3316-458b-8e7f-867455a74b50","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-07T16:20:01.353332977Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1503"
+      - "1458"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:45 GMT
+      - Tue, 07 Nov 2023 16:20:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c75b5901-c784-47ce-a265-3d0c1724da53
+      - 3a9222e2-7674-45c2-b3f6-9d9d3a11efdb
     status: 200 OK
     code: 200
     duration: ""
@@ -148,19 +148,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f2b97a1-db52-45b1-97f0-782edf34220e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f2b97a1-db52-45b1-97f0-782edf34220e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.787648Z","created_at":"2023-10-18T16:35:45.787648Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f2b97a1-db52-45b1-97f0-782edf34220e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f2b97a1-db52-45b1-97f0-782edf34220e","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"bbcadfae-9d75-4dbe-9e9d-7fcfa8ce40c3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-10-18T16:35:45.806720Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.345686Z","created_at":"2023-11-07T16:20:01.345686Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1125c396-3316-458b-8e7f-867455a74b50","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-07T16:20:01.353333Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1494"
+      - "1449"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:45 GMT
+      - Tue, 07 Nov 2023 16:20:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1cf6c085-4de6-4883-8036-43309ae792b2
+      - b1af82d2-5d8d-4295-b94b-151e56f208c7
     status: 200 OK
     code: 200
     duration: ""
@@ -181,19 +181,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f2b97a1-db52-45b1-97f0-782edf34220e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f2b97a1-db52-45b1-97f0-782edf34220e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.787648Z","created_at":"2023-10-18T16:35:45.787648Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f2b97a1-db52-45b1-97f0-782edf34220e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f2b97a1-db52-45b1-97f0-782edf34220e","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"bbcadfae-9d75-4dbe-9e9d-7fcfa8ce40c3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-10-18T16:35:47.914979Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.345686Z","created_at":"2023-11-07T16:20:01.345686Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1125c396-3316-458b-8e7f-867455a74b50","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-07T16:20:01.353333Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1499"
+      - "1449"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:50 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df74a584-d9d0-42d0-bf25-616dad1e9296
+      - 99b193af-b64d-4898-bffd-a79a92ef77f1
     status: 200 OK
     code: 200
     duration: ""
@@ -214,19 +214,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f2b97a1-db52-45b1-97f0-782edf34220e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f2b97a1-db52-45b1-97f0-782edf34220e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.787648Z","created_at":"2023-10-18T16:35:45.787648Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f2b97a1-db52-45b1-97f0-782edf34220e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f2b97a1-db52-45b1-97f0-782edf34220e","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"bbcadfae-9d75-4dbe-9e9d-7fcfa8ce40c3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-10-18T16:35:47.914979Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.345686Z","created_at":"2023-11-07T16:20:01.345686Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1125c396-3316-458b-8e7f-867455a74b50","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-07T16:20:07.047402Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1499"
+      - "1454"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 16:20:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0af95ac0-5e5d-43a9-a1ad-c4c001650b78
+      - 0d464817-8438-4ec5-b5fa-57fc1a807864
     status: 200 OK
     code: 200
     duration: ""
@@ -247,19 +247,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f2b97a1-db52-45b1-97f0-782edf34220e/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC16b25lIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VFhwVk1FNHhiMWhFVkUxNlRWUkJlRTU2UlRKTmVsVXdUakZ2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlVIQmhDa05tUnl0Q1NqbDFaV2xZZEVSdFlVUkNRMUpaYUZWc1RIbGtOalUwWW5STlUzbHdkSEZTVUc1TGRFaEVVRzlWUVhGb2VrOUZhSGd3Y0V4VVJHaHFTRVFLU1ZoSWVrbFFObFJJUVRScVFqbFRWRmRHZEVWSWVYVXpVR3hVVVdOVFZFVTVWMWRWV1N0dVR6QndNelo1UkdkSksxSkZkelIzUkdWTWQxbFRPRGRLTlFwUmIwWTVTWGRIV1ZnMGNGVmxOVEJKZHpsYVMyUnhWV2czVkRkNlVFeDZWVGhZTkN0dGVFc3haSHBXUkRsalNsVkhOVWhQSzBWbVIyMVdWVGRtV21abENtVkVObGxKYUhwM1dYZDZRazFQYWxBMGVraFhXWG92WVhKNGNHcHhSR05zTUhkaFpHRXdTV05IYkhOdmRXaDFLMko2TWpabFExZHFlSFpQYURoYU5td0tTMloyUTJZdlNYWkJhVGxZTXpkWmJuRmpSM00wTVhSb1dVaGxiV3BqVkVaUlpqRnNkWFZCWVRNcmF6Z3ZTbEZoY2xWamVtVnljVkZDUldSTlNHaGxad3BsVEdnMVYzbE5kVTlCY1VKdFdFaFdUbGxyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpJSzBrd1YwZEhZbVpCYVRGUU5YUlBaV2haVEZCMlp5OXBSSFZOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCSzNwTFoxQjZLM00wY0RORWNGaEhMM05WUWt4dFpXNDVXRFp3YjFrdmN6WkVTVGxGVkRocVEydDFibk4yUjBoQlpBcDZOR0pxUlhCdlFuRTJOVGRwVm1GMFpEbHVVMWhYZVZCb056VnJPR1Z5VlhRMWFTdEZTbEE0ZEhKd1R6aERXbVZaVDAxVk9WaEtOak51VjBwRWRESnVDbEpRVldoYVlYbGFiRmM0YUdFNGRrbHZkbEJ3TDJVM0t6WmhNRmN3WVVaeWRWVndlV2RtVkROUGRtY3pWMFoxYWxsWU1GVnBVV3Q2YmsxRWNHUkxLMFVLUzJFMk5FUTBaRTFXVDI5VU0wSllPRUp6TUZwbE4yeDNZVGxEY1cxcVluQjFTamxQTUhOWmRTOXVOVmRwYVRoa1QyMDFjV1l2TUhWeFpVWXpLMFpqU2dwcE5ITlNVRWRyZDNkelNXTmtNRGhGVFM5a1kwMXZjMkZPYVRCS01IcG9NRkV6UzFrMVpsUlhkSFpYYlRCRlZuTjFNSFIzV2xGclYzbFJWblptTTFsTENuTXhVa05NYUc5ck1sSTRiVWhpZURVMFJuWnhhR05OVGtKbmNuaE1ZUzlsTmtGc1NRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly80ZjJiOTdhMS1kYjUyLTQ1YjEtOTdmMC03ODJlZGYzNDIyMGUuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXpvbmUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC16b25lIgogICAgdXNlcjogdGVzdC1wb29sLXpvbmUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtem9uZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC16b25lLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB4YWRUdUVUYml3aHltSmFjNmJvQmFLUVUya0JnRXJyYk85T2l6M0hXbUl1azN1WFRUelZ5UDJOWA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.345686Z","created_at":"2023-11-07T16:20:01.345686Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1125c396-3316-458b-8e7f-867455a74b50","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-07T16:20:07.047402Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2606"
+      - "1454"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 16:20:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b319aa6c-248e-4e52-be41-5c22b346aaea
+      - e6213269-2f63-4590-b78b-49febeae9330
     status: 200 OK
     code: 200
     duration: ""
@@ -280,19 +280,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f2b97a1-db52-45b1-97f0-782edf34220e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f2b97a1-db52-45b1-97f0-782edf34220e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.787648Z","created_at":"2023-10-18T16:35:45.787648Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f2b97a1-db52-45b1-97f0-782edf34220e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f2b97a1-db52-45b1-97f0-782edf34220e","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"bbcadfae-9d75-4dbe-9e9d-7fcfa8ce40c3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-10-18T16:35:47.914979Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC16b25lIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwNXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUbXh2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlREUkZDbXc0U25KWFUxbHhXRVpCVmxkamNuTm9hbVpNUkdSWFJEZG9NbXBMZGtaeFdtVXpOU3RyV1hNeGNqZEdTR3hLVGxsclRHbFZWRmROYlZSVlYxbFNSVVFLZDJOb1oxQnlTakpEWmpCWWFIcFFWMVkyY0VST05tNVNXbkpsU0RkTWFsTTJSMWhxVWpCeU5rUTBXR2xUTjBSR05sTm9kemhPYm5sdGMyeGpVbUV3V0FwRWNHWm9aSFJMZERGWFIzZE9kRUYwZFhOeGVWZGhSR0owVG5WeWFsRnVlbXh5VDFCellVRmFSRGRSVXpabmJtcHBkVXhKZWtGWFlscDFZV1pTUVZONkNsSllkamR4TTBsU2RrZGpSa3QyYkhVeGRGVXlkRkJ3V2tOMVJVbFpUekpPVVVVM1JYVkVaRWRTYzA5dWIxaE9WRGRRUm5JMWVXTXZTMnBxTldRNU1Ea0tWSGgyY0hjeFpXRjVORlZKZEhOSGVVaHVhMFV3VmxKMWRsZHpXbmt6T0VsaE5VRktWbE16TDFoblNsZENhR3hKU2tkc0sweG5aV3RFUWtSSldrTmlWd3BOV20xbVNIbFFlbmxYYlVWdlZISnJTRWxOUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpPWkRCSmVYRkZSVGRYTWtoT1pVNXFiV050YURScWFIWlFNV1JOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEVG05R1JGRjVha3hsWmxGdFFtUlZaVmd6WTNWNWEyNTJaMEZuTlRaSU5XOTNWa0p0VlRORVprMHhlbUZrWXpkMVZRcDZlazFYVWxKRVEzWTRhbTlqYWtSWWNVMWlTREZtVG5ocVUyb3dabkl6Y0dSSGJUSlVabXc1VFdVeWFtSk1hMVJyZFVoWlNtOXpUR1YxTHpGdlZuUlBDa2RPYlhaNmMxWlhTR3R3Ym5wamMybFZiekJQTVZwTGJWQldkMFZNU2prMVptTnRRMjVSUkVObFNUbElZVmc0VVZONE5VWnhWakowU210bU15dHpZMDRLUlhkcVZUZHFTalF2U2xkelZFdzBZbEJyUldNeU4zbFVVSGt3UWpSRlJVNW1VekZ1TVVadWJXeE9UbE5zWkhGWVdVUlpkWGhXV0M5UE15OTFWelpoY0FwNE9ETXpSak41ZFRGb0sycGlVRGRJZWs5MFkycE9Mekp5TUdwR2Jtc3plV05UV1V4M2RESk5hR1kyVDJONGFHbEhZVmMxVFN0dWNsazRUV1pUVURkSkNreEZOMkV4YlZGMGFITklSWFkwV1RKNWFYTlplazVvVFRCS1UzRm9NMk41WVhaSmN3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81YmI5ZjA0Zi0wM2YzLTQyMGYtYjFiZi05ZTYxMGVkMmNhZDIuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXpvbmUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC16b25lIgogICAgdXNlcjogdGVzdC1wb29sLXpvbmUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtem9uZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC16b25lLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBLaEZaVnpsdE5pNUF6Vk9DM05wa3JkSFQwYklmMUFacU80d0lKSXNMMGpCN2U4ZEhZRGJZRms3Wg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1499"
+      - "2604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 16:20:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,12 +302,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72b1893c-7a74-49fb-82b9-a2efbe7f620e
+      - da7c4f64-70d8-4d40-bbd7-34f6c62afe04
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"kubelet_args":{},"upgrade_policy":null,"zone":"fr-par-2","root_volume_type":"default_volume_type","root_volume_size":null,"public_ip_disabled":false}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.345686Z","created_at":"2023-11-07T16:20:01.345686Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1125c396-3316-458b-8e7f-867455a74b50","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-07T16:20:07.047402Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1454"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:20:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a65e1f32-f760-4c10-b2a7-a71591af2c03
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"test-pool-zone","node_type":"gp1_xs","autoscaling":true,"size":1,"min_size":1,"max_size":1,"container_runtime":"containerd","autohealing":true,"tags":["terraform-test","scaleway_k8s_cluster","zone"],"kubelet_args":{},"zone":"fr-par-2","root_volume_type":"default_volume_type","public_ip_disabled":false}'
     form: {}
     headers:
       Content-Type:
@@ -315,19 +348,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f2b97a1-db52-45b1-97f0-782edf34220e/pools
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2/pools
     method: POST
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232182853Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786036Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "675"
+      - "650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 16:20:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -337,7 +370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31cb6124-eef7-45ac-b08a-c4ef7140641b
+      - ceedb538-0f1f-4488-a375-6d90bc035b88
     status: 200 OK
     code: 200
     duration: ""
@@ -348,19 +381,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:51 GMT
+      - Tue, 07 Nov 2023 16:20:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -370,7 +403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eac6c717-b2a4-4895-a234-2351a7ff0921
+      - f300452e-7271-426c-88db-ebc6fcbcc657
     status: 200 OK
     code: 200
     duration: ""
@@ -381,19 +414,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:56 GMT
+      - Tue, 07 Nov 2023 16:20:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -403,7 +436,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6fa63a64-2b96-4ac4-8c50-1aa4c1b72abf
+      - fa2d02c0-a7cc-4150-8be3-fd95b42bd3d7
     status: 200 OK
     code: 200
     duration: ""
@@ -414,19 +447,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:02 GMT
+      - Tue, 07 Nov 2023 16:20:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -436,7 +469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b182f12-cd80-4a2e-9cc4-33d00c428658
+      - b08ff008-1577-411c-bf23-cee0988dab8a
     status: 200 OK
     code: 200
     duration: ""
@@ -447,19 +480,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:07 GMT
+      - Tue, 07 Nov 2023 16:20:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -469,7 +502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5ca8fd0-99f0-4769-96e2-d2994d2549df
+      - 94727d5b-a80b-4e24-9a4b-fd7e8cce4cf9
     status: 200 OK
     code: 200
     duration: ""
@@ -480,19 +513,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:13 GMT
+      - Tue, 07 Nov 2023 16:20:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb8619c4-9eed-49df-9995-a42a998fc2cb
+      - 3db52863-aade-46d4-b323-ad9fc21581dd
     status: 200 OK
     code: 200
     duration: ""
@@ -513,19 +546,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:18 GMT
+      - Tue, 07 Nov 2023 16:20:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75e35ef8-b18d-45cb-8d39-1783e671271c
+      - fa325f5e-f2c2-4710-9dcc-d3bc69e3ff43
     status: 200 OK
     code: 200
     duration: ""
@@ -546,19 +579,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:23 GMT
+      - Tue, 07 Nov 2023 16:20:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39eebcb8-2893-41e5-b107-03de1ab5e4a6
+      - bfb75035-25e0-489e-8832-bb513d5009c3
     status: 200 OK
     code: 200
     duration: ""
@@ -579,19 +612,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:28 GMT
+      - Tue, 07 Nov 2023 16:20:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 351a7dd5-80d2-43df-983b-57acf6c1c39a
+      - 750dcafb-1b74-427d-9229-efbac3152c59
     status: 200 OK
     code: 200
     duration: ""
@@ -612,19 +645,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:33 GMT
+      - Tue, 07 Nov 2023 16:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -634,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3dd01460-0511-4472-867d-070fb219249f
+      - 52f4c93e-2fac-407c-b845-38f6152d2e6a
     status: 200 OK
     code: 200
     duration: ""
@@ -645,19 +678,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:38 GMT
+      - Tue, 07 Nov 2023 16:20:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6fa83c4-a76f-43c6-8e27-88ae5924c984
+      - 39deaa60-d4cc-420f-9f7b-9dbb4c303ac6
     status: 200 OK
     code: 200
     duration: ""
@@ -678,19 +711,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:43 GMT
+      - Tue, 07 Nov 2023 16:21:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72801387-0f3e-4652-ad77-753e31abee6d
+      - 657d691b-a2ca-457b-92b6-532de16fbfdd
     status: 200 OK
     code: 200
     duration: ""
@@ -711,19 +744,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:48 GMT
+      - Tue, 07 Nov 2023 16:21:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f63f1a4f-1acf-41e0-b546-6f7bef288d00
+      - f8a6a6eb-1be2-4a65-9cf3-7cf13d6712d7
     status: 200 OK
     code: 200
     duration: ""
@@ -744,19 +777,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:53 GMT
+      - Tue, 07 Nov 2023 16:21:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3da7df45-90c6-4d9d-a156-076a7b596685
+      - 3c8a3c2d-4e37-4423-ac7c-f9bb7d6050b1
     status: 200 OK
     code: 200
     duration: ""
@@ -777,19 +810,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:36:58 GMT
+      - Tue, 07 Nov 2023 16:21:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67f6b7b1-508c-47bd-99d9-a78e4b3d6655
+      - 798a7491-f2bc-460c-995a-7cec9f444862
     status: 200 OK
     code: 200
     duration: ""
@@ -810,19 +843,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:03 GMT
+      - Tue, 07 Nov 2023 16:21:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91a99afe-864a-4900-b451-1f34af697a28
+      - d6db5992-7a97-4eb3-8e53-699dcd8e134a
     status: 200 OK
     code: 200
     duration: ""
@@ -843,19 +876,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:08 GMT
+      - Tue, 07 Nov 2023 16:21:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f55ac812-c2c7-496f-bca6-3e7f89d8db61
+      - cc4a22c1-0e47-4c96-89da-e33fc7eac9c8
     status: 200 OK
     code: 200
     duration: ""
@@ -876,19 +909,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:13 GMT
+      - Tue, 07 Nov 2023 16:21:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dedcb26b-be8a-4b99-8062-24b82fc0e42e
+      - f03b2b0b-c4f5-4d86-93bf-69c9f66355a3
     status: 200 OK
     code: 200
     duration: ""
@@ -909,19 +942,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:18 GMT
+      - Tue, 07 Nov 2023 16:21:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42da0835-e1cc-436b-8006-c143aee09fb2
+      - 2c121d34-b5fc-4f7b-8bcd-2a6c68f4b159
     status: 200 OK
     code: 200
     duration: ""
@@ -942,19 +975,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:23 GMT
+      - Tue, 07 Nov 2023 16:21:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d3b6ef9-1769-4431-9196-9edac47a5c20
+      - 2537ec1b-6793-4a7e-826c-c030e467e20c
     status: 200 OK
     code: 200
     duration: ""
@@ -975,19 +1008,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:28 GMT
+      - Tue, 07 Nov 2023 16:21:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a786827a-f44d-48c8-8b66-45acff5e026e
+      - 6260f90e-128a-4819-bc48-2c8e391d7d3a
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,19 +1041,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:33 GMT
+      - Tue, 07 Nov 2023 16:21:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,7 +1063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5489989-5280-4ede-aaac-57ac0babf1ba
+      - 89238866-8679-456e-a09b-bfbbed41a7a5
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,19 +1074,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:39 GMT
+      - Tue, 07 Nov 2023 16:21:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1063,7 +1096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b091fdfb-71bf-4003-8daf-b80e0b08e294
+      - 174d0218-cea8-49ef-b140-3e23d0230fc7
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,19 +1107,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:44 GMT
+      - Tue, 07 Nov 2023 16:22:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1096,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3060e58b-9706-4740-be16-401fdb687e7e
+      - 1800f2be-6eb9-4769-b05a-23c5c6fe1162
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,19 +1140,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:49 GMT
+      - Tue, 07 Nov 2023 16:22:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1129,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3dbdb467-af84-4157-8219-0f50ca933aa9
+      - 28ca7605-f265-48cf-a071-97a901e31a09
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,19 +1173,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:54 GMT
+      - Tue, 07 Nov 2023 16:22:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0160b31e-9353-49e9-b985-67b41a6f5e23
+      - c14bba9c-0261-4c28-96d6-c9cce99013d0
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,19 +1206,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:37:59 GMT
+      - Tue, 07 Nov 2023 16:22:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eae40598-6e04-4c8f-8ded-fe7226849661
+      - 1d6f46f5-d7a1-44e6-b01d-205222fec033
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,19 +1239,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:04 GMT
+      - Tue, 07 Nov 2023 16:22:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1228,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14afb4fb-b1ef-4935-9225-c0129e121cd6
+      - c431b116-0e00-41ed-a9dc-a79e2d5908f9
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,19 +1272,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:09 GMT
+      - Tue, 07 Nov 2023 16:22:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a564e212-63be-4cd1-8a78-3a284878b55f
+      - 2aa3f1a0-9374-45c9-a4e0-30a202e583af
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,19 +1305,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:14 GMT
+      - Tue, 07 Nov 2023 16:22:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1044847b-f4b0-47fa-a917-3e78678b87df
+      - cb676acd-43ec-407d-86da-3d92c1537fef
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,19 +1338,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:19 GMT
+      - Tue, 07 Nov 2023 16:22:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1327,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c434cd2e-e56e-4f73-a7ca-b2bf701589a3
+      - fa4f0f72-9ff4-4c0e-95aa-62273bd6480d
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,19 +1371,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:24 GMT
+      - Tue, 07 Nov 2023 16:22:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1360,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1178ba6-9629-4cf6-a8b2-139becd5a7bc
+      - 33a3c690-ad57-43ed-a400-765aa41ac52f
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,19 +1404,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:29 GMT
+      - Tue, 07 Nov 2023 16:22:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1393,7 +1426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3038f45a-eeab-4854-ad3e-d2d4858e4dd4
+      - 7f87c4a7-0669-4b7c-9f38-8a04a89d476e
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,19 +1437,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:34 GMT
+      - Tue, 07 Nov 2023 16:22:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1426,7 +1459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc2a35e6-b9af-4d87-b8ef-8decb228ee3c
+      - 18858ac5-2c23-4052-9608-b17bbdba8853
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,19 +1470,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:39 GMT
+      - Tue, 07 Nov 2023 16:23:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1459,7 +1492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 368b7ce3-0302-430b-9619-a32385d1120a
+      - 2ba4b605-393f-47d0-8b85-827a0e26e16b
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,19 +1503,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:44 GMT
+      - Tue, 07 Nov 2023 16:23:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1492,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd8fd5aa-52f9-47c5-816c-18b6f453b2eb
+      - 65176a95-c46d-4ff2-a866-eda7ad7d5283
     status: 200 OK
     code: 200
     duration: ""
@@ -1503,19 +1536,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:49 GMT
+      - Tue, 07 Nov 2023 16:23:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7440baf2-7c57-4d0e-9dfb-91e27203698e
+      - 8a406ced-cbe4-4648-808a-217b50dc81d1
     status: 200 OK
     code: 200
     duration: ""
@@ -1536,19 +1569,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:54 GMT
+      - Tue, 07 Nov 2023 16:23:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1558,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3bdb6f9a-804f-411c-bc08-bc7dd3c697cd
+      - f5aa18b4-fb32-4a17-a023-dddcedd6e745
     status: 200 OK
     code: 200
     duration: ""
@@ -1569,19 +1602,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:38:59 GMT
+      - Tue, 07 Nov 2023 16:23:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1591,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fcb7ec1e-49a9-4949-86e7-6454eb3b23f0
+      - a23182c3-0de5-4310-af74-2be2f0cf14b2
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,19 +1635,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:04 GMT
+      - Tue, 07 Nov 2023 16:23:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 259bcf40-e379-4926-8f4d-7c3bce5b1232
+      - dde8d687-0d54-4d4a-b49e-da745739bc0d
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,19 +1668,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:09 GMT
+      - Tue, 07 Nov 2023 16:23:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1657,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37701c35-71c9-4ed8-bdef-5088e67cf0b5
+      - d0be9c65-07fe-447a-8264-adf90f5f0964
     status: 200 OK
     code: 200
     duration: ""
@@ -1668,19 +1701,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:14 GMT
+      - Tue, 07 Nov 2023 16:23:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1690,7 +1723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4065f99f-e1e1-454d-9226-04d96f148ea8
+      - 16982710-40a7-4141-a1d9-a99626bf06b6
     status: 200 OK
     code: 200
     duration: ""
@@ -1701,19 +1734,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:19 GMT
+      - Tue, 07 Nov 2023 16:23:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1723,7 +1756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 422882af-ac2e-46af-b57c-49f359b771bb
+      - 088106cb-d40e-4a45-9815-43326a695802
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,19 +1767,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:24 GMT
+      - Tue, 07 Nov 2023 16:23:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1756,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86efea57-3e11-4c58-a14e-999cbb1c88fb
+      - c179d5ea-c6f3-4037-979a-fc32e1ce156b
     status: 200 OK
     code: 200
     duration: ""
@@ -1767,19 +1800,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:30 GMT
+      - Tue, 07 Nov 2023 16:23:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1789,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff387f8c-19f4-49e3-93f7-8ff424d2329e
+      - da1faff7-adff-4f82-93e2-c2e2310e89f0
     status: 200 OK
     code: 200
     duration: ""
@@ -1800,19 +1833,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:35 GMT
+      - Tue, 07 Nov 2023 16:23:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1822,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ec4363b-03d0-44f2-9f29-fea078978845
+      - 177a07d1-e59b-4e20-93eb-a31f7312a945
     status: 200 OK
     code: 200
     duration: ""
@@ -1833,19 +1866,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:40 GMT
+      - Tue, 07 Nov 2023 16:24:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1855,7 +1888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - abe40bff-0338-4ef9-a481-f7f3bff18197
+      - 2aea3d9b-71d8-45af-b1d6-5c2d85fbaf6d
     status: 200 OK
     code: 200
     duration: ""
@@ -1866,19 +1899,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:45 GMT
+      - Tue, 07 Nov 2023 16:24:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1888,7 +1921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04a18ea8-a95d-44fe-8d51-855308e9e740
+      - a7a5b09c-269f-4b4d-903e-67a17a5e8a98
     status: 200 OK
     code: 200
     duration: ""
@@ -1899,19 +1932,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:50 GMT
+      - Tue, 07 Nov 2023 16:24:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1921,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ade7c44d-451f-4ab0-b919-c64d33bc45d4
+      - f09bb5ce-37b6-4052-bdcb-da8826b449cd
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,19 +1965,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:39:55 GMT
+      - Tue, 07 Nov 2023 16:24:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1954,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09305131-d267-4959-92e9-b1e8b0656523
+      - addd2b9b-d62a-4b02-9d00-cbe56d7db166
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,19 +1998,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:00 GMT
+      - Tue, 07 Nov 2023 16:24:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1987,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 113f993d-b662-40df-91e2-75c24d9d2954
+      - 5cb7dbf7-a273-4314-ac8e-31c86274a8e0
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,19 +2031,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:05 GMT
+      - Tue, 07 Nov 2023 16:24:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2020,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24adcb9c-522f-45a2-b07e-fa0bfc27b01e
+      - 7259b285-e0fc-4cf0-871d-8688bdf14767
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,19 +2064,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:10 GMT
+      - Tue, 07 Nov 2023 16:24:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2053,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c81ec0c5-2fd9-4025-a065-e47458e8fa4a
+      - 13433931-9fc5-4c4a-b905-65884edd8cdf
     status: 200 OK
     code: 200
     duration: ""
@@ -2064,19 +2097,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:15 GMT
+      - Tue, 07 Nov 2023 16:24:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2086,7 +2119,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e40cd8b7-4706-47d9-9626-a085ef5d8902
+      - 717d183f-7eec-474a-9411-db5b9606a6ae
     status: 200 OK
     code: 200
     duration: ""
@@ -2097,19 +2130,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:20 GMT
+      - Tue, 07 Nov 2023 16:24:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2119,7 +2152,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35bdd509-f8ac-4b07-a831-fe9204113843
+      - 15c97d01-787e-4a80-bff1-67aabffb4ee0
     status: 200 OK
     code: 200
     duration: ""
@@ -2130,19 +2163,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:25 GMT
+      - Tue, 07 Nov 2023 16:24:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2152,7 +2185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7980ce4c-233a-456b-8c3e-da34f3e92dae
+      - d0e772e4-a6f1-446b-a326-70bdc9853591
     status: 200 OK
     code: 200
     duration: ""
@@ -2163,19 +2196,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:30 GMT
+      - Tue, 07 Nov 2023 16:24:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2185,7 +2218,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3cfcc411-8f7b-4482-b3b3-8a5e7364e0c7
+      - b8f88f48-9a65-4a2b-bd73-fadd878dec19
     status: 200 OK
     code: 200
     duration: ""
@@ -2196,19 +2229,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:35 GMT
+      - Tue, 07 Nov 2023 16:24:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2218,7 +2251,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c5ea182-40a3-4b60-8c8d-6e7b15d5d121
+      - 37449641-dae6-4194-8158-df71a74cbef4
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,19 +2262,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:20:12.129786Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "647"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:40 GMT
+      - Tue, 07 Nov 2023 16:25:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2251,7 +2284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c214b4c-13d1-406f-b597-f6d84327e9b6
+      - a57b546e-25e5-47ef-ab20-01f2bed5f78e
     status: 200 OK
     code: 200
     duration: ""
@@ -2262,19 +2295,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:25:02.328915Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "645"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:45 GMT
+      - Tue, 07 Nov 2023 16:25:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2284,7 +2317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51c03b65-7d84-4217-becc-2ee3086cebad
+      - e663226d-969e-42e4-ac15-518b6a9c3247
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,19 +2328,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.345686Z","created_at":"2023-11-07T16:20:01.345686Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1125c396-3316-458b-8e7f-867455a74b50","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-07T16:21:45.933361Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "672"
+      - "1446"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:50 GMT
+      - Tue, 07 Nov 2023 16:25:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2317,7 +2350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed281d02-1cfb-45a7-bf8a-c3fa0f137ec7
+      - 8445d9af-00a0-4331-9cfc-1d221ea8a6b6
     status: 200 OK
     code: 200
     duration: ""
@@ -2328,19 +2361,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:25:02.328915Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "645"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:40:55 GMT
+      - Tue, 07 Nov 2023 16:25:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2350,7 +2383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1a39ea2-bd4a-4122-a35b-46654edad2ed
+      - 165581a6-6dbc-418b-bf51-cc76506abd39
     status: 200 OK
     code: 200
     duration: ""
@@ -2361,19 +2394,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2/nodes?order_by=created_at_asc&page=1&pool_id=a6e741b9-dc84-4f78-9956-fe8830e20325&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"nodes":[{"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T16:22:16.028152Z","error_message":null,"id":"f6135907-3760-4c49-8cd7-c5b95609d3ea","name":"scw-test-pool-zone-test-pool-zone-f61359073760","pool_id":"a6e741b9-dc84-4f78-9956-fe8830e20325","provider_id":"scaleway://instance/fr-par-2/f5fb3bc1-574d-4299-9b0f-0415ca26f7a9","public_ip_v4":"51.159.162.93","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:25:02.312448Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "672"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:00 GMT
+      - Tue, 07 Nov 2023 16:25:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2383,7 +2416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5547d529-29ce-4d29-9110-c1b856654b84
+      - 290d8b40-b2b0-47fb-a7a2-5716a9b1fbf8
     status: 200 OK
     code: 200
     duration: ""
@@ -2394,19 +2427,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.345686Z","created_at":"2023-11-07T16:20:01.345686Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1125c396-3316-458b-8e7f-867455a74b50","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-07T16:21:45.933361Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "672"
+      - "1446"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:05 GMT
+      - Tue, 07 Nov 2023 16:25:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2416,7 +2449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a467d4d-4801-4890-b459-6e6396e61eb5
+      - ed26f259-f470-4228-8325-3b9018110bf7
     status: 200 OK
     code: 200
     duration: ""
@@ -2427,19 +2460,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:25:02.328915Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "645"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:11 GMT
+      - Tue, 07 Nov 2023 16:25:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2449,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2e7a07d-7d91-4fdd-831c-8512bed13a2a
+      - e7911e2a-8a41-4604-b600-b8c7604bb209
     status: 200 OK
     code: 200
     duration: ""
@@ -2460,19 +2493,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1125c396-3316-458b-8e7f-867455a74b50
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"created_at":"2023-11-07T16:19:59.947696Z","dhcp_enabled":true,"id":"1125c396-3316-458b-8e7f-867455a74b50","name":"test-pool-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.947696Z","id":"2d9eec37-8e62-4435-b050-69ba4ce4b6c5","subnet":"172.16.16.0/22","updated_at":"2023-11-07T16:19:59.947696Z"},{"created_at":"2023-11-07T16:19:59.947696Z","id":"1dbc7251-c7f9-439a-bc11-df0c6cfcf3a2","subnet":"fd63:256c:45f7:10e0::/64","updated_at":"2023-11-07T16:19:59.947696Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.947696Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "672"
+      - "698"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:16 GMT
+      - Tue, 07 Nov 2023 16:25:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2482,7 +2515,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93f0715b-3441-40e0-be80-b41b02f79400
+      - 38ac7115-465c-46cc-b588-01afddb4d7e8
     status: 200 OK
     code: 200
     duration: ""
@@ -2493,19 +2526,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.345686Z","created_at":"2023-11-07T16:20:01.345686Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1125c396-3316-458b-8e7f-867455a74b50","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-07T16:21:45.933361Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "672"
+      - "1446"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:21 GMT
+      - Tue, 07 Nov 2023 16:25:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2515,7 +2548,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f846059e-01d3-4afa-8510-bf652a859f4c
+      - b5fee3a0-20e5-41f5-ac4b-0a8a057bfde7
     status: 200 OK
     code: 200
     duration: ""
@@ -2526,19 +2559,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2/kubeconfig
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC16b25lIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVJYZE9ha1V5VFdwQmQwNXNiMWhFVkUxNlRWUkZkMDVxUlRKTmFrRjNUbXh2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlREUkZDbXc0U25KWFUxbHhXRVpCVmxkamNuTm9hbVpNUkdSWFJEZG9NbXBMZGtaeFdtVXpOU3RyV1hNeGNqZEdTR3hLVGxsclRHbFZWRmROYlZSVlYxbFNSVVFLZDJOb1oxQnlTakpEWmpCWWFIcFFWMVkyY0VST05tNVNXbkpsU0RkTWFsTTJSMWhxVWpCeU5rUTBXR2xUTjBSR05sTm9kemhPYm5sdGMyeGpVbUV3V0FwRWNHWm9aSFJMZERGWFIzZE9kRUYwZFhOeGVWZGhSR0owVG5WeWFsRnVlbXh5VDFCellVRmFSRGRSVXpabmJtcHBkVXhKZWtGWFlscDFZV1pTUVZONkNsSllkamR4TTBsU2RrZGpSa3QyYkhVeGRGVXlkRkJ3V2tOMVJVbFpUekpPVVVVM1JYVkVaRWRTYzA5dWIxaE9WRGRRUm5JMWVXTXZTMnBxTldRNU1Ea0tWSGgyY0hjeFpXRjVORlZKZEhOSGVVaHVhMFV3VmxKMWRsZHpXbmt6T0VsaE5VRktWbE16TDFoblNsZENhR3hKU2tkc0sweG5aV3RFUWtSSldrTmlWd3BOV20xbVNIbFFlbmxYYlVWdlZISnJTRWxOUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpPWkRCSmVYRkZSVGRYTWtoT1pVNXFiV050YURScWFIWlFNV1JOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZEVG05R1JGRjVha3hsWmxGdFFtUlZaVmd6WTNWNWEyNTJaMEZuTlRaSU5XOTNWa0p0VlRORVprMHhlbUZrWXpkMVZRcDZlazFYVWxKRVEzWTRhbTlqYWtSWWNVMWlTREZtVG5ocVUyb3dabkl6Y0dSSGJUSlVabXc1VFdVeWFtSk1hMVJyZFVoWlNtOXpUR1YxTHpGdlZuUlBDa2RPYlhaNmMxWlhTR3R3Ym5wamMybFZiekJQTVZwTGJWQldkMFZNU2prMVptTnRRMjVSUkVObFNUbElZVmc0VVZONE5VWnhWakowU210bU15dHpZMDRLUlhkcVZUZHFTalF2U2xkelZFdzBZbEJyUldNeU4zbFVVSGt3UWpSRlJVNW1VekZ1TVVadWJXeE9UbE5zWkhGWVdVUlpkWGhXV0M5UE15OTFWelpoY0FwNE9ETXpSak41ZFRGb0sycGlVRGRJZWs5MFkycE9Mekp5TUdwR2Jtc3plV05UV1V4M2RESk5hR1kyVDJONGFHbEhZVmMxVFN0dWNsazRUV1pUVURkSkNreEZOMkV4YlZGMGFITklSWFkwV1RKNWFYTlplazVvVFRCS1UzRm9NMk41WVhaSmN3b3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly81YmI5ZjA0Zi0wM2YzLTQyMGYtYjFiZi05ZTYxMGVkMmNhZDIuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXpvbmUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC16b25lIgogICAgdXNlcjogdGVzdC1wb29sLXpvbmUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtem9uZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC16b25lLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBLaEZaVnpsdE5pNUF6Vk9DM05wa3JkSFQwYklmMUFacU80d0lKSXNMMGpCN2U4ZEhZRGJZRms3Wg==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "672"
+      - "2604"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:26 GMT
+      - Tue, 07 Nov 2023 16:25:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2548,7 +2581,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cff5b94f-68a7-4677-8fec-98217611929f
+      - 0c039d9c-72f2-4157-bf5e-d47f6d6910d6
     status: 200 OK
     code: 200
     duration: ""
@@ -2559,19 +2592,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:25:02.328915Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "672"
+      - "645"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:31 GMT
+      - Tue, 07 Nov 2023 16:25:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2581,7 +2614,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98c06be4-bf47-4145-b1b9-a8a5c4eb7ffd
+      - e705f85a-99bf-4a93-929c-298d428201cc
     status: 200 OK
     code: 200
     duration: ""
@@ -2592,19 +2625,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2/nodes?order_by=created_at_asc&page=1&pool_id=a6e741b9-dc84-4f78-9956-fe8830e20325&status=unknown
     method: GET
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"nodes":[{"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-11-07T16:22:16.028152Z","error_message":null,"id":"f6135907-3760-4c49-8cd7-c5b95609d3ea","name":"scw-test-pool-zone-test-pool-zone-f61359073760","pool_id":"a6e741b9-dc84-4f78-9956-fe8830e20325","provider_id":"scaleway://instance/fr-par-2/f5fb3bc1-574d-4299-9b0f-0415ca26f7a9","public_ip_v4":"51.159.162.93","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-11-07T16:25:02.312448Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "672"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:41:36 GMT
+      - Tue, 07 Nov 2023 16:25:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2614,7 +2647,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4410673-8c45-4a9d-9420-66ab473edccf
+      - 15a1b3b9-9d45-4aad-a87e-cdae1bb18946
     status: 200 OK
     code: 200
     duration: ""
@@ -2625,877 +2658,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
-    headers:
-      Content-Length:
-      - "672"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - aaaddde7-1078-4edd-a89b-25af3124a7a7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
-    headers:
-      Content-Length:
-      - "672"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 81bd1706-a1a7-455d-9c63-b8f0eaccbd4f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
-    headers:
-      Content-Length:
-      - "672"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d649140e-ba94-49c0-a0e9-24a456bce9fe
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
-    headers:
-      Content-Length:
-      - "672"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:41:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 232ce488-3ff5-4b2e-989b-8c8133c49f42
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
-    headers:
-      Content-Length:
-      - "672"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8b636c61-dfa5-4c43-80c3-4339d15228ca
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
-    headers:
-      Content-Length:
-      - "672"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2dbc21b0-523e-483e-a00d-5a8f662b3249
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
-    headers:
-      Content-Length:
-      - "672"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f4831cb9-19cd-4849-8466-4ef2fb4f87d6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
-    headers:
-      Content-Length:
-      - "672"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5873f028-5257-42f1-b6d0-ccf4f8ea471d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
-    headers:
-      Content-Length:
-      - "672"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a339f6dc-11c8-4b56-a991-3c1bf9016242
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
-    headers:
-      Content-Length:
-      - "672"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1c9b7870-45b3-4653-9c5c-773417ff9824
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
-    headers:
-      Content-Length:
-      - "672"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cb1a821e-af85-4dfb-a9d2-51aaaa3dc513
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
-    headers:
-      Content-Length:
-      - "672"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ba579f8b-d8d3-4fe5-b556-342086e2a798
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
-    headers:
-      Content-Length:
-      - "672"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 396770cb-22e8-4e1a-aa71-7fbf9adeebf5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
-    headers:
-      Content-Length:
-      - "672"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c744486f-7ea1-4c98-8996-8f526a6079f7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"scaling","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:35:51.232183Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
-    headers:
-      Content-Length:
-      - "672"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b4336ddd-a0dc-4290-b946-6979185cb2ee
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:42:55.319289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
-    headers:
-      Content-Length:
-      - "670"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 33a82a8c-ce46-421a-8f4d-b4da5b1b8fc8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f2b97a1-db52-45b1-97f0-782edf34220e
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f2b97a1-db52-45b1-97f0-782edf34220e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.787648Z","created_at":"2023-10-18T16:35:45.787648Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f2b97a1-db52-45b1-97f0-782edf34220e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f2b97a1-db52-45b1-97f0-782edf34220e","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"bbcadfae-9d75-4dbe-9e9d-7fcfa8ce40c3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-10-18T16:37:14.958686Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1491"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b2c08902-d468-46ec-a041-ec119ae1171e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:42:55.319289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
-    headers:
-      Content-Length:
-      - "670"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 779a2776-0418-4612-93fb-592413389083
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f2b97a1-db52-45b1-97f0-782edf34220e/nodes?order_by=created_at_asc&page=1&pool_id=c8c0752f-ce31-47a8-8860-8351fc61dccd&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:37:43.584219Z","error_message":null,"id":"debc4f53-692b-4fbe-88f5-f1be005c206d","name":"scw-test-pool-zone-test-pool-zone-debc4f53692b","pool_id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","provider_id":"scaleway://instance/fr-par-2/f648fb2e-f7b7-4c73-9340-606aa12583c9","public_ip_v4":"51.159.131.178","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:42:55.300617Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "659"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 80bf134b-51b0-4b37-9a24-7b6b2d28b5fa
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f2b97a1-db52-45b1-97f0-782edf34220e
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f2b97a1-db52-45b1-97f0-782edf34220e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.787648Z","created_at":"2023-10-18T16:35:45.787648Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f2b97a1-db52-45b1-97f0-782edf34220e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f2b97a1-db52-45b1-97f0-782edf34220e","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"bbcadfae-9d75-4dbe-9e9d-7fcfa8ce40c3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-10-18T16:37:14.958686Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1491"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 67a00b71-70fb-4523-b97e-77410af8b0d0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:42:55.319289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
-    headers:
-      Content-Length:
-      - "670"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d760f8a8-e5ef-4385-99b8-97b27166d4da
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bbcadfae-9d75-4dbe-9e9d-7fcfa8ce40c3
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-18T16:35:44.620844Z","dhcp_enabled":true,"id":"bbcadfae-9d75-4dbe-9e9d-7fcfa8ce40c3","name":"test-pool-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:35:44.620844Z","id":"76cf3e27-3a4f-46a7-8873-d5b762f56fc0","subnet":"172.16.32.0/22","updated_at":"2023-10-18T16:35:44.620844Z"},{"created_at":"2023-10-18T16:35:44.620844Z","id":"85a6b9d1-979b-4c8e-84fd-e1f4e1b8b73c","subnet":"fd63:256c:45f7:5a8f::/64","updated_at":"2023-10-18T16:35:44.620844Z"}],"tags":[],"updated_at":"2023-10-18T16:35:44.620844Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "715"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c5645b67-0bf7-4f56-9e47-bbdba026165f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f2b97a1-db52-45b1-97f0-782edf34220e
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f2b97a1-db52-45b1-97f0-782edf34220e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.787648Z","created_at":"2023-10-18T16:35:45.787648Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f2b97a1-db52-45b1-97f0-782edf34220e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f2b97a1-db52-45b1-97f0-782edf34220e","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"bbcadfae-9d75-4dbe-9e9d-7fcfa8ce40c3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-10-18T16:37:14.958686Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1491"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1e71070d-d8a0-4409-bdab-e849d3437195
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f2b97a1-db52-45b1-97f0-782edf34220e/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtcG9vbC16b25lIgogIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTTFla05EUVdNclowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZWsxVVFYaE9la1V5VFhwVk1FNHhiMWhFVkUxNlRWUkJlRTU2UlRKTmVsVXdUakZ2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlVIQmhDa05tUnl0Q1NqbDFaV2xZZEVSdFlVUkNRMUpaYUZWc1RIbGtOalUwWW5STlUzbHdkSEZTVUc1TGRFaEVVRzlWUVhGb2VrOUZhSGd3Y0V4VVJHaHFTRVFLU1ZoSWVrbFFObFJJUVRScVFqbFRWRmRHZEVWSWVYVXpVR3hVVVdOVFZFVTVWMWRWV1N0dVR6QndNelo1UkdkSksxSkZkelIzUkdWTWQxbFRPRGRLTlFwUmIwWTVTWGRIV1ZnMGNGVmxOVEJKZHpsYVMyUnhWV2czVkRkNlVFeDZWVGhZTkN0dGVFc3haSHBXUkRsalNsVkhOVWhQSzBWbVIyMVdWVGRtV21abENtVkVObGxKYUhwM1dYZDZRazFQYWxBMGVraFhXWG92WVhKNGNHcHhSR05zTUhkaFpHRXdTV05IYkhOdmRXaDFLMko2TWpabFExZHFlSFpQYURoYU5td0tTMloyUTJZdlNYWkJhVGxZTXpkWmJuRmpSM00wTVhSb1dVaGxiV3BqVkVaUlpqRnNkWFZCWVRNcmF6Z3ZTbEZoY2xWamVtVnljVkZDUldSTlNHaGxad3BsVEdnMVYzbE5kVTlCY1VKdFdFaFdUbGxyUTBGM1JVRkJZVTVEVFVWQmQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpJSzBrd1YwZEhZbVpCYVRGUU5YUlBaV2haVEZCMlp5OXBSSFZOUVRCSFExTnhSMU5KWWpNS1JGRkZRa04zVlVGQk5FbENRVkZCSzNwTFoxQjZLM00wY0RORWNGaEhMM05WUWt4dFpXNDVXRFp3YjFrdmN6WkVTVGxGVkRocVEydDFibk4yUjBoQlpBcDZOR0pxUlhCdlFuRTJOVGRwVm1GMFpEbHVVMWhYZVZCb056VnJPR1Z5VlhRMWFTdEZTbEE0ZEhKd1R6aERXbVZaVDAxVk9WaEtOak51VjBwRWRESnVDbEpRVldoYVlYbGFiRmM0YUdFNGRrbHZkbEJ3TDJVM0t6WmhNRmN3WVVaeWRWVndlV2RtVkROUGRtY3pWMFoxYWxsWU1GVnBVV3Q2YmsxRWNHUkxLMFVLUzJFMk5FUTBaRTFXVDI5VU0wSllPRUp6TUZwbE4yeDNZVGxEY1cxcVluQjFTamxQTUhOWmRTOXVOVmRwYVRoa1QyMDFjV1l2TUhWeFpVWXpLMFpqU2dwcE5ITlNVRWRyZDNkelNXTmtNRGhGVFM5a1kwMXZjMkZPYVRCS01IcG9NRkV6UzFrMVpsUlhkSFpYYlRCRlZuTjFNSFIzV2xGclYzbFJWblptTTFsTENuTXhVa05NYUc5ck1sSTRiVWhpZURVMFJuWnhhR05OVGtKbmNuaE1ZUzlsTmtGc1NRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0KICAgIHNlcnZlcjogaHR0cHM6Ly80ZjJiOTdhMS1kYjUyLTQ1YjEtOTdmMC03ODJlZGYzNDIyMGUuYXBpLms4cy5mci1wYXIuc2N3LmNsb3VkOjY0NDMKY29udGV4dHM6Ci0gbmFtZTogYWRtaW5AdGVzdC1wb29sLXpvbmUKICBjb250ZXh0OgogICAgY2x1c3RlcjogInRlc3QtcG9vbC16b25lIgogICAgdXNlcjogdGVzdC1wb29sLXpvbmUtYWRtaW4KY3VycmVudC1jb250ZXh0OiBhZG1pbkB0ZXN0LXBvb2wtem9uZQpraW5kOiBDb25maWcKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOgotIG5hbWU6IHRlc3QtcG9vbC16b25lLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB4YWRUdUVUYml3aHltSmFjNmJvQmFLUVUya0JnRXJyYk85T2l6M0hXbUl1azN1WFRUelZ5UDJOWA==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2606"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0a94a5e2-7c3b-49d5-8c6a-731166010d5a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
-    method: GET
-  response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"ready","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:42:55.319289Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
-    headers:
-      Content-Length:
-      - "670"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6f757003-2b35-496c-8bb8-a90f3e758bad
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f2b97a1-db52-45b1-97f0-782edf34220e/nodes?order_by=created_at_asc&page=1&pool_id=c8c0752f-ce31-47a8-8860-8351fc61dccd&status=unknown
-    method: GET
-  response:
-    body: '{"nodes":[{"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","conditions":{"DiskPressure":"False","MemoryPressure":"False","PIDPressure":"False","PrivateNetworkUnavailable":"False","Ready":"True"},"created_at":"2023-10-18T16:37:43.584219Z","error_message":null,"id":"debc4f53-692b-4fbe-88f5-f1be005c206d","name":"scw-test-pool-zone-test-pool-zone-debc4f53692b","pool_id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","provider_id":"scaleway://instance/fr-par-2/f648fb2e-f7b7-4c73-9340-606aa12583c9","public_ip_v4":"51.159.131.178","public_ip_v6":null,"region":"fr-par","status":"ready","updated_at":"2023-10-18T16:42:55.300617Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "659"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0dba0172-56b7-447f-b7f2-a5164f672bcf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c8c0752f-ce31-47a8-8860-8351fc61dccd
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: DELETE
   response:
-    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","container_runtime":"containerd","created_at":"2023-10-18T16:35:51.224179Z","id":"c8c0752f-ce31-47a8-8860-8351fc61dccd","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-10-18T16:42:58.676218873Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:25:08.797094991Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "676"
+      - "651"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:58 GMT
+      - Tue, 07 Nov 2023 16:25:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3505,7 +2680,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 753f78c2-98df-4d1b-9e8e-79e60111c237
+      - 04009b74-2767-4952-b667-bbb0a00d3193
     status: 200 OK
     code: 200
     duration: ""
@@ -3516,52 +2691,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f2b97a1-db52-45b1-97f0-782edf34220e?with_additional_resources=true
-    method: DELETE
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f2b97a1-db52-45b1-97f0-782edf34220e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.787648Z","created_at":"2023-10-18T16:35:45.787648Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f2b97a1-db52-45b1-97f0-782edf34220e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f2b97a1-db52-45b1-97f0-782edf34220e","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"bbcadfae-9d75-4dbe-9e9d-7fcfa8ce40c3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-10-18T16:42:58.749660268Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1497"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:42:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 01617018-de72-483a-98ae-7bec7420d621
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f2b97a1-db52-45b1-97f0-782edf34220e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f2b97a1-db52-45b1-97f0-782edf34220e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.787648Z","created_at":"2023-10-18T16:35:45.787648Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f2b97a1-db52-45b1-97f0-782edf34220e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f2b97a1-db52-45b1-97f0-782edf34220e","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"bbcadfae-9d75-4dbe-9e9d-7fcfa8ce40c3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-10-18T16:42:58.749660Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:25:08.797095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "1494"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:42:58 GMT
+      - Tue, 07 Nov 2023 16:25:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3571,7 +2713,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7e2138e-1d04-4ac9-a568-172e67188649
+      - 3dee69ff-15f7-4e0d-93ba-0a3087754f3b
     status: 200 OK
     code: 200
     duration: ""
@@ -3582,19 +2724,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f2b97a1-db52-45b1-97f0-782edf34220e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f2b97a1-db52-45b1-97f0-782edf34220e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.787648Z","created_at":"2023-10-18T16:35:45.787648Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f2b97a1-db52-45b1-97f0-782edf34220e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f2b97a1-db52-45b1-97f0-782edf34220e","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"bbcadfae-9d75-4dbe-9e9d-7fcfa8ce40c3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-10-18T16:42:58.749660Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"autohealing":true,"autoscaling":true,"cluster_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","container_runtime":"containerd","created_at":"2023-11-07T16:20:12.104548Z","id":"a6e741b9-dc84-4f78-9956-fe8830e20325","kubelet_args":{},"max_size":1,"min_size":1,"name":"test-pool-zone","node_type":"gp1_xs","placement_group_id":null,"public_ip_disabled":false,"region":"fr-par","root_volume_size":150000000000,"root_volume_type":"l_ssd","size":1,"status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"updated_at":"2023-11-07T16:25:08.797095Z","upgrade_policy":{"max_surge":0,"max_unavailable":1},"version":"1.28.2","zone":"fr-par-2"}'
     headers:
       Content-Length:
-      - "1494"
+      - "648"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:03 GMT
+      - Tue, 07 Nov 2023 16:25:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3604,7 +2746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b355027-58f9-4137-80e3-80798bce941c
+      - 38ef0a09-b397-4784-8dae-48caee5d4531
     status: 200 OK
     code: 200
     duration: ""
@@ -3615,19 +2757,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f2b97a1-db52-45b1-97f0-782edf34220e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/a6e741b9-dc84-4f78-9956-fe8830e20325
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f2b97a1-db52-45b1-97f0-782edf34220e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.787648Z","created_at":"2023-10-18T16:35:45.787648Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f2b97a1-db52-45b1-97f0-782edf34220e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f2b97a1-db52-45b1-97f0-782edf34220e","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"bbcadfae-9d75-4dbe-9e9d-7fcfa8ce40c3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-10-18T16:42:58.749660Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"message":"resource is not found","resource":"pool","resource_id":"a6e741b9-dc84-4f78-9956-fe8830e20325","type":"not_found"}'
     headers:
       Content-Length:
-      - "1494"
+      - "125"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:08 GMT
+      - Tue, 07 Nov 2023 16:25:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3637,73 +2779,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aae1030b-34e1-4693-b160-e33cb5e1a89d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f2b97a1-db52-45b1-97f0-782edf34220e
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://4f2b97a1-db52-45b1-97f0-782edf34220e.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:35:45.787648Z","created_at":"2023-10-18T16:35:45.787648Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.4f2b97a1-db52-45b1-97f0-782edf34220e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"4f2b97a1-db52-45b1-97f0-782edf34220e","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"bbcadfae-9d75-4dbe-9e9d-7fcfa8ce40c3","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-10-18T16:42:58.749660Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1494"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 156e44e8-5426-4ecc-bc58-c34f28fbbfb8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f2b97a1-db52-45b1-97f0-782edf34220e
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "128"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a8f4cd61-dc0d-4860-9fdc-e46e0b42cd7c
+      - 65c5f012-397d-4cd6-8f62-fba2b296d130
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3714,10 +2790,142 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bbcadfae-9d75-4dbe-9e9d-7fcfa8ce40c3
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"bbcadfae-9d75-4dbe-9e9d-7fcfa8ce40c3","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.345686Z","created_at":"2023-11-07T16:20:01.345686Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1125c396-3316-458b-8e7f-867455a74b50","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-07T16:25:19.065942353Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1452"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:25:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 85423279-3455-4ecb-9374-179ae48bcd07
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.345686Z","created_at":"2023-11-07T16:20:01.345686Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1125c396-3316-458b-8e7f-867455a74b50","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-07T16:25:19.065942Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1449"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:25:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5044e146-fadc-44e2-865d-27675fcf0b3c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:01.345686Z","created_at":"2023-11-07T16:20:01.345686Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.5bb9f04f-03f3-420f-b1bf-9e610ed2cad2.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","ingress":"none","name":"test-pool-zone","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"1125c396-3316-458b-8e7f-867455a74b50","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","zone"],"type":"kapsule","updated_at":"2023-11-07T16:25:19.065942Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1449"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:25:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ff6796a6-8a8c-490b-a0fc-c28859e652cf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:25:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2e996622-8f58-4786-90b5-b9e0c4ae7202
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/1125c396-3316-458b-8e7f-867455a74b50
+    method: DELETE
+  response:
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"1125c396-3316-458b-8e7f-867455a74b50","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3726,7 +2934,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:19 GMT
+      - Tue, 07 Nov 2023 16:25:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3736,7 +2944,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cbeaad63-76b5-43b4-a4ee-895dfb7e3fe8
+      - b952e66e-cd62-4cb3-8e9f-3d1045432a9d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3747,10 +2955,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/4f2b97a1-db52-45b1-97f0-782edf34220e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/5bb9f04f-03f3-420f-b1bf-9e610ed2cad2
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"4f2b97a1-db52-45b1-97f0-782edf34220e","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"5bb9f04f-03f3-420f-b1bf-9e610ed2cad2","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3759,7 +2967,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:19 GMT
+      - Tue, 07 Nov 2023 16:25:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3769,7 +2977,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad8a1cd5-89ec-4570-8b58-b3471b0b504e
+      - 00001876-4efe-455c-9fae-193f8ce81ee3
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-private-network.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-private-network.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:26:42 GMT
+      - Tue, 07 Nov 2023 16:19:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,12 +34,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5dbc4fce-bf7f-4083-925b-f5627c2911f2
+      - 60646dae-e4ab-410d-9424-ce80c401f045
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"k8s-private-network","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"k8s-private-network","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-18T17:26:43.392150Z","dhcp_enabled":true,"id":"6a3be534-eff7-48ad-bc55-d55fc9d0d221","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T17:26:43.392150Z","id":"d500e056-6397-47eb-9654-4402c581487b","subnet":"172.16.16.0/22","updated_at":"2023-10-18T17:26:43.392150Z"},{"created_at":"2023-10-18T17:26:43.392150Z","id":"b26df8da-60fc-4ed0-a991-3086679d352c","subnet":"fd63:256c:45f7:8c5c::/64","updated_at":"2023-10-18T17:26:43.392150Z"}],"tags":[],"updated_at":"2023-10-18T17:26:43.392150Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:19:59.780272Z","dhcp_enabled":true,"id":"e7f53646-b279-4a10-8b55-be84031db17b","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.780272Z","id":"40c98dce-5a7a-4dea-8eae-76d3bfd8da01","subnet":"172.16.24.0/22","updated_at":"2023-11-07T16:19:59.780272Z"},{"created_at":"2023-11-07T16:19:59.780272Z","id":"07f3dbc1-1163-4ce3-9516-ea9e678aa025","subnet":"fd63:256c:45f7:c212::/64","updated_at":"2023-11-07T16:19:59.780272Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.780272Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "720"
+      - "703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:26:44 GMT
+      - Tue, 07 Nov 2023 16:20:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 909c34cd-dc66-4cac-ac3a-6f2d62ef4bd2
+      - 62d6d03a-5b3f-4132-9a28-b341830e1aab
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6a3be534-eff7-48ad-bc55-d55fc9d0d221
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7f53646-b279-4a10-8b55-be84031db17b
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T17:26:43.392150Z","dhcp_enabled":true,"id":"6a3be534-eff7-48ad-bc55-d55fc9d0d221","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T17:26:43.392150Z","id":"d500e056-6397-47eb-9654-4402c581487b","subnet":"172.16.16.0/22","updated_at":"2023-10-18T17:26:43.392150Z"},{"created_at":"2023-10-18T17:26:43.392150Z","id":"b26df8da-60fc-4ed0-a991-3086679d352c","subnet":"fd63:256c:45f7:8c5c::/64","updated_at":"2023-10-18T17:26:43.392150Z"}],"tags":[],"updated_at":"2023-10-18T17:26:43.392150Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:19:59.780272Z","dhcp_enabled":true,"id":"e7f53646-b279-4a10-8b55-be84031db17b","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.780272Z","id":"40c98dce-5a7a-4dea-8eae-76d3bfd8da01","subnet":"172.16.24.0/22","updated_at":"2023-11-07T16:19:59.780272Z"},{"created_at":"2023-11-07T16:19:59.780272Z","id":"07f3dbc1-1163-4ce3-9516-ea9e678aa025","subnet":"fd63:256c:45f7:c212::/64","updated_at":"2023-11-07T16:19:59.780272Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.780272Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "720"
+      - "703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:26:44 GMT
+      - Tue, 07 Nov 2023 16:20:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6334baf-89de-4521-86a1-d4dc7e4bddb0
+      - c26fc414-f1e4-41ec-96ad-bad3f81b5ed4
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"k8s-private-network-cluster","description":"","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":"6a3be534-eff7-48ad-bc55-d55fc9d0d221"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"k8s-private-network-cluster","description":"","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"e7f53646-b279-4a10-8b55-be84031db17b"}'
     form: {}
     headers:
       Content-Type:
@@ -118,16 +118,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e8c177fa-ad15-4ba8-ab2a-f530ce4268e7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T17:26:44.740738233Z","created_at":"2023-10-18T17:26:44.740738233Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e8c177fa-ad15-4ba8-ab2a-f530ce4268e7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e8c177fa-ad15-4ba8-ab2a-f530ce4268e7","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"6a3be534-eff7-48ad-bc55-d55fc9d0d221","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T17:26:44.793300415Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b319e7df-5562-48f6-a2c5-e29c2ca00375.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.202959621Z","created_at":"2023-11-07T16:20:01.202959621Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b319e7df-5562-48f6-a2c5-e29c2ca00375.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b319e7df-5562-48f6-a2c5-e29c2ca00375","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7f53646-b279-4a10-8b55-be84031db17b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:01.214928607Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1527"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:26:44 GMT
+      - Tue, 07 Nov 2023 16:20:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6e8c5b6-30fa-475c-ae7e-aa0c067ffa6d
+      - f9e93287-3108-4e1a-a0f6-f99fb1fcdce2
     status: 200 OK
     code: 200
     duration: ""
@@ -148,19 +148,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e8c177fa-ad15-4ba8-ab2a-f530ce4268e7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e8c177fa-ad15-4ba8-ab2a-f530ce4268e7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T17:26:44.740738Z","created_at":"2023-10-18T17:26:44.740738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e8c177fa-ad15-4ba8-ab2a-f530ce4268e7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e8c177fa-ad15-4ba8-ab2a-f530ce4268e7","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"6a3be534-eff7-48ad-bc55-d55fc9d0d221","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T17:26:44.793300Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b319e7df-5562-48f6-a2c5-e29c2ca00375.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.202960Z","created_at":"2023-11-07T16:20:01.202960Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b319e7df-5562-48f6-a2c5-e29c2ca00375.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b319e7df-5562-48f6-a2c5-e29c2ca00375","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7f53646-b279-4a10-8b55-be84031db17b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:01.214929Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1518"
+      - "1473"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:26:44 GMT
+      - Tue, 07 Nov 2023 16:20:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3151ee66-029e-4ac9-a33c-fbee1c45581f
+      - 274f4261-1d6d-4b83-8b81-1198e68ee568
     status: 200 OK
     code: 200
     duration: ""
@@ -181,19 +181,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e8c177fa-ad15-4ba8-ab2a-f530ce4268e7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e8c177fa-ad15-4ba8-ab2a-f530ce4268e7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T17:26:44.740738Z","created_at":"2023-10-18T17:26:44.740738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e8c177fa-ad15-4ba8-ab2a-f530ce4268e7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e8c177fa-ad15-4ba8-ab2a-f530ce4268e7","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"6a3be534-eff7-48ad-bc55-d55fc9d0d221","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T17:26:46.757593Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b319e7df-5562-48f6-a2c5-e29c2ca00375.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.202960Z","created_at":"2023-11-07T16:20:01.202960Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b319e7df-5562-48f6-a2c5-e29c2ca00375.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b319e7df-5562-48f6-a2c5-e29c2ca00375","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7f53646-b279-4a10-8b55-be84031db17b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.813028Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1523"
+      - "1478"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:26:49 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eaa307dc-f3c9-4f31-a3fa-14be4acf1e12
+      - 0e88596f-2675-4bde-8778-e1861a4b02a3
     status: 200 OK
     code: 200
     duration: ""
@@ -214,19 +214,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e8c177fa-ad15-4ba8-ab2a-f530ce4268e7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e8c177fa-ad15-4ba8-ab2a-f530ce4268e7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T17:26:44.740738Z","created_at":"2023-10-18T17:26:44.740738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e8c177fa-ad15-4ba8-ab2a-f530ce4268e7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e8c177fa-ad15-4ba8-ab2a-f530ce4268e7","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"6a3be534-eff7-48ad-bc55-d55fc9d0d221","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T17:26:46.757593Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b319e7df-5562-48f6-a2c5-e29c2ca00375.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.202960Z","created_at":"2023-11-07T16:20:01.202960Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b319e7df-5562-48f6-a2c5-e29c2ca00375.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b319e7df-5562-48f6-a2c5-e29c2ca00375","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7f53646-b279-4a10-8b55-be84031db17b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.813028Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1523"
+      - "1478"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:26:49 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e47300b-611b-4171-8096-8addd5b69c07
+      - 6276f075-74de-40bb-8c45-1d13635f02a8
     status: 200 OK
     code: 200
     duration: ""
@@ -247,19 +247,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e8c177fa-ad15-4ba8-ab2a-f530ce4268e7/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVelRXcFpNRTVzYjFoRVZFMTZUVlJCZUU1NlJUTk5hbGt3VG14dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTbVpYQ2tSUGFuUXpObnBsZDBJdlVuRlNZMkp6Tlc1M1RrSkJSRkZ5VEZGcmNtVkVRVzhyZUVSVGIwOWhZMEo0Y3pnelEwcDVlVmhWU0M5eE9XSkZka1pTV1hrS1NYVlBkSEJqV21GUE4wbGFLMlJZWjBjdlYxZHpLMnR3Y2xaVVVuZGFURWhpUjJRNWFVWnZaM01yZUVGbWEzcEJXbmd6VGtWTVdEUmxXR00wUm5Vck9RcHFTVXBCZFdWTmRXMUVOMXBhWkVKUEsyUTFiemhCWWxSQ1MyRkRPVUZPVG0wdlRuTlpNR1FyZDFwYWJUbFZVRE1yVURCU2RHUTBTa3ByYTJ4VlF6ZEtDalpxT0d0V1FXVTJOMEl3Vkd4U2VXNDRZWFZSTlVsck1rdEtiRnB6UmpsdlRXdHhWbE5VTkRoNmRFOXZaM1ZJUldSU1NrbHpUbU5GWjNNNWJIVlhXSFVLZGl0Vk9FUk5aVFV6TW1Ka2VFRTVkV2RrYjBaclpsUkhOWFpQYVhkTFJqWjJaMFJSTVRKbmN6SmFXa292YkVoUFIyMWtlVEl2VDNWcFJuUkdWaXR2TndwdVJXMXlNVTgzWVRGeWNIbE5ORXhJUkd3NFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTFdtWk9NRlpJZGxsTVQxcE1UVEJtTlRVemFHYzBZVWgxTHpKTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1l6SjVNVXBWVGxONVNVaExVVWg2UjFwNE16ZE1Za28zZWswckwwUkNNRTByZVRCR2NUQjBiWE5YUVRWaGVsSk5jUW94VkVwT1RYbFVNM2d4Y0hwU01XaDBVMkpuZDFaRVdVZFZRWFZLVTNOdGNVUnVWVEI1VkdkUWFtSmhSMWR1ZVc1ck56ZERXbkExUzA4MFRtMTZhMUpFQ25RcmVUQlBabVphV21GWlJXdEVXVTUyVGtkMlZsQk9hemh5WkVwWWRVdFZPRUpGV0hGa2JFMXNlVFI0ZVRGdkwyMVJRVGRvZUZOWGN5ODFVR1ZuYTA4S1VXNXlSVGMyY0RGS2VXVlFkWE5aTkVSbk5VbHZReTlDT0VSQmJEZE9NM2RpY1ZSTldXUktTazV3YTJkdlEzWlpVVk5CZDFOSFMydDNibXhhV2s1UVdncGpVR3Q2ZFVvemVtRndkRFExUW5WWVdrRnRMM3BtTUVzck5GWlZPVmxxUzI1clRHZE5SMk0yZEd0SU9GQjFZbmh3Vkhoa2JtdzJTV0p5ZEVZMFUzZFdDa0UwWjA1eU9UbEJPVGxVU0ZFNVltUnVUazlVVUUxT0sydHBMM0JQVm1WT1J5dHhZUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZThjMTc3ZmEtYWQxNS00YmE4LWFiMmEtZjUzMGNlNDI2OGU3LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB5Y3NJQTY5ZVZob0E4WWZCYTVKb24zOEQyTzlUU01Vc3J2b1dRUFpkeWNVR3dCOVo3Rnp0M1RVMQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEJkMDFzYjFoRVZFMTZUVlJGZDA1cVJUSk5ha0YzVFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUbFZCQ2tkVWVXNURlRGRwTlVGeGVVWlBlR3MwTjJkclZXY3JkMlpzWm1sRFpEQnFjSGhhUTBaU2FGRmxSR1ZtTUhablNqY3daelpMYm5WVU9YbFZlbE5KTkhnS2R6ZDFZMU50YUU5blExVllLMjV6Ym1JeE0wWk5WbWxsWWswd1JGVmxhbXAzY2pZeVdtVnJaRVZ4Y1dKRmJUbENkemxOVW1Gb2FrRlRkMk5rV2xSaFZ3cFhVM0ppVUVKTWRtbHpSRU54YldrclIyWmpSalpFZDNNMmVXSXdXRGxNVTIxb2J6Y3JjV1JHVVU1YVlYQlJOVzFLUlVST1JtVnVSRkI2WTAxUU1VOUNDbmx5VDA5Uk9TdDRhRUp4Yms1cE1Dc3lWMnBYZUhCek1qQjJkMnMwT1hOVFVYVkJZbFpUVEU5RFFrRndVR0p6UmxOVGExWmhPWHB1SzFSVFp6bDZTRmdLVkZZM2NuWktUSFJVYm1oTGNVTkhTVllyUm5wT1FsbDJiMDVwYUdaV1Z6RlNVRW8xYkV4a2RFZ3ZUemt4THpWdVJFMU9lR3ByYW14bk9IZERlRzlzZVFwbmFFTldVREIxU1Rjd1VFNTVOU3RVZWtFNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTVNWcHlkVVF2YTFZeVdURlBNazFtZW1KT05XWjNNMmN3ZFZGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRVMxTk9NRk5JTjA5NVZIZFVhSEF2UmxWSWVubEtRblJLWmk5b1kwTnBiRU4yVTNJME1rTndOMHhHTjNadmJsVlRUUXBtYkNzNVJUa3ZSMjluVDFOcWNuSkhkbFphUXpsbE0zcGFOM0JEZUVaM1pHOWpZVFZVTm1rM1RYWlZXbEJ2VkdsWWFHdG1kWGQ1YzBwaGNuQjRaa1UxQ2tGWmNXVjFRbVJHWml0UlNrSmFORFp1UjJsM01EZFNlbGhxTlRoVGEydGFVVFJ2UTNKRVl6WnNlbVZyVVc1alVFYzVkR05rTVN0VVNVUkJkVTVQUW0wS2VWaGhMemxWZHpsRWJFWmhhRk5qSzNKVlNtSk1VVTg0WjJkc2NFUmpVMUJyUzJ4NlJIWllSbGRCVDJwc01YVTVOek0wTDNvMEx6UlpNM3BNYWt0U05ncDNiM0kyZDAxTGNHNTRaV3R3U1ZWQlpsWlFkMGhZUmtkdGVsWndaSGh5T1dGTGMyOHhVVzlaWkhsalowNVNUWGcxUVV0TGJHSTJWbVJNY0dKdk1ERjJDbFp0V1hwQk4yMHdjaXRuY2pkU09HMUhiRkF5YWpCaVJubHRUMUZRVnpSblduSTNkUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYjMxOWU3ZGYtNTU2Mi00OGY2LWEyYzUtZTI5YzJjYTAwMzc1LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA1eXFobEh4cm8ydWJwelloV1BDVGh4TGRNVXJWV0xwR013ZDVrYnVGMDZXb2pJTTBWYzdTY0p5NA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2710"
+      - "2708"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:26:50 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad8b6cb3-a5da-43d9-b3a0-9d6e837f18ac
+      - 1aebb882-50f2-4cf2-8ea7-c129ed2c3cad
     status: 200 OK
     code: 200
     duration: ""
@@ -280,19 +280,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e8c177fa-ad15-4ba8-ab2a-f530ce4268e7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e8c177fa-ad15-4ba8-ab2a-f530ce4268e7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T17:26:44.740738Z","created_at":"2023-10-18T17:26:44.740738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e8c177fa-ad15-4ba8-ab2a-f530ce4268e7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e8c177fa-ad15-4ba8-ab2a-f530ce4268e7","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"6a3be534-eff7-48ad-bc55-d55fc9d0d221","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T17:26:46.757593Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b319e7df-5562-48f6-a2c5-e29c2ca00375.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.202960Z","created_at":"2023-11-07T16:20:01.202960Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b319e7df-5562-48f6-a2c5-e29c2ca00375.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b319e7df-5562-48f6-a2c5-e29c2ca00375","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7f53646-b279-4a10-8b55-be84031db17b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.813028Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1523"
+      - "1478"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:26:50 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73b6f873-c564-4f81-8d21-2ecc70d2cf7f
+      - 9812ac02-7fd8-45d4-8f6f-79fc84694273
     status: 200 OK
     code: 200
     duration: ""
@@ -313,19 +313,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6a3be534-eff7-48ad-bc55-d55fc9d0d221
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7f53646-b279-4a10-8b55-be84031db17b
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T17:26:43.392150Z","dhcp_enabled":true,"id":"6a3be534-eff7-48ad-bc55-d55fc9d0d221","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T17:26:43.392150Z","id":"d500e056-6397-47eb-9654-4402c581487b","subnet":"172.16.16.0/22","updated_at":"2023-10-18T17:26:43.392150Z"},{"created_at":"2023-10-18T17:26:43.392150Z","id":"b26df8da-60fc-4ed0-a991-3086679d352c","subnet":"fd63:256c:45f7:8c5c::/64","updated_at":"2023-10-18T17:26:43.392150Z"}],"tags":[],"updated_at":"2023-10-18T17:26:43.392150Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:19:59.780272Z","dhcp_enabled":true,"id":"e7f53646-b279-4a10-8b55-be84031db17b","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.780272Z","id":"40c98dce-5a7a-4dea-8eae-76d3bfd8da01","subnet":"172.16.24.0/22","updated_at":"2023-11-07T16:19:59.780272Z"},{"created_at":"2023-11-07T16:19:59.780272Z","id":"07f3dbc1-1163-4ce3-9516-ea9e678aa025","subnet":"fd63:256c:45f7:c212::/64","updated_at":"2023-11-07T16:19:59.780272Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.780272Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "720"
+      - "703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:26:50 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -335,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6044e60d-8359-4e6d-9c97-6f102a52b79d
+      - 18884fa8-b201-49b5-8a1f-47f076bbabc7
     status: 200 OK
     code: 200
     duration: ""
@@ -346,19 +346,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e8c177fa-ad15-4ba8-ab2a-f530ce4268e7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e8c177fa-ad15-4ba8-ab2a-f530ce4268e7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T17:26:44.740738Z","created_at":"2023-10-18T17:26:44.740738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e8c177fa-ad15-4ba8-ab2a-f530ce4268e7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e8c177fa-ad15-4ba8-ab2a-f530ce4268e7","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"6a3be534-eff7-48ad-bc55-d55fc9d0d221","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T17:26:46.757593Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b319e7df-5562-48f6-a2c5-e29c2ca00375.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.202960Z","created_at":"2023-11-07T16:20:01.202960Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b319e7df-5562-48f6-a2c5-e29c2ca00375.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b319e7df-5562-48f6-a2c5-e29c2ca00375","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7f53646-b279-4a10-8b55-be84031db17b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.813028Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1523"
+      - "1478"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:26:50 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -368,7 +368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59bfb245-bf58-4c39-b241-636aaddcf975
+      - c4828126-b42e-4074-9282-248a2340e8ca
     status: 200 OK
     code: 200
     duration: ""
@@ -379,19 +379,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6a3be534-eff7-48ad-bc55-d55fc9d0d221
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7f53646-b279-4a10-8b55-be84031db17b
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T17:26:43.392150Z","dhcp_enabled":true,"id":"6a3be534-eff7-48ad-bc55-d55fc9d0d221","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T17:26:43.392150Z","id":"d500e056-6397-47eb-9654-4402c581487b","subnet":"172.16.16.0/22","updated_at":"2023-10-18T17:26:43.392150Z"},{"created_at":"2023-10-18T17:26:43.392150Z","id":"b26df8da-60fc-4ed0-a991-3086679d352c","subnet":"fd63:256c:45f7:8c5c::/64","updated_at":"2023-10-18T17:26:43.392150Z"}],"tags":[],"updated_at":"2023-10-18T17:26:43.392150Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:19:59.780272Z","dhcp_enabled":true,"id":"e7f53646-b279-4a10-8b55-be84031db17b","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.780272Z","id":"40c98dce-5a7a-4dea-8eae-76d3bfd8da01","subnet":"172.16.24.0/22","updated_at":"2023-11-07T16:19:59.780272Z"},{"created_at":"2023-11-07T16:19:59.780272Z","id":"07f3dbc1-1163-4ce3-9516-ea9e678aa025","subnet":"fd63:256c:45f7:c212::/64","updated_at":"2023-11-07T16:19:59.780272Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.780272Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "720"
+      - "703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:26:50 GMT
+      - Tue, 07 Nov 2023 16:20:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -401,7 +401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8913b8fc-3bb1-4015-8697-5d2f54afdee4
+      - 3ad6e754-dff2-4d45-b367-4f57c1199f90
     status: 200 OK
     code: 200
     duration: ""
@@ -412,19 +412,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e8c177fa-ad15-4ba8-ab2a-f530ce4268e7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e8c177fa-ad15-4ba8-ab2a-f530ce4268e7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T17:26:44.740738Z","created_at":"2023-10-18T17:26:44.740738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e8c177fa-ad15-4ba8-ab2a-f530ce4268e7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e8c177fa-ad15-4ba8-ab2a-f530ce4268e7","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"6a3be534-eff7-48ad-bc55-d55fc9d0d221","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T17:26:46.757593Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b319e7df-5562-48f6-a2c5-e29c2ca00375.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.202960Z","created_at":"2023-11-07T16:20:01.202960Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b319e7df-5562-48f6-a2c5-e29c2ca00375.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b319e7df-5562-48f6-a2c5-e29c2ca00375","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7f53646-b279-4a10-8b55-be84031db17b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.813028Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1523"
+      - "1478"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:26:50 GMT
+      - Tue, 07 Nov 2023 16:20:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -434,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1ff4782-3bde-44b9-a0c8-0567063086b2
+      - ebd3313f-cf61-4e15-8fb9-8decfa2325e1
     status: 200 OK
     code: 200
     duration: ""
@@ -445,19 +445,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e8c177fa-ad15-4ba8-ab2a-f530ce4268e7/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVelRXcFpNRTVzYjFoRVZFMTZUVlJCZUU1NlJUTk5hbGt3VG14dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTbVpYQ2tSUGFuUXpObnBsZDBJdlVuRlNZMkp6Tlc1M1RrSkJSRkZ5VEZGcmNtVkVRVzhyZUVSVGIwOWhZMEo0Y3pnelEwcDVlVmhWU0M5eE9XSkZka1pTV1hrS1NYVlBkSEJqV21GUE4wbGFLMlJZWjBjdlYxZHpLMnR3Y2xaVVVuZGFURWhpUjJRNWFVWnZaM01yZUVGbWEzcEJXbmd6VGtWTVdEUmxXR00wUm5Vck9RcHFTVXBCZFdWTmRXMUVOMXBhWkVKUEsyUTFiemhCWWxSQ1MyRkRPVUZPVG0wdlRuTlpNR1FyZDFwYWJUbFZVRE1yVURCU2RHUTBTa3ByYTJ4VlF6ZEtDalpxT0d0V1FXVTJOMEl3Vkd4U2VXNDRZWFZSTlVsck1rdEtiRnB6UmpsdlRXdHhWbE5VTkRoNmRFOXZaM1ZJUldSU1NrbHpUbU5GWjNNNWJIVlhXSFVLZGl0Vk9FUk5aVFV6TW1Ka2VFRTVkV2RrYjBaclpsUkhOWFpQYVhkTFJqWjJaMFJSTVRKbmN6SmFXa292YkVoUFIyMWtlVEl2VDNWcFJuUkdWaXR2TndwdVJXMXlNVTgzWVRGeWNIbE5ORXhJUkd3NFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTFdtWk9NRlpJZGxsTVQxcE1UVEJtTlRVemFHYzBZVWgxTHpKTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1l6SjVNVXBWVGxONVNVaExVVWg2UjFwNE16ZE1Za28zZWswckwwUkNNRTByZVRCR2NUQjBiWE5YUVRWaGVsSk5jUW94VkVwT1RYbFVNM2d4Y0hwU01XaDBVMkpuZDFaRVdVZFZRWFZLVTNOdGNVUnVWVEI1VkdkUWFtSmhSMWR1ZVc1ck56ZERXbkExUzA4MFRtMTZhMUpFQ25RcmVUQlBabVphV21GWlJXdEVXVTUyVGtkMlZsQk9hemh5WkVwWWRVdFZPRUpGV0hGa2JFMXNlVFI0ZVRGdkwyMVJRVGRvZUZOWGN5ODFVR1ZuYTA4S1VXNXlSVGMyY0RGS2VXVlFkWE5aTkVSbk5VbHZReTlDT0VSQmJEZE9NM2RpY1ZSTldXUktTazV3YTJkdlEzWlpVVk5CZDFOSFMydDNibXhhV2s1UVdncGpVR3Q2ZFVvemVtRndkRFExUW5WWVdrRnRMM3BtTUVzck5GWlZPVmxxUzI1clRHZE5SMk0yZEd0SU9GQjFZbmh3Vkhoa2JtdzJTV0p5ZEVZMFUzZFdDa0UwWjA1eU9UbEJPVGxVU0ZFNVltUnVUazlVVUUxT0sydHBMM0JQVm1WT1J5dHhZUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZThjMTc3ZmEtYWQxNS00YmE4LWFiMmEtZjUzMGNlNDI2OGU3LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB5Y3NJQTY5ZVZob0E4WWZCYTVKb24zOEQyTzlUU01Vc3J2b1dRUFpkeWNVR3dCOVo3Rnp0M1RVMQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEJkMDFzYjFoRVZFMTZUVlJGZDA1cVJUSk5ha0YzVFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUbFZCQ2tkVWVXNURlRGRwTlVGeGVVWlBlR3MwTjJkclZXY3JkMlpzWm1sRFpEQnFjSGhhUTBaU2FGRmxSR1ZtTUhablNqY3daelpMYm5WVU9YbFZlbE5KTkhnS2R6ZDFZMU50YUU5blExVllLMjV6Ym1JeE0wWk5WbWxsWWswd1JGVmxhbXAzY2pZeVdtVnJaRVZ4Y1dKRmJUbENkemxOVW1Gb2FrRlRkMk5rV2xSaFZ3cFhVM0ppVUVKTWRtbHpSRU54YldrclIyWmpSalpFZDNNMmVXSXdXRGxNVTIxb2J6Y3JjV1JHVVU1YVlYQlJOVzFLUlVST1JtVnVSRkI2WTAxUU1VOUNDbmx5VDA5Uk9TdDRhRUp4Yms1cE1Dc3lWMnBYZUhCek1qQjJkMnMwT1hOVFVYVkJZbFpUVEU5RFFrRndVR0p6UmxOVGExWmhPWHB1SzFSVFp6bDZTRmdLVkZZM2NuWktUSFJVYm1oTGNVTkhTVllyUm5wT1FsbDJiMDVwYUdaV1Z6RlNVRW8xYkV4a2RFZ3ZUemt4THpWdVJFMU9lR3ByYW14bk9IZERlRzlzZVFwbmFFTldVREIxU1Rjd1VFNTVOU3RVZWtFNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTVNWcHlkVVF2YTFZeVdURlBNazFtZW1KT05XWjNNMmN3ZFZGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRVMxTk9NRk5JTjA5NVZIZFVhSEF2UmxWSWVubEtRblJLWmk5b1kwTnBiRU4yVTNJME1rTndOMHhHTjNadmJsVlRUUXBtYkNzNVJUa3ZSMjluVDFOcWNuSkhkbFphUXpsbE0zcGFOM0JEZUVaM1pHOWpZVFZVTm1rM1RYWlZXbEJ2VkdsWWFHdG1kWGQ1YzBwaGNuQjRaa1UxQ2tGWmNXVjFRbVJHWml0UlNrSmFORFp1UjJsM01EZFNlbGhxTlRoVGEydGFVVFJ2UTNKRVl6WnNlbVZyVVc1alVFYzVkR05rTVN0VVNVUkJkVTVQUW0wS2VWaGhMemxWZHpsRWJFWmhhRk5qSzNKVlNtSk1VVTg0WjJkc2NFUmpVMUJyUzJ4NlJIWllSbGRCVDJwc01YVTVOek0wTDNvMEx6UlpNM3BNYWt0U05ncDNiM0kyZDAxTGNHNTRaV3R3U1ZWQlpsWlFkMGhZUmtkdGVsWndaSGh5T1dGTGMyOHhVVzlaWkhsalowNVNUWGcxUVV0TGJHSTJWbVJNY0dKdk1ERjJDbFp0V1hwQk4yMHdjaXRuY2pkU09HMUhiRkF5YWpCaVJubHRUMUZRVnpSblduSTNkUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYjMxOWU3ZGYtNTU2Mi00OGY2LWEyYzUtZTI5YzJjYTAwMzc1LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA1eXFobEh4cm8ydWJwelloV1BDVGh4TGRNVXJWV0xwR013ZDVrYnVGMDZXb2pJTTBWYzdTY0p5NA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2710"
+      - "2708"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:26:50 GMT
+      - Tue, 07 Nov 2023 16:20:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -467,7 +467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9691d707-8f57-4ecc-9352-4ebc1e7611cc
+      - 2440a27e-87d7-45e2-bd51-c4195546bcf0
     status: 200 OK
     code: 200
     duration: ""
@@ -478,19 +478,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6a3be534-eff7-48ad-bc55-d55fc9d0d221
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7f53646-b279-4a10-8b55-be84031db17b
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T17:26:43.392150Z","dhcp_enabled":true,"id":"6a3be534-eff7-48ad-bc55-d55fc9d0d221","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T17:26:43.392150Z","id":"d500e056-6397-47eb-9654-4402c581487b","subnet":"172.16.16.0/22","updated_at":"2023-10-18T17:26:43.392150Z"},{"created_at":"2023-10-18T17:26:43.392150Z","id":"b26df8da-60fc-4ed0-a991-3086679d352c","subnet":"fd63:256c:45f7:8c5c::/64","updated_at":"2023-10-18T17:26:43.392150Z"}],"tags":[],"updated_at":"2023-10-18T17:26:43.392150Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:19:59.780272Z","dhcp_enabled":true,"id":"e7f53646-b279-4a10-8b55-be84031db17b","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.780272Z","id":"40c98dce-5a7a-4dea-8eae-76d3bfd8da01","subnet":"172.16.24.0/22","updated_at":"2023-11-07T16:19:59.780272Z"},{"created_at":"2023-11-07T16:19:59.780272Z","id":"07f3dbc1-1163-4ce3-9516-ea9e678aa025","subnet":"fd63:256c:45f7:c212::/64","updated_at":"2023-11-07T16:19:59.780272Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.780272Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "720"
+      - "703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:26:51 GMT
+      - Tue, 07 Nov 2023 16:20:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -500,7 +500,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e71d7c0a-9709-4725-bfc7-771f11bf2eae
+      - 815506f0-c39f-499e-ac87-af8c109c4765
     status: 200 OK
     code: 200
     duration: ""
@@ -511,19 +511,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e8c177fa-ad15-4ba8-ab2a-f530ce4268e7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e8c177fa-ad15-4ba8-ab2a-f530ce4268e7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T17:26:44.740738Z","created_at":"2023-10-18T17:26:44.740738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e8c177fa-ad15-4ba8-ab2a-f530ce4268e7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e8c177fa-ad15-4ba8-ab2a-f530ce4268e7","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"6a3be534-eff7-48ad-bc55-d55fc9d0d221","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T17:26:46.757593Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b319e7df-5562-48f6-a2c5-e29c2ca00375.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.202960Z","created_at":"2023-11-07T16:20:01.202960Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b319e7df-5562-48f6-a2c5-e29c2ca00375.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b319e7df-5562-48f6-a2c5-e29c2ca00375","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7f53646-b279-4a10-8b55-be84031db17b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.813028Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1523"
+      - "1478"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:26:51 GMT
+      - Tue, 07 Nov 2023 16:20:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -533,7 +533,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78f60483-6b62-4533-802d-648b5623099d
+      - 00d8586e-b16e-40ba-8a34-62ee2f0cdad0
     status: 200 OK
     code: 200
     duration: ""
@@ -544,19 +544,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e8c177fa-ad15-4ba8-ab2a-f530ce4268e7/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVelRXcFpNRTVzYjFoRVZFMTZUVlJCZUU1NlJUTk5hbGt3VG14dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJTbVpYQ2tSUGFuUXpObnBsZDBJdlVuRlNZMkp6Tlc1M1RrSkJSRkZ5VEZGcmNtVkVRVzhyZUVSVGIwOWhZMEo0Y3pnelEwcDVlVmhWU0M5eE9XSkZka1pTV1hrS1NYVlBkSEJqV21GUE4wbGFLMlJZWjBjdlYxZHpLMnR3Y2xaVVVuZGFURWhpUjJRNWFVWnZaM01yZUVGbWEzcEJXbmd6VGtWTVdEUmxXR00wUm5Vck9RcHFTVXBCZFdWTmRXMUVOMXBhWkVKUEsyUTFiemhCWWxSQ1MyRkRPVUZPVG0wdlRuTlpNR1FyZDFwYWJUbFZVRE1yVURCU2RHUTBTa3ByYTJ4VlF6ZEtDalpxT0d0V1FXVTJOMEl3Vkd4U2VXNDRZWFZSTlVsck1rdEtiRnB6UmpsdlRXdHhWbE5VTkRoNmRFOXZaM1ZJUldSU1NrbHpUbU5GWjNNNWJIVlhXSFVLZGl0Vk9FUk5aVFV6TW1Ka2VFRTVkV2RrYjBaclpsUkhOWFpQYVhkTFJqWjJaMFJSTVRKbmN6SmFXa292YkVoUFIyMWtlVEl2VDNWcFJuUkdWaXR2TndwdVJXMXlNVTgzWVRGeWNIbE5ORXhJUkd3NFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTFdtWk9NRlpJZGxsTVQxcE1UVEJtTlRVemFHYzBZVWgxTHpKTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ1l6SjVNVXBWVGxONVNVaExVVWg2UjFwNE16ZE1Za28zZWswckwwUkNNRTByZVRCR2NUQjBiWE5YUVRWaGVsSk5jUW94VkVwT1RYbFVNM2d4Y0hwU01XaDBVMkpuZDFaRVdVZFZRWFZLVTNOdGNVUnVWVEI1VkdkUWFtSmhSMWR1ZVc1ck56ZERXbkExUzA4MFRtMTZhMUpFQ25RcmVUQlBabVphV21GWlJXdEVXVTUyVGtkMlZsQk9hemh5WkVwWWRVdFZPRUpGV0hGa2JFMXNlVFI0ZVRGdkwyMVJRVGRvZUZOWGN5ODFVR1ZuYTA4S1VXNXlSVGMyY0RGS2VXVlFkWE5aTkVSbk5VbHZReTlDT0VSQmJEZE9NM2RpY1ZSTldXUktTazV3YTJkdlEzWlpVVk5CZDFOSFMydDNibXhhV2s1UVdncGpVR3Q2ZFVvemVtRndkRFExUW5WWVdrRnRMM3BtTUVzck5GWlZPVmxxUzI1clRHZE5SMk0yZEd0SU9GQjFZbmh3Vkhoa2JtdzJTV0p5ZEVZMFUzZFdDa0UwWjA1eU9UbEJPVGxVU0ZFNVltUnVUazlVVUUxT0sydHBMM0JQVm1WT1J5dHhZUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZThjMTc3ZmEtYWQxNS00YmE4LWFiMmEtZjUzMGNlNDI2OGU3LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB5Y3NJQTY5ZVZob0E4WWZCYTVKb24zOEQyTzlUU01Vc3J2b1dRUFpkeWNVR3dCOVo3Rnp0M1RVMQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEJkMDFzYjFoRVZFMTZUVlJGZDA1cVJUSk5ha0YzVFd4dmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUbFZCQ2tkVWVXNURlRGRwTlVGeGVVWlBlR3MwTjJkclZXY3JkMlpzWm1sRFpEQnFjSGhhUTBaU2FGRmxSR1ZtTUhablNqY3daelpMYm5WVU9YbFZlbE5KTkhnS2R6ZDFZMU50YUU5blExVllLMjV6Ym1JeE0wWk5WbWxsWWswd1JGVmxhbXAzY2pZeVdtVnJaRVZ4Y1dKRmJUbENkemxOVW1Gb2FrRlRkMk5rV2xSaFZ3cFhVM0ppVUVKTWRtbHpSRU54YldrclIyWmpSalpFZDNNMmVXSXdXRGxNVTIxb2J6Y3JjV1JHVVU1YVlYQlJOVzFLUlVST1JtVnVSRkI2WTAxUU1VOUNDbmx5VDA5Uk9TdDRhRUp4Yms1cE1Dc3lWMnBYZUhCek1qQjJkMnMwT1hOVFVYVkJZbFpUVEU5RFFrRndVR0p6UmxOVGExWmhPWHB1SzFSVFp6bDZTRmdLVkZZM2NuWktUSFJVYm1oTGNVTkhTVllyUm5wT1FsbDJiMDVwYUdaV1Z6RlNVRW8xYkV4a2RFZ3ZUemt4THpWdVJFMU9lR3ByYW14bk9IZERlRzlzZVFwbmFFTldVREIxU1Rjd1VFNTVOU3RVZWtFNFEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTVNWcHlkVVF2YTFZeVdURlBNazFtZW1KT05XWjNNMmN3ZFZGTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGRVMxTk9NRk5JTjA5NVZIZFVhSEF2UmxWSWVubEtRblJLWmk5b1kwTnBiRU4yVTNJME1rTndOMHhHTjNadmJsVlRUUXBtYkNzNVJUa3ZSMjluVDFOcWNuSkhkbFphUXpsbE0zcGFOM0JEZUVaM1pHOWpZVFZVTm1rM1RYWlZXbEJ2VkdsWWFHdG1kWGQ1YzBwaGNuQjRaa1UxQ2tGWmNXVjFRbVJHWml0UlNrSmFORFp1UjJsM01EZFNlbGhxTlRoVGEydGFVVFJ2UTNKRVl6WnNlbVZyVVc1alVFYzVkR05rTVN0VVNVUkJkVTVQUW0wS2VWaGhMemxWZHpsRWJFWmhhRk5qSzNKVlNtSk1VVTg0WjJkc2NFUmpVMUJyUzJ4NlJIWllSbGRCVDJwc01YVTVOek0wTDNvMEx6UlpNM3BNYWt0U05ncDNiM0kyZDAxTGNHNTRaV3R3U1ZWQlpsWlFkMGhZUmtkdGVsWndaSGh5T1dGTGMyOHhVVzlaWkhsalowNVNUWGcxUVV0TGJHSTJWbVJNY0dKdk1ERjJDbFp0V1hwQk4yMHdjaXRuY2pkU09HMUhiRkF5YWpCaVJubHRUMUZRVnpSblduSTNkUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vYjMxOWU3ZGYtNTU2Mi00OGY2LWEyYzUtZTI5YzJjYTAwMzc1LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA1eXFobEh4cm8ydWJwelloV1BDVGh4TGRNVXJWV0xwR013ZDVrYnVGMDZXb2pJTTBWYzdTY0p5NA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2710"
+      - "2708"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:26:51 GMT
+      - Tue, 07 Nov 2023 16:20:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -566,7 +566,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6821f652-f505-43a0-af35-6a01af9df94b
+      - be9836d7-8f50-4152-b92f-6438921cd88e
     status: 200 OK
     code: 200
     duration: ""
@@ -577,19 +577,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e8c177fa-ad15-4ba8-ab2a-f530ce4268e7?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375?with_additional_resources=false
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e8c177fa-ad15-4ba8-ab2a-f530ce4268e7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T17:26:44.740738Z","created_at":"2023-10-18T17:26:44.740738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e8c177fa-ad15-4ba8-ab2a-f530ce4268e7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e8c177fa-ad15-4ba8-ab2a-f530ce4268e7","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"6a3be534-eff7-48ad-bc55-d55fc9d0d221","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T17:26:51.929631596Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b319e7df-5562-48f6-a2c5-e29c2ca00375.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.202960Z","created_at":"2023-11-07T16:20:01.202960Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b319e7df-5562-48f6-a2c5-e29c2ca00375.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b319e7df-5562-48f6-a2c5-e29c2ca00375","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7f53646-b279-4a10-8b55-be84031db17b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:08.641478961Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1521"
+      - "1476"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:26:51 GMT
+      - Tue, 07 Nov 2023 16:20:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -599,7 +599,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1fb60a26-d933-4275-bdb3-c3e9fab210d6
+      - 39752d40-2fdf-4f02-b75c-1239bb97b2a1
     status: 200 OK
     code: 200
     duration: ""
@@ -610,19 +610,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e8c177fa-ad15-4ba8-ab2a-f530ce4268e7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e8c177fa-ad15-4ba8-ab2a-f530ce4268e7.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T17:26:44.740738Z","created_at":"2023-10-18T17:26:44.740738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e8c177fa-ad15-4ba8-ab2a-f530ce4268e7.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e8c177fa-ad15-4ba8-ab2a-f530ce4268e7","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"6a3be534-eff7-48ad-bc55-d55fc9d0d221","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T17:26:51.929632Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://b319e7df-5562-48f6-a2c5-e29c2ca00375.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:01.202960Z","created_at":"2023-11-07T16:20:01.202960Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.b319e7df-5562-48f6-a2c5-e29c2ca00375.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"b319e7df-5562-48f6-a2c5-e29c2ca00375","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e7f53646-b279-4a10-8b55-be84031db17b","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:08.641479Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1518"
+      - "1473"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:26:52 GMT
+      - Tue, 07 Nov 2023 16:20:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -632,7 +632,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc9cc3c3-2f46-48bc-bd7c-ddab81bf8508
+      - 3c8d8fa2-68f1-4e40-bc90-99971134879b
     status: 200 OK
     code: 200
     duration: ""
@@ -643,10 +643,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e8c177fa-ad15-4ba8-ab2a-f530ce4268e7
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/b319e7df-5562-48f6-a2c5-e29c2ca00375
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"e8c177fa-ad15-4ba8-ab2a-f530ce4268e7","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"b319e7df-5562-48f6-a2c5-e29c2ca00375","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -655,7 +655,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:26:57 GMT
+      - Tue, 07 Nov 2023 16:20:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -665,12 +665,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5614c553-af2c-4484-9fc6-4fc2d78a418c
+      - 0d9e700d-0844-4cda-ab17-c767996bd35b
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"name":"other-private-network","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"other-private-network","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -681,16 +681,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-18T17:26:57.136489Z","dhcp_enabled":true,"id":"02f63466-90d0-48be-8b23-68f750589571","name":"other-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T17:26:57.136489Z","id":"545a4856-8091-4572-a6cf-5c5576ac127e","subnet":"172.16.0.0/22","updated_at":"2023-10-18T17:26:57.136489Z"},{"created_at":"2023-10-18T17:26:57.136489Z","id":"fdaedd6c-a4d4-4b8d-b8fe-a4a11986e759","subnet":"fd63:256c:45f7:3fee::/64","updated_at":"2023-10-18T17:26:57.136489Z"}],"tags":[],"updated_at":"2023-10-18T17:26:57.136489Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:20:13.855092Z","dhcp_enabled":true,"id":"c8e07b1d-1267-417b-9678-cff85d318b6c","name":"other-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:20:13.855092Z","id":"67403ad0-3b3d-4b2f-9645-e6bc76a0dc8e","subnet":"172.16.40.0/22","updated_at":"2023-11-07T16:20:13.855092Z"},{"created_at":"2023-11-07T16:20:13.855092Z","id":"4858e44f-4032-4960-9ce7-8bcfd548a087","subnet":"fd63:256c:45f7:8588::/64","updated_at":"2023-11-07T16:20:13.855092Z"}],"tags":[],"updated_at":"2023-11-07T16:20:13.855092Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "721"
+      - "705"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:26:57 GMT
+      - Tue, 07 Nov 2023 16:20:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef0b5c5a-bc0f-42c1-bd4a-c2085314f76a
+      - a031bb3e-ac29-4723-8b34-bcf470d22b90
     status: 200 OK
     code: 200
     duration: ""
@@ -711,19 +711,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/02f63466-90d0-48be-8b23-68f750589571
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c8e07b1d-1267-417b-9678-cff85d318b6c
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T17:26:57.136489Z","dhcp_enabled":true,"id":"02f63466-90d0-48be-8b23-68f750589571","name":"other-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T17:26:57.136489Z","id":"545a4856-8091-4572-a6cf-5c5576ac127e","subnet":"172.16.0.0/22","updated_at":"2023-10-18T17:26:57.136489Z"},{"created_at":"2023-10-18T17:26:57.136489Z","id":"fdaedd6c-a4d4-4b8d-b8fe-a4a11986e759","subnet":"fd63:256c:45f7:3fee::/64","updated_at":"2023-10-18T17:26:57.136489Z"}],"tags":[],"updated_at":"2023-10-18T17:26:57.136489Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:20:13.855092Z","dhcp_enabled":true,"id":"c8e07b1d-1267-417b-9678-cff85d318b6c","name":"other-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:20:13.855092Z","id":"67403ad0-3b3d-4b2f-9645-e6bc76a0dc8e","subnet":"172.16.40.0/22","updated_at":"2023-11-07T16:20:13.855092Z"},{"created_at":"2023-11-07T16:20:13.855092Z","id":"4858e44f-4032-4960-9ce7-8bcfd548a087","subnet":"fd63:256c:45f7:8588::/64","updated_at":"2023-11-07T16:20:13.855092Z"}],"tags":[],"updated_at":"2023-11-07T16:20:13.855092Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "721"
+      - "705"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:26:58 GMT
+      - Tue, 07 Nov 2023 16:20:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,12 +733,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e005a02-6553-41bd-841a-ec046b20325b
+      - fa166378-366b-4040-bd04-9190f168b3e3
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"k8s-private-network-cluster","description":"","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":"02f63466-90d0-48be-8b23-68f750589571"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"","name":"k8s-private-network-cluster","description":"","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"version":"1.28.2","cni":"calico","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"c8e07b1d-1267-417b-9678-cff85d318b6c"}'
     form: {}
     headers:
       Content-Type:
@@ -749,16 +749,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d30bc90c-849c-441a-b765-324e245c9506.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T17:26:58.538708699Z","created_at":"2023-10-18T17:26:58.538708699Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d30bc90c-849c-441a-b765-324e245c9506.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d30bc90c-849c-441a-b765-324e245c9506","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"02f63466-90d0-48be-8b23-68f750589571","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T17:26:58.553738392Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://363fe404-36c7-4c92-a3ca-daed5d218c63.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:15.921622925Z","created_at":"2023-11-07T16:20:15.921622925Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.363fe404-36c7-4c92-a3ca-daed5d218c63.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"363fe404-36c7-4c92-a3ca-daed5d218c63","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c8e07b1d-1267-417b-9678-cff85d318b6c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:16.003047962Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1527"
+      - "1482"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:26:58 GMT
+      - Tue, 07 Nov 2023 16:20:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -768,7 +768,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b29f881a-8f4a-4e62-9c48-36e5b885551e
+      - a17fad14-da54-48a4-a6ad-d38b38ecf206
     status: 200 OK
     code: 200
     duration: ""
@@ -779,19 +779,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d30bc90c-849c-441a-b765-324e245c9506
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d30bc90c-849c-441a-b765-324e245c9506.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T17:26:58.538709Z","created_at":"2023-10-18T17:26:58.538709Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d30bc90c-849c-441a-b765-324e245c9506.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d30bc90c-849c-441a-b765-324e245c9506","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"02f63466-90d0-48be-8b23-68f750589571","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T17:26:58.553738Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://363fe404-36c7-4c92-a3ca-daed5d218c63.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:15.921623Z","created_at":"2023-11-07T16:20:15.921623Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.363fe404-36c7-4c92-a3ca-daed5d218c63.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"363fe404-36c7-4c92-a3ca-daed5d218c63","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c8e07b1d-1267-417b-9678-cff85d318b6c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:16.003048Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1518"
+      - "1473"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:26:58 GMT
+      - Tue, 07 Nov 2023 16:20:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -801,7 +801,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e80a4493-855a-460e-9669-dded6092094e
+      - 594dc933-9371-4bdf-b55c-49f73f2ec2e5
     status: 200 OK
     code: 200
     duration: ""
@@ -812,19 +812,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d30bc90c-849c-441a-b765-324e245c9506
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d30bc90c-849c-441a-b765-324e245c9506.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T17:26:58.538709Z","created_at":"2023-10-18T17:26:58.538709Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d30bc90c-849c-441a-b765-324e245c9506.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d30bc90c-849c-441a-b765-324e245c9506","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"02f63466-90d0-48be-8b23-68f750589571","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T17:27:00.077774Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://363fe404-36c7-4c92-a3ca-daed5d218c63.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:15.921623Z","created_at":"2023-11-07T16:20:15.921623Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.363fe404-36c7-4c92-a3ca-daed5d218c63.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"363fe404-36c7-4c92-a3ca-daed5d218c63","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c8e07b1d-1267-417b-9678-cff85d318b6c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:18.999330Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1523"
+      - "1478"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:27:03 GMT
+      - Tue, 07 Nov 2023 16:20:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -834,7 +834,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d1f02ae-0c3c-46a7-9f6a-4b4f3d653048
+      - 0f1b1cd4-2a20-41d2-aad5-5233c2bf2319
     status: 200 OK
     code: 200
     duration: ""
@@ -845,19 +845,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d30bc90c-849c-441a-b765-324e245c9506
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d30bc90c-849c-441a-b765-324e245c9506.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T17:26:58.538709Z","created_at":"2023-10-18T17:26:58.538709Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d30bc90c-849c-441a-b765-324e245c9506.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d30bc90c-849c-441a-b765-324e245c9506","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"02f63466-90d0-48be-8b23-68f750589571","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T17:27:00.077774Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://363fe404-36c7-4c92-a3ca-daed5d218c63.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:15.921623Z","created_at":"2023-11-07T16:20:15.921623Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.363fe404-36c7-4c92-a3ca-daed5d218c63.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"363fe404-36c7-4c92-a3ca-daed5d218c63","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c8e07b1d-1267-417b-9678-cff85d318b6c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:18.999330Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1523"
+      - "1478"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:27:03 GMT
+      - Tue, 07 Nov 2023 16:20:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -867,7 +867,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8722b51d-6b8e-444d-8ab4-316b0485e41a
+      - 828350b2-d422-47a8-993a-abd871369f27
     status: 200 OK
     code: 200
     duration: ""
@@ -878,19 +878,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d30bc90c-849c-441a-b765-324e245c9506/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVelRXcFpNVTlXYjFoRVZFMTZUVlJCZUU1NlJUTk5hbGt4VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJVRVFyQ2tzcmF5OURkVXRpWW1FeGJITjFkbHBQUW5aNVNYZFhhbWhGZVVoc1YzZFBjbkpLYWxKVVdrOUhWVmRZYjFNNVIyNVlUMk0yVkZac1RtVnRibUZ0VDJVS1RHSkZlazQwTVVwVFRUVktRbFJTWVZWd2RFbExXV3cyTkdWR2RXeDJSM0JxVTB0TFdTdFdVa3cxT0V4S1RrNU9hVEJyWWswMmFXWjVOMjVvTW00Mlp3bzJPVnA0UmpScGJsSXdSRTFwTkdzNGNXcEtMekpKZW14d2IzcFRiU3RIYVVSdFRuUnNkREJtT0hrMmNuWk1Xa0ZJT0ZaM1JFZHBUa2RrV0cwMVNtWTRDa1pHZUhock1XTkhVVTVZWlM5Q1pHaHVhRE5sVDNaV2RHSmhSRXRyWkVGNVVYTklWVWRNVW1GV1N6VXhOMmRTUzB0cWIzbEtZa2t6TlZSSlFXaFJXRzhLY0hKMlJtNW5jRkJhWVdGMFdrUkZjVUpxZGxvd1VEUTFkMVJDWWk5eFJuWndRalF6ZUdkclpYSXdOSEpwV0RkV1FXRkRablJhVEhSdlJFcG5lWFozTndwNFpXSkRTMjVQYTBacWVWVXZiVEJ5UjJJd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTE1FRXliWHBXYVhWQ1dEVTRTWGhNWlU1MVJXOTZWbGhsUlZOTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ09HdHFZV1I2YnpKS2NWaFRPSEpWVDNSTFVHOUpaMnRPVTJKS2VtbFVhRk01U1VKS1ZsTlZiVkpJVlhoUk1qbDNlQXBpT1RoeGRUbEhhekZYTTNOcWJHWlBiVTU0UkZGbVUzQm1PVlZZYTBFM1kzazFjM1Z4WkVkcFZIRTVZWE5VU0RNNWEzZEpSa05ZYURCck1FRTRUMjVzQ2xOUE5FVlNORFJaZFVaRllYVllja2huYTFKQ1V6ZGllaXMwUkhSeWJXbFZXV0prVkM5bE1TdGxjazlhUW5samVrOUpRVTF2UmxoRGNGUlhPRk01TVZrS0sybExjMDR6VFRsVk1VVm9MMVp6WTNoVlNIaFVhVWxOV1U1bk5FdGhSa0kwVVVWT1R5OUpiMFJQZGtZd01ucGxNR2hJT1VWVVIyY3pPWGxxVlc1NGRBcHdha0ptY1V4MVIyTjBOVmh2UVc5eFFsQjBZa0ZaZDJwSE5ESkdaRFprYm5SNE1sSlFZVWxLTldaaFEyVnVWM1Z4T1RrckswbDNObTVST0dOT01rVXpDbmw2UzBwRFZXRnRWbXR5U0dRelRHbzRVa2RTWVVoMVNrbEZNRzVITmtWRFdVa3pXUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZDMwYmM5MGMtODQ5Yy00NDFhLWI3NjUtMzI0ZTI0NWM5NTA2LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBRakFDRTg4RTl5Y2JEa3Rmc3oxd2I2Z1hNdTBiejRzWHF1NHFvRWdreXI4UmprSHJ3OFIxajl5Rw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEJlRTlHYjFoRVZFMTZUVlJGZDA1cVJUSk5ha0Y0VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUWG80Q2s1R1kwOUVWRXh6UVM4dkwzbEtWa3hvVERoc2JtazJlRlJLY1cxRWNrMXVPR1kwUTIxWWFXSm5NRzgxWmtkalJHRkpiMEUwVGswMFUwWkVaR05EU0U4S2RUZENVRlJvZG5Od2FFVnBVbUl4WXpCMGVHcGlUVFJIUzA1d1lVRmxkVVJpYm14SmMwZDFNSFZwUVd0a2EzVTRiM1JvVTJZdlMzbHNkU3N6Y2xwWlRncHFiazVYYkVSbVMyNVNieXRZYVVGdk5XOURVMDVDTkdOdFMxcE1aMFF4YjI5Q1JXWTFaMHhHVmk5cWNGSjFiV0ZQVWpSSGRuazRMMlF4VWtGMk1qWlJDakpJVjNoNlZuTnpkRWg1TVZWRlEyRXllakpHWVVZcldYbzVhVmRXUm0xcVQyVnlTMU5tZDFsMlYyMVJZa2RIYzA1aUwzWkxkVzlhYzJsbFlVZDVVMndLZHpWS00wbHFVRkV5UkM5MVZsWnJibEZXVVd3M1lUUmFNMDE1ZURoSFFYb3JWblE0V0UwNWRuRnpNWEJxT0RCTVdGWkxUa1JPYzFrM2FFVlhjWGRWWmdwalR6ZFRiRXBuVW5GRU9HMTROSE16TWtSRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUVptcFRWMGxJTUcxWVRGQTBlVEZKU201RlJEVXZMMkZ4WTJoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlJERlpUbWw1ZVd3ek5UQklSR2xqV0V0TWFrY3pWVmhyTlZweVJHTTFhRUpDVGpnM00xWXlOV2t3WTNFek5teDRTZ28yUldwQkwweEpWWGc1V0Uxb1JVVmhXV05DZUhKMU1FOVRlbkpqTlRCdFdWRjBlWEpCUm1wcVMxQlViVmhPYkhFNVEySkxVMGRpVEhFeGRsWkxPR0pNQ214VFZWbHZiVTlIWkdkc2FqVnRORFJUZFZOcGJtVmFRV1Z2Tmt0ekswSlVhVTk0ZGs1M1ZrbzJWVEUwT1ZSaU5GUlFabVE0VFhRMU1XZ3JRME5ZUWxZS1VYVlBUSGxHTUZOc1RsQkhLM013WmpoMWNVTjJVWFJHV2psbFpFNVZaSEZtVW5aSVoxTk9hbE5SZWk5b1p6TXZaV2RDYjNoTFZUQnpPWGRuV1hkTU1ncDNTRVJYYW1STFZUTmhkbFk0WnpnelZXeDBSVFpPUzFCVWQySndZbTVHVTJscWQxVXhaRWhJTmtWck5IVm9SV1ZFT1RaWmQzUmhRMjA1YlRWM1JrNUtDbE5zUW1Sd2IwaEVkVTV1TDJRcmFXOVNWSEZsVUhadGJ6VmFNM1E0YzJ4WmIzaHFUZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMzYzZmU0MDQtMzZjNy00YzkyLWEzY2EtZGFlZDVkMjE4YzYzLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB0clN1RDJhRjF1NEZic2M1WWtLdlhwS0lKbVJhSDg4WHZidXlCVUV6WHZ5bng5RjBCVmRFS0h3ZA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2710"
+      - "2708"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:27:03 GMT
+      - Tue, 07 Nov 2023 16:20:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -900,7 +900,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7fb0618-9a29-4277-8106-727d30619a55
+      - 34fdae59-bd59-4e64-89f5-c4bd7633a3eb
     status: 200 OK
     code: 200
     duration: ""
@@ -911,19 +911,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d30bc90c-849c-441a-b765-324e245c9506
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d30bc90c-849c-441a-b765-324e245c9506.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T17:26:58.538709Z","created_at":"2023-10-18T17:26:58.538709Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d30bc90c-849c-441a-b765-324e245c9506.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d30bc90c-849c-441a-b765-324e245c9506","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"02f63466-90d0-48be-8b23-68f750589571","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T17:27:00.077774Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://363fe404-36c7-4c92-a3ca-daed5d218c63.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:15.921623Z","created_at":"2023-11-07T16:20:15.921623Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.363fe404-36c7-4c92-a3ca-daed5d218c63.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"363fe404-36c7-4c92-a3ca-daed5d218c63","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c8e07b1d-1267-417b-9678-cff85d318b6c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:18.999330Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1523"
+      - "1478"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:27:04 GMT
+      - Tue, 07 Nov 2023 16:20:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -933,7 +933,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5652ffe3-face-4bc5-ac83-ac4a4f946a76
+      - c371b92c-382e-41b0-a8c8-ffd73198f254
     status: 200 OK
     code: 200
     duration: ""
@@ -944,19 +944,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6a3be534-eff7-48ad-bc55-d55fc9d0d221
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7f53646-b279-4a10-8b55-be84031db17b
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T17:26:43.392150Z","dhcp_enabled":true,"id":"6a3be534-eff7-48ad-bc55-d55fc9d0d221","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T17:26:43.392150Z","id":"d500e056-6397-47eb-9654-4402c581487b","subnet":"172.16.16.0/22","updated_at":"2023-10-18T17:26:43.392150Z"},{"created_at":"2023-10-18T17:26:43.392150Z","id":"b26df8da-60fc-4ed0-a991-3086679d352c","subnet":"fd63:256c:45f7:8c5c::/64","updated_at":"2023-10-18T17:26:43.392150Z"}],"tags":[],"updated_at":"2023-10-18T17:26:43.392150Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:19:59.780272Z","dhcp_enabled":true,"id":"e7f53646-b279-4a10-8b55-be84031db17b","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.780272Z","id":"40c98dce-5a7a-4dea-8eae-76d3bfd8da01","subnet":"172.16.24.0/22","updated_at":"2023-11-07T16:19:59.780272Z"},{"created_at":"2023-11-07T16:19:59.780272Z","id":"07f3dbc1-1163-4ce3-9516-ea9e678aa025","subnet":"fd63:256c:45f7:c212::/64","updated_at":"2023-11-07T16:19:59.780272Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.780272Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "720"
+      - "703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:27:04 GMT
+      - Tue, 07 Nov 2023 16:20:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -966,7 +966,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1de01863-b61d-4d70-bab6-7cf46b6a78ad
+      - f4416849-7852-44af-95dd-0cd4cb48afbf
     status: 200 OK
     code: 200
     duration: ""
@@ -977,19 +977,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/02f63466-90d0-48be-8b23-68f750589571
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c8e07b1d-1267-417b-9678-cff85d318b6c
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T17:26:57.136489Z","dhcp_enabled":true,"id":"02f63466-90d0-48be-8b23-68f750589571","name":"other-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T17:26:57.136489Z","id":"545a4856-8091-4572-a6cf-5c5576ac127e","subnet":"172.16.0.0/22","updated_at":"2023-10-18T17:26:57.136489Z"},{"created_at":"2023-10-18T17:26:57.136489Z","id":"fdaedd6c-a4d4-4b8d-b8fe-a4a11986e759","subnet":"fd63:256c:45f7:3fee::/64","updated_at":"2023-10-18T17:26:57.136489Z"}],"tags":[],"updated_at":"2023-10-18T17:26:57.136489Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:20:13.855092Z","dhcp_enabled":true,"id":"c8e07b1d-1267-417b-9678-cff85d318b6c","name":"other-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:20:13.855092Z","id":"67403ad0-3b3d-4b2f-9645-e6bc76a0dc8e","subnet":"172.16.40.0/22","updated_at":"2023-11-07T16:20:13.855092Z"},{"created_at":"2023-11-07T16:20:13.855092Z","id":"4858e44f-4032-4960-9ce7-8bcfd548a087","subnet":"fd63:256c:45f7:8588::/64","updated_at":"2023-11-07T16:20:13.855092Z"}],"tags":[],"updated_at":"2023-11-07T16:20:13.855092Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "721"
+      - "705"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:27:04 GMT
+      - Tue, 07 Nov 2023 16:20:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -999,7 +999,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9556751c-e3af-40d9-b603-85fe755d9e86
+      - c222f5fd-3420-419a-8943-881d08ceef16
     status: 200 OK
     code: 200
     duration: ""
@@ -1010,19 +1010,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d30bc90c-849c-441a-b765-324e245c9506
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d30bc90c-849c-441a-b765-324e245c9506.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T17:26:58.538709Z","created_at":"2023-10-18T17:26:58.538709Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d30bc90c-849c-441a-b765-324e245c9506.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d30bc90c-849c-441a-b765-324e245c9506","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"02f63466-90d0-48be-8b23-68f750589571","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T17:27:00.077774Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://363fe404-36c7-4c92-a3ca-daed5d218c63.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:15.921623Z","created_at":"2023-11-07T16:20:15.921623Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.363fe404-36c7-4c92-a3ca-daed5d218c63.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"363fe404-36c7-4c92-a3ca-daed5d218c63","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c8e07b1d-1267-417b-9678-cff85d318b6c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:18.999330Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1523"
+      - "1478"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:27:04 GMT
+      - Tue, 07 Nov 2023 16:20:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1032,7 +1032,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1618276f-d512-40bf-a9a6-b1289bdad0c8
+      - a884ac0a-a68d-4960-860e-89773542c584
     status: 200 OK
     code: 200
     duration: ""
@@ -1043,19 +1043,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6a3be534-eff7-48ad-bc55-d55fc9d0d221
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c8e07b1d-1267-417b-9678-cff85d318b6c
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T17:26:43.392150Z","dhcp_enabled":true,"id":"6a3be534-eff7-48ad-bc55-d55fc9d0d221","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T17:26:43.392150Z","id":"d500e056-6397-47eb-9654-4402c581487b","subnet":"172.16.16.0/22","updated_at":"2023-10-18T17:26:43.392150Z"},{"created_at":"2023-10-18T17:26:43.392150Z","id":"b26df8da-60fc-4ed0-a991-3086679d352c","subnet":"fd63:256c:45f7:8c5c::/64","updated_at":"2023-10-18T17:26:43.392150Z"}],"tags":[],"updated_at":"2023-10-18T17:26:43.392150Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:20:13.855092Z","dhcp_enabled":true,"id":"c8e07b1d-1267-417b-9678-cff85d318b6c","name":"other-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:20:13.855092Z","id":"67403ad0-3b3d-4b2f-9645-e6bc76a0dc8e","subnet":"172.16.40.0/22","updated_at":"2023-11-07T16:20:13.855092Z"},{"created_at":"2023-11-07T16:20:13.855092Z","id":"4858e44f-4032-4960-9ce7-8bcfd548a087","subnet":"fd63:256c:45f7:8588::/64","updated_at":"2023-11-07T16:20:13.855092Z"}],"tags":[],"updated_at":"2023-11-07T16:20:13.855092Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "720"
+      - "705"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:27:04 GMT
+      - Tue, 07 Nov 2023 16:20:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1065,7 +1065,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2edbf4b8-eecb-4433-b162-f2480d17201c
+      - a0ea4fea-2352-4fbe-9153-5f3d52b42ea0
     status: 200 OK
     code: 200
     duration: ""
@@ -1076,19 +1076,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/02f63466-90d0-48be-8b23-68f750589571
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7f53646-b279-4a10-8b55-be84031db17b
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T17:26:57.136489Z","dhcp_enabled":true,"id":"02f63466-90d0-48be-8b23-68f750589571","name":"other-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T17:26:57.136489Z","id":"545a4856-8091-4572-a6cf-5c5576ac127e","subnet":"172.16.0.0/22","updated_at":"2023-10-18T17:26:57.136489Z"},{"created_at":"2023-10-18T17:26:57.136489Z","id":"fdaedd6c-a4d4-4b8d-b8fe-a4a11986e759","subnet":"fd63:256c:45f7:3fee::/64","updated_at":"2023-10-18T17:26:57.136489Z"}],"tags":[],"updated_at":"2023-10-18T17:26:57.136489Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:19:59.780272Z","dhcp_enabled":true,"id":"e7f53646-b279-4a10-8b55-be84031db17b","name":"k8s-private-network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.780272Z","id":"40c98dce-5a7a-4dea-8eae-76d3bfd8da01","subnet":"172.16.24.0/22","updated_at":"2023-11-07T16:19:59.780272Z"},{"created_at":"2023-11-07T16:19:59.780272Z","id":"07f3dbc1-1163-4ce3-9516-ea9e678aa025","subnet":"fd63:256c:45f7:c212::/64","updated_at":"2023-11-07T16:19:59.780272Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.780272Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "721"
+      - "703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:27:04 GMT
+      - Tue, 07 Nov 2023 16:20:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1098,7 +1098,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94169a1f-4819-466f-bdf2-b039b3a37c42
+      - 1fbd2e77-ab23-472d-85a0-0cc1b07a313f
     status: 200 OK
     code: 200
     duration: ""
@@ -1109,19 +1109,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d30bc90c-849c-441a-b765-324e245c9506
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d30bc90c-849c-441a-b765-324e245c9506.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T17:26:58.538709Z","created_at":"2023-10-18T17:26:58.538709Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d30bc90c-849c-441a-b765-324e245c9506.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d30bc90c-849c-441a-b765-324e245c9506","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"02f63466-90d0-48be-8b23-68f750589571","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T17:27:00.077774Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://363fe404-36c7-4c92-a3ca-daed5d218c63.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:15.921623Z","created_at":"2023-11-07T16:20:15.921623Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.363fe404-36c7-4c92-a3ca-daed5d218c63.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"363fe404-36c7-4c92-a3ca-daed5d218c63","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c8e07b1d-1267-417b-9678-cff85d318b6c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:18.999330Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1523"
+      - "1478"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:27:04 GMT
+      - Tue, 07 Nov 2023 16:20:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1131,7 +1131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e393aafd-8154-4120-b779-6c6a4d345803
+      - 263db28f-9b4d-4b2c-84b1-766bd5695b0e
     status: 200 OK
     code: 200
     duration: ""
@@ -1142,19 +1142,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d30bc90c-849c-441a-b765-324e245c9506/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVRWGhPZWtVelRXcFpNVTlXYjFoRVZFMTZUVlJCZUU1NlJUTk5hbGt4VDFadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJVRVFyQ2tzcmF5OURkVXRpWW1FeGJITjFkbHBQUW5aNVNYZFhhbWhGZVVoc1YzZFBjbkpLYWxKVVdrOUhWVmRZYjFNNVIyNVlUMk0yVkZac1RtVnRibUZ0VDJVS1RHSkZlazQwTVVwVFRUVktRbFJTWVZWd2RFbExXV3cyTkdWR2RXeDJSM0JxVTB0TFdTdFdVa3cxT0V4S1RrNU9hVEJyWWswMmFXWjVOMjVvTW00Mlp3bzJPVnA0UmpScGJsSXdSRTFwTkdzNGNXcEtMekpKZW14d2IzcFRiU3RIYVVSdFRuUnNkREJtT0hrMmNuWk1Xa0ZJT0ZaM1JFZHBUa2RrV0cwMVNtWTRDa1pHZUhock1XTkhVVTVZWlM5Q1pHaHVhRE5sVDNaV2RHSmhSRXRyWkVGNVVYTklWVWRNVW1GV1N6VXhOMmRTUzB0cWIzbEtZa2t6TlZSSlFXaFJXRzhLY0hKMlJtNW5jRkJhWVdGMFdrUkZjVUpxZGxvd1VEUTFkMVJDWWk5eFJuWndRalF6ZUdkclpYSXdOSEpwV0RkV1FXRkRablJhVEhSdlJFcG5lWFozTndwNFpXSkRTMjVQYTBacWVWVXZiVEJ5UjJJd1EwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaTE1FRXliWHBXYVhWQ1dEVTRTWGhNWlU1MVJXOTZWbGhsUlZOTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQ09HdHFZV1I2YnpKS2NWaFRPSEpWVDNSTFVHOUpaMnRPVTJKS2VtbFVhRk01U1VKS1ZsTlZiVkpJVlhoUk1qbDNlQXBpT1RoeGRUbEhhekZYTTNOcWJHWlBiVTU0UkZGbVUzQm1PVlZZYTBFM1kzazFjM1Z4WkVkcFZIRTVZWE5VU0RNNWEzZEpSa05ZYURCck1FRTRUMjVzQ2xOUE5FVlNORFJaZFVaRllYVllja2huYTFKQ1V6ZGllaXMwUkhSeWJXbFZXV0prVkM5bE1TdGxjazlhUW5samVrOUpRVTF2UmxoRGNGUlhPRk01TVZrS0sybExjMDR6VFRsVk1VVm9MMVp6WTNoVlNIaFVhVWxOV1U1bk5FdGhSa0kwVVVWT1R5OUpiMFJQZGtZd01ucGxNR2hJT1VWVVIyY3pPWGxxVlc1NGRBcHdha0ptY1V4MVIyTjBOVmh2UVc5eFFsQjBZa0ZaZDJwSE5ESkdaRFprYm5SNE1sSlFZVWxLTldaaFEyVnVWM1Z4T1RrckswbDNObTVST0dOT01rVXpDbmw2UzBwRFZXRnRWbXR5U0dRelRHbzRVa2RTWVVoMVNrbEZNRzVITmtWRFdVa3pXUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vZDMwYmM5MGMtODQ5Yy00NDFhLWI3NjUtMzI0ZTI0NWM5NTA2LmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBRakFDRTg4RTl5Y2JEa3Rmc3oxd2I2Z1hNdTBiejRzWHF1NHFvRWdreXI4UmprSHJ3OFIxajl5Rw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogIms4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlciIKICBjbHVzdGVyOgogICAgY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE6IExTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU0xZWtORFFXTXJaMEYzU1VKQlowbENRVVJCVGtKbmEzRm9hMmxIT1hjd1FrRlJjMFpCUkVGV1RWSk5kMFZSV1VSV1VWRkVSWGR3Y21SWFNtd0tZMjAxYkdSSFZucE5RalJZUkZSSmVrMVVSWGRPYWtVeVRXcEJlRTlHYjFoRVZFMTZUVlJGZDA1cVJUSk5ha0Y0VDBadmQwWlVSVlJOUWtWSFFURlZSUXBCZUUxTFlUTldhVnBZU25WYVdGSnNZM3BEUTBGVFNYZEVVVmxLUzI5YVNXaDJZMDVCVVVWQ1FsRkJSR2RuUlZCQlJFTkRRVkZ2UTJkblJVSkJUWG80Q2s1R1kwOUVWRXh6UVM4dkwzbEtWa3hvVERoc2JtazJlRlJLY1cxRWNrMXVPR1kwUTIxWWFXSm5NRzgxWmtkalJHRkpiMEUwVGswMFUwWkVaR05EU0U4S2RUZENVRlJvZG5Od2FFVnBVbUl4WXpCMGVHcGlUVFJIUzA1d1lVRmxkVVJpYm14SmMwZDFNSFZwUVd0a2EzVTRiM1JvVTJZdlMzbHNkU3N6Y2xwWlRncHFiazVYYkVSbVMyNVNieXRZYVVGdk5XOURVMDVDTkdOdFMxcE1aMFF4YjI5Q1JXWTFaMHhHVmk5cWNGSjFiV0ZQVWpSSGRuazRMMlF4VWtGMk1qWlJDakpJVjNoNlZuTnpkRWg1TVZWRlEyRXllakpHWVVZcldYbzVhVmRXUm0xcVQyVnlTMU5tZDFsMlYyMVJZa2RIYzA1aUwzWkxkVzlhYzJsbFlVZDVVMndLZHpWS00wbHFVRkV5UkM5MVZsWnJibEZXVVd3M1lUUmFNMDE1ZURoSFFYb3JWblE0V0UwNWRuRnpNWEJxT0RCTVdGWkxUa1JPYzFrM2FFVlhjWGRWWmdwalR6ZFRiRXBuVW5GRU9HMTROSE16TWtSRlEwRjNSVUZCWVU1RFRVVkJkMFJuV1VSV1VqQlFRVkZJTDBKQlVVUkJaMHRyVFVFNFIwRXhWV1JGZDBWQ0NpOTNVVVpOUVUxQ1FXWTRkMGhSV1VSV1VqQlBRa0paUlVaUVptcFRWMGxJTUcxWVRGQTBlVEZKU201RlJEVXZMMkZ4WTJoTlFUQkhRMU54UjFOSllqTUtSRkZGUWtOM1ZVRkJORWxDUVZGQlJERlpUbWw1ZVd3ek5UQklSR2xqV0V0TWFrY3pWVmhyTlZweVJHTTFhRUpDVGpnM00xWXlOV2t3WTNFek5teDRTZ28yUldwQkwweEpWWGc1V0Uxb1JVVmhXV05DZUhKMU1FOVRlbkpqTlRCdFdWRjBlWEpCUm1wcVMxQlViVmhPYkhFNVEySkxVMGRpVEhFeGRsWkxPR0pNQ214VFZWbHZiVTlIWkdkc2FqVnRORFJUZFZOcGJtVmFRV1Z2Tmt0ekswSlVhVTk0ZGs1M1ZrbzJWVEUwT1ZSaU5GUlFabVE0VFhRMU1XZ3JRME5ZUWxZS1VYVlBUSGxHTUZOc1RsQkhLM013WmpoMWNVTjJVWFJHV2psbFpFNVZaSEZtVW5aSVoxTk9hbE5SZWk5b1p6TXZaV2RDYjNoTFZUQnpPWGRuV1hkTU1ncDNTRVJYYW1STFZUTmhkbFk0WnpnelZXeDBSVFpPUzFCVWQySndZbTVHVTJscWQxVXhaRWhJTmtWck5IVm9SV1ZFT1RaWmQzUmhRMjA1YlRWM1JrNUtDbE5zUW1Sd2IwaEVkVTV1TDJRcmFXOVNWSEZsVUhadGJ6VmFNM1E0YzJ4WmIzaHFUZ290TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09CiAgICBzZXJ2ZXI6IGh0dHBzOi8vMzYzZmU0MDQtMzZjNy00YzkyLWEzY2EtZGFlZDVkMjE4YzYzLmFwaS5rOHMuZnItcGFyLnNjdy5jbG91ZDo2NDQzCmNvbnRleHRzOgotIG5hbWU6IGFkbWluQGs4cy1wcml2YXRlLW5ldHdvcmstY2x1c3RlcgogIGNvbnRleHQ6CiAgICBjbHVzdGVyOiAiazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyIgogICAgdXNlcjogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCmN1cnJlbnQtY29udGV4dDogYWRtaW5AazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogazhzLXByaXZhdGUtbmV0d29yay1jbHVzdGVyLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB0clN1RDJhRjF1NEZic2M1WWtLdlhwS0lKbVJhSDg4WHZidXlCVUV6WHZ5bng5RjBCVmRFS0h3ZA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2710"
+      - "2708"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:27:04 GMT
+      - Tue, 07 Nov 2023 16:20:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1164,7 +1164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ffc5b31d-528c-44cb-a9e0-1fff3433391a
+      - 6b1be42c-b541-4db3-b546-12601b242e32
     status: 200 OK
     code: 200
     duration: ""
@@ -1175,19 +1175,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d30bc90c-849c-441a-b765-324e245c9506?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63?with_additional_resources=false
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d30bc90c-849c-441a-b765-324e245c9506.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T17:26:58.538709Z","created_at":"2023-10-18T17:26:58.538709Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d30bc90c-849c-441a-b765-324e245c9506.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d30bc90c-849c-441a-b765-324e245c9506","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"02f63466-90d0-48be-8b23-68f750589571","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T17:27:05.384695643Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://363fe404-36c7-4c92-a3ca-daed5d218c63.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:15.921623Z","created_at":"2023-11-07T16:20:15.921623Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.363fe404-36c7-4c92-a3ca-daed5d218c63.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"363fe404-36c7-4c92-a3ca-daed5d218c63","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c8e07b1d-1267-417b-9678-cff85d318b6c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:23.992461188Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1521"
+      - "1476"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:27:05 GMT
+      - Tue, 07 Nov 2023 16:20:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1197,7 +1197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66d24114-81c6-4114-82c8-33fe3cf53f66
+      - aadc5f24-c947-4703-8491-cb78a6de0c67
     status: 200 OK
     code: 200
     duration: ""
@@ -1208,40 +1208,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d30bc90c-849c-441a-b765-324e245c9506
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://d30bc90c-849c-441a-b765-324e245c9506.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-10-18T17:26:58.538709Z","created_at":"2023-10-18T17:26:58.538709Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.d30bc90c-849c-441a-b765-324e245c9506.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"d30bc90c-849c-441a-b765-324e245c9506","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"02f63466-90d0-48be-8b23-68f750589571","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-10-18T17:27:05.384696Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1518"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 17:27:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b5796937-f1b6-42aa-be15-4d00e814dc2e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6a3be534-eff7-48ad-bc55-d55fc9d0d221
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e7f53646-b279-4a10-8b55-be84031db17b
     method: DELETE
   response:
     body: ""
@@ -1251,7 +1218,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:27:06 GMT
+      - Tue, 07 Nov 2023 16:20:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1261,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 975516c3-01b4-44e4-935b-0462bed1694a
+      - 9237f4a9-5bcc-46e8-ae79-cf7064a27cb8
     status: 204 No Content
     code: 204
     duration: ""
@@ -1272,19 +1239,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d30bc90c-849c-441a-b765-324e245c9506
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"d30bc90c-849c-441a-b765-324e245c9506","type":"not_found"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://363fe404-36c7-4c92-a3ca-daed5d218c63.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:15.921623Z","created_at":"2023-11-07T16:20:15.921623Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.363fe404-36c7-4c92-a3ca-daed5d218c63.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"363fe404-36c7-4c92-a3ca-daed5d218c63","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c8e07b1d-1267-417b-9678-cff85d318b6c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:23.992461Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "128"
+      - "1473"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:27:10 GMT
+      - Tue, 07 Nov 2023 16:20:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1294,7 +1261,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e112b4eb-50e9-4557-911c-c05d38321f55
+      - 0eabe3be-3347-45ac-9c7c-3b2ad2138181
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://363fe404-36c7-4c92-a3ca-daed5d218c63.api.k8s.fr-par.scw.cloud:6443","cni":"calico","commitment_ends_at":"2023-11-07T16:20:15.921623Z","created_at":"2023-11-07T16:20:15.921623Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.363fe404-36c7-4c92-a3ca-daed5d218c63.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"363fe404-36c7-4c92-a3ca-daed5d218c63","ingress":"none","name":"k8s-private-network-cluster","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"c8e07b1d-1267-417b-9678-cff85d318b6c","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","private_network"],"type":"kapsule","updated_at":"2023-11-07T16:20:23.992461Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1473"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:20:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 319c3323-ae67-48d6-9d3e-32b5ccccbce2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"363fe404-36c7-4c92-a3ca-daed5d218c63","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:20:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 816e6a3b-fb4e-4e03-9638-34d4c752a937
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1305,7 +1338,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/02f63466-90d0-48be-8b23-68f750589571
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c8e07b1d-1267-417b-9678-cff85d318b6c
     method: DELETE
   response:
     body: ""
@@ -1315,7 +1348,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:27:11 GMT
+      - Tue, 07 Nov 2023 16:20:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1325,7 +1358,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1dde3047-a8b4-4986-98d8-b23228dd4914
+      - 19dbd95e-23e6-4997-9e77-f4c5f337ed2c
     status: 204 No Content
     code: 204
     duration: ""
@@ -1336,10 +1369,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/d30bc90c-849c-441a-b765-324e245c9506
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/363fe404-36c7-4c92-a3ca-daed5d218c63
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"d30bc90c-849c-441a-b765-324e245c9506","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"363fe404-36c7-4c92-a3ca-daed5d218c63","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -1348,7 +1381,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 17:27:11 GMT
+      - Tue, 07 Nov 2023 16:20:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1358,7 +1391,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cbbee0d3-d039-4bfb-85fe-a6ccb995654f
+      - 3807c22d-4958-426d-9d73-d480e4a9cbf9
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/k8s-cluster-type-change.cassette.yaml
+++ b/scaleway/testdata/k8s-cluster-type-change.cassette.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:35:41 GMT
+      - Tue, 07 Nov 2023 16:19:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,12 +34,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19fe143d-70ba-4d67-a57c-a96bb5855105
+      - 191b76e5-c2c3-49f7-b5c9-bdc70472b845
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-type-change","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"test-type-change","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -50,16 +50,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-18T16:43:35.686906Z","dhcp_enabled":true,"id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:35.686906Z","id":"6e957e34-653e-4fed-ad63-38ba4eb78285","subnet":"172.16.16.0/22","updated_at":"2023-10-18T16:43:35.686906Z"},{"created_at":"2023-10-18T16:43:35.686906Z","id":"975a8ca4-bf73-442f-8fed-25cd29f6029e","subnet":"fd63:256c:45f7:91b4::/64","updated_at":"2023-10-18T16:43:35.686906Z"}],"tags":[],"updated_at":"2023-10-18T16:43:35.686906Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:19:59.627263Z","dhcp_enabled":true,"id":"963ac687-26f9-42a1-87c7-0a8737d493be","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.627263Z","id":"8b424081-dce6-41f2-9807-d34dcf032f45","subnet":"172.16.12.0/22","updated_at":"2023-11-07T16:19:59.627263Z"},{"created_at":"2023-11-07T16:19:59.627263Z","id":"9a8f7905-ef99-4cb9-bed8-a31b86103108","subnet":"fd63:256c:45f7:6697::/64","updated_at":"2023-11-07T16:19:59.627263Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.627263Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "717"
+      - "700"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:36 GMT
+      - Tue, 07 Nov 2023 16:20:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -69,7 +69,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8bb1dc70-1dbc-4e8e-89c9-e6205c59a349
+      - d07bb328-3562-4d38-920c-33faeeaf4f3c
     status: 200 OK
     code: 200
     duration: ""
@@ -80,19 +80,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e119ab2a-cb88-4b75-b93d-94e1eabcf342
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/963ac687-26f9-42a1-87c7-0a8737d493be
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:43:35.686906Z","dhcp_enabled":true,"id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:35.686906Z","id":"6e957e34-653e-4fed-ad63-38ba4eb78285","subnet":"172.16.16.0/22","updated_at":"2023-10-18T16:43:35.686906Z"},{"created_at":"2023-10-18T16:43:35.686906Z","id":"975a8ca4-bf73-442f-8fed-25cd29f6029e","subnet":"fd63:256c:45f7:91b4::/64","updated_at":"2023-10-18T16:43:35.686906Z"}],"tags":[],"updated_at":"2023-10-18T16:43:35.686906Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:19:59.627263Z","dhcp_enabled":true,"id":"963ac687-26f9-42a1-87c7-0a8737d493be","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.627263Z","id":"8b424081-dce6-41f2-9807-d34dcf032f45","subnet":"172.16.12.0/22","updated_at":"2023-11-07T16:19:59.627263Z"},{"created_at":"2023-11-07T16:19:59.627263Z","id":"9a8f7905-ef99-4cb9-bed8-a31b86103108","subnet":"fd63:256c:45f7:6697::/64","updated_at":"2023-11-07T16:19:59.627263Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.627263Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "717"
+      - "700"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:36 GMT
+      - Tue, 07 Nov 2023 16:20:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0d997d2-92e4-4bb0-b2ec-2da84d14894a
+      - 4a36700e-82d5-43d2-b044-ccc538847e95
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"kapsule","name":"test-type-change","description":"","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"kapsule","name":"test-type-change","description":"","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be"}'
     form: {}
     headers:
       Content-Type:
@@ -118,16 +118,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:43:36.596072727Z","created_at":"2023-10-18T16:43:36.596072727Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-10-18T16:43:36.605301121Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:00.701149788Z","created_at":"2023-11-07T16:20:00.701149788Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-07T16:20:00.713800316Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1512"
+      - "1467"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:36 GMT
+      - Tue, 07 Nov 2023 16:20:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -137,7 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 238dc787-d171-41bf-8911-d335fe2f9841
+      - c98f2ff6-3a09-4ab2-9061-c1a65822b1f7
     status: 200 OK
     code: 200
     duration: ""
@@ -148,19 +148,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:43:36.596073Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-10-18T16:43:36.605301Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:00.701150Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-07T16:20:00.713800Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1503"
+      - "1458"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:36 GMT
+      - Tue, 07 Nov 2023 16:20:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -170,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5b3007d-7f64-428c-9661-1e9fe0199b1c
+      - 835b6a31-6d67-4e7b-85a2-3e5042233d77
     status: 200 OK
     code: 200
     duration: ""
@@ -181,19 +181,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:43:36.596073Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-10-18T16:43:38.070338Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:00.701150Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.488508Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1508"
+      - "1463"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:41 GMT
+      - Tue, 07 Nov 2023 16:20:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -203,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0726ceca-0781-4150-a182-e90e57bc91f7
+      - 55db3779-467f-4596-9748-74797c6877d2
     status: 200 OK
     code: 200
     duration: ""
@@ -214,19 +214,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:43:36.596073Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-10-18T16:43:38.070338Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:00.701150Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.488508Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1508"
+      - "1463"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:41 GMT
+      - Tue, 07 Nov 2023 16:20:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -236,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c467c08-4b43-4d5e-a9b5-543363bf2ca2
+      - d791340e-cd7d-43d2-8c3d-d7cdde00c790
     status: 200 OK
     code: 200
     duration: ""
@@ -247,19 +247,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUa1JOZWs0eGIxaEVWRTE2VFZSQmVFNTZSVEpPUkUxNlRqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNkckNsSTFSRGR4UjBvelkyVm1OMWR6VmxGM1RXSmxVMll3ZHpaVE0yOWFUSGhaTkZOSllVazBZMGhaY214aFFrUkNMMUExVWxOVU9TOVhaVlZaVFN0NVRsb0tNM1JUVmpOcFIydFBZWHBWTTA5TGJ6bHZRM0JyVnpneE5HdHVUamswUzJsM1kyTmlibEo1VVV4cFFXVkdRV2hIU0dOYU1FUlpOek5VUld4TlVVdENNZ3BTWjBkck5XTlRkVlZFY2pCa05rVlliRkU0YTNCU01XYzNTaXRIUm5VM1EydFlZVkZuZG5wcE5WTlRlVVE0U2taWGF6RnZabVU0UTJsTU1sVTRWMVEwQ2tRelMzRTNTVXN4Ynk4dlNGbExTalJDWlROa1dWa3lUV054U0d0cFRIQmlRbE5STkZoVmVqUjRVMUV4WmtSNVRuaHdSbkZ4ZUdaeFNraDNTelZZVGs4S2RqSlVTRkJoTXk5dWJEbHBRMk5ITjFCcFIwdDRORll5TlRFeVVGVlBiRkp3VlZacmQzTXdhMmcwWTFONWFFNXRRVkZHT1RRcllWUm1SRVI0WkdaQ2N3b3ZkV2hhTkVWNFNHZGhOemMyUkVNeFVrYzRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkVaV3B6UzJkVVIwWllhblppZHpFNVJXdDRTREZoWlM5RWNrRk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRTRTV5VUZKVWJqazJkM1ZvWlhKTFNXVmlUbnB4Ym1adlRtMW9iMkphZGxKNmRYcEVTRmhvWVRSdU5GbGFVMHhoVEFvM1RpOXpZbnBvZWpscFpYaHhObU53Y21WVmR6ZzFlRkU0TDJObldrRnVTSFpYV1VSRlRqaDNPVFpPZGk4MldIWjZOMXBZVUZvck5FcDJjbk5QU21SUENtSlRWbEYzWldOS2IwaHZZWEF3WjBGcWFHdDRZUzlLYlVoME0za3hObGhpV1dkVE0xaFdaWFEwWWl0R2IySlVXVGx5Tkc5aGNtdGFUMlF6VUZjNFoxY0tZa1U1UWtoYVNIUkJaM0kzUWpaSVpUVlBlazVFZWtWNGFuVlNVV04xV2pOSE5rNVNTRmgwVGxFeFFYUkdPR2RrVEdaR04zRkNNMVZCV0daTFJrWlRWd280YjBZeGVYaERTa3RIUzI0eWVuYzVaSFpGV1ZkWGExUmpPR3RFV1ZRdlkwOXRaakZWUm01MU0yaFRVelJpT0VScFR6QjJlRGhFYVdsQk4xRXlVRzVwQ25aeFltVjZTMDF2U1RKeFEyaENjbFJxTkRSWVVHSkNOalZ5WVdKME9YTnBiVk15THdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2JlNGFkMzI3LWU0Y2QtNDc2ZS1iMzdkLWUzMmUwMjA4NTAxNC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpZDJQcjRSbUNOY3hUd0ZKWE9BQXZ0QnRUWUFNanNxRm83T3ZoRGRTekVGWXhxNkRTZFlqbFY3MA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAxc2IxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxKS0NuWlZkVVJoUkUxMkwxZ3JaMHQyVTBkRGRsRkZNa0U1YzBSVE9IaE1jRVl5UTNaV1JFcHBVaXN5UzJ3elNEaHBNVEIxY1hSTldYVklWamROT1dkUloyOEtkbkJ2VG5FcmVHazJkazFPU0ZWbU5IcGhNR1ZqWlhWcFoxbEpiamxoT1RGRWRpdHJZekozYkZsUmNHTlRaMVY2VVhjclRtMHhSMk5wSzA1eFJYUlFaZ3AyYUZsaE1HMUdjV001U2xaa1UyeGhkVU0wVW5ocmVuZElhbEJtZW5GeVIxQTJVMGRZTlVGTVRXZEVibGxqVFRNMVR6Y3pSVzVSWWxKTWFuQktlRUZGQ2k5YVIxUmxVMlY1U1c0MU5rNXdkVXBYTlVJNWVVMUNkR2wyUWprdk5VeEtZMHRvUjFWaVoxTnViVkEwTWpsS1UyMVVkbE5PTkRSWVkxRk1OVnBOY25nS2FIRTJlSFl5WXpGalVWRmhSakZpTURKbVNERlZjbWQ2YzFwT1RqQnBhMVJPVERSU1QzRkJRbVZhVjBGR2NWSlNSSE16VVVzeVdEWXlNVVZoZUdoWVJBcE9Wa052Y0ZGV2MwbDVlV0ZHYURKUWQwZ3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhaMnRGUTJFdlpXTTBOSEp1UjFFMU5XaE9OazlwUlV4T1R6Qk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSM1JOWWtobGNuWm5lRTkzZEdseFZ6VjRNelZWT0Zwc2VVWTVSR3M1VGxOelRuRmFMelJMYmtsdmVsUjFNVFpGTlFwTmRucENkR041VkVGUFRtaE1ka1E0VUZsWVlrNUpWVmw2ZVhoNGVVOHdRamhUYlRacWFERk5kVEZwZW0xSlRFbG1RV05CWjA1elMwbGFXREZ6VHpWcENsUm5WVnBuWkVNMVdEQmFMM3AzY1c5SFRFRkpTbk12VkVsa2J6UkdUR1ZyWTNkRVExVnFhekVyVWtsdlRucEZiRkJTVm5aRVlURk1VamRZZG5GUlpERUtXbVpGUkVZeFlXaEZjbHBVUzNWTlUwcHZlSFE0VUU5R1kyUjZPWGtyWVhrM2EwWlpOMVU1YlcxTU1YZEhRVWRNYUdGNWQyaFRUWG8yVVVVNWNrMVRZd3A2TW04NE4wdEpaRkJ5Y0VwRmEzcE5ZMjlTYW5OR1RXRnJlRkJJU1ZndlUwRkpObnBsV25oSGFHUlhLMFJ4Um1nck5GUnhZMVoyWmpRNVZ6VkdiVzQ1Q2pNeldERkRkSGgyTTNSa2VuWlhXbTEyTmpGbk0yeFdZMGw1WVRWdldWUkRTak5NUmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzg3Y2U3ZWRlLWZkMWYtNGY0Mi1iZWEwLTY1YTM2OGUzZjM2Yi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB0d2NaZjhyOWxJa2ZVaUJ1eTBBMFJBNWxyWjhNMXlVVGJnOHJFNXVVdWQ1bXFwSG1BWnRGdXRKVA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2622"
+      - "2620"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:41 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -269,7 +269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3051cae8-e59f-4048-a70a-676ac3a80946
+      - 5d0bf3fb-6828-4b2e-9098-6fdc05305a84
     status: 200 OK
     code: 200
     duration: ""
@@ -280,19 +280,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:43:36.596073Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-10-18T16:43:38.070338Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:00.701150Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.488508Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1508"
+      - "1463"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:41 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eab31cc5-1711-491e-8e37-b6ad05799241
+      - be66c245-5045-40f1-b2b3-fa0cfd06944a
     status: 200 OK
     code: 200
     duration: ""
@@ -313,19 +313,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e119ab2a-cb88-4b75-b93d-94e1eabcf342
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/963ac687-26f9-42a1-87c7-0a8737d493be
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:43:35.686906Z","dhcp_enabled":true,"id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:35.686906Z","id":"6e957e34-653e-4fed-ad63-38ba4eb78285","subnet":"172.16.16.0/22","updated_at":"2023-10-18T16:43:35.686906Z"},{"created_at":"2023-10-18T16:43:35.686906Z","id":"975a8ca4-bf73-442f-8fed-25cd29f6029e","subnet":"fd63:256c:45f7:91b4::/64","updated_at":"2023-10-18T16:43:35.686906Z"}],"tags":[],"updated_at":"2023-10-18T16:43:35.686906Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:19:59.627263Z","dhcp_enabled":true,"id":"963ac687-26f9-42a1-87c7-0a8737d493be","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.627263Z","id":"8b424081-dce6-41f2-9807-d34dcf032f45","subnet":"172.16.12.0/22","updated_at":"2023-11-07T16:19:59.627263Z"},{"created_at":"2023-11-07T16:19:59.627263Z","id":"9a8f7905-ef99-4cb9-bed8-a31b86103108","subnet":"fd63:256c:45f7:6697::/64","updated_at":"2023-11-07T16:19:59.627263Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.627263Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "717"
+      - "700"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:42 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -335,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4ee71f3-16d8-40e2-9001-d4f80a30d99f
+      - 5fcdeafb-46cc-482d-aacd-b97f0cd189b9
     status: 200 OK
     code: 200
     duration: ""
@@ -346,19 +346,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:43:36.596073Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-10-18T16:43:38.070338Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:00.701150Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.488508Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1508"
+      - "1463"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:42 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -368,7 +368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 971bb444-1b7c-4d3d-8509-56ae094c7833
+      - 1ed2d4b0-4ea6-4c7e-a323-423acf3bb7cc
     status: 200 OK
     code: 200
     duration: ""
@@ -379,19 +379,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUa1JOZWs0eGIxaEVWRTE2VFZSQmVFNTZSVEpPUkUxNlRqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNkckNsSTFSRGR4UjBvelkyVm1OMWR6VmxGM1RXSmxVMll3ZHpaVE0yOWFUSGhaTkZOSllVazBZMGhaY214aFFrUkNMMUExVWxOVU9TOVhaVlZaVFN0NVRsb0tNM1JUVmpOcFIydFBZWHBWTTA5TGJ6bHZRM0JyVnpneE5HdHVUamswUzJsM1kyTmlibEo1VVV4cFFXVkdRV2hIU0dOYU1FUlpOek5VUld4TlVVdENNZ3BTWjBkck5XTlRkVlZFY2pCa05rVlliRkU0YTNCU01XYzNTaXRIUm5VM1EydFlZVkZuZG5wcE5WTlRlVVE0U2taWGF6RnZabVU0UTJsTU1sVTRWMVEwQ2tRelMzRTNTVXN4Ynk4dlNGbExTalJDWlROa1dWa3lUV054U0d0cFRIQmlRbE5STkZoVmVqUjRVMUV4WmtSNVRuaHdSbkZ4ZUdaeFNraDNTelZZVGs4S2RqSlVTRkJoTXk5dWJEbHBRMk5ITjFCcFIwdDRORll5TlRFeVVGVlBiRkp3VlZacmQzTXdhMmcwWTFONWFFNXRRVkZHT1RRcllWUm1SRVI0WkdaQ2N3b3ZkV2hhTkVWNFNHZGhOemMyUkVNeFVrYzRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkVaV3B6UzJkVVIwWllhblppZHpFNVJXdDRTREZoWlM5RWNrRk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRTRTV5VUZKVWJqazJkM1ZvWlhKTFNXVmlUbnB4Ym1adlRtMW9iMkphZGxKNmRYcEVTRmhvWVRSdU5GbGFVMHhoVEFvM1RpOXpZbnBvZWpscFpYaHhObU53Y21WVmR6ZzFlRkU0TDJObldrRnVTSFpYV1VSRlRqaDNPVFpPZGk4MldIWjZOMXBZVUZvck5FcDJjbk5QU21SUENtSlRWbEYzWldOS2IwaHZZWEF3WjBGcWFHdDRZUzlLYlVoME0za3hObGhpV1dkVE0xaFdaWFEwWWl0R2IySlVXVGx5Tkc5aGNtdGFUMlF6VUZjNFoxY0tZa1U1UWtoYVNIUkJaM0kzUWpaSVpUVlBlazVFZWtWNGFuVlNVV04xV2pOSE5rNVNTRmgwVGxFeFFYUkdPR2RrVEdaR04zRkNNMVZCV0daTFJrWlRWd280YjBZeGVYaERTa3RIUzI0eWVuYzVaSFpGV1ZkWGExUmpPR3RFV1ZRdlkwOXRaakZWUm01MU0yaFRVelJpT0VScFR6QjJlRGhFYVdsQk4xRXlVRzVwQ25aeFltVjZTMDF2U1RKeFEyaENjbFJxTkRSWVVHSkNOalZ5WVdKME9YTnBiVk15THdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2JlNGFkMzI3LWU0Y2QtNDc2ZS1iMzdkLWUzMmUwMjA4NTAxNC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpZDJQcjRSbUNOY3hUd0ZKWE9BQXZ0QnRUWUFNanNxRm83T3ZoRGRTekVGWXhxNkRTZFlqbFY3MA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAxc2IxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxKS0NuWlZkVVJoUkUxMkwxZ3JaMHQyVTBkRGRsRkZNa0U1YzBSVE9IaE1jRVl5UTNaV1JFcHBVaXN5UzJ3elNEaHBNVEIxY1hSTldYVklWamROT1dkUloyOEtkbkJ2VG5FcmVHazJkazFPU0ZWbU5IcGhNR1ZqWlhWcFoxbEpiamxoT1RGRWRpdHJZekozYkZsUmNHTlRaMVY2VVhjclRtMHhSMk5wSzA1eFJYUlFaZ3AyYUZsaE1HMUdjV001U2xaa1UyeGhkVU0wVW5ocmVuZElhbEJtZW5GeVIxQTJVMGRZTlVGTVRXZEVibGxqVFRNMVR6Y3pSVzVSWWxKTWFuQktlRUZGQ2k5YVIxUmxVMlY1U1c0MU5rNXdkVXBYTlVJNWVVMUNkR2wyUWprdk5VeEtZMHRvUjFWaVoxTnViVkEwTWpsS1UyMVVkbE5PTkRSWVkxRk1OVnBOY25nS2FIRTJlSFl5WXpGalVWRmhSakZpTURKbVNERlZjbWQ2YzFwT1RqQnBhMVJPVERSU1QzRkJRbVZhVjBGR2NWSlNSSE16VVVzeVdEWXlNVVZoZUdoWVJBcE9Wa052Y0ZGV2MwbDVlV0ZHYURKUWQwZ3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhaMnRGUTJFdlpXTTBOSEp1UjFFMU5XaE9OazlwUlV4T1R6Qk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSM1JOWWtobGNuWm5lRTkzZEdseFZ6VjRNelZWT0Zwc2VVWTVSR3M1VGxOelRuRmFMelJMYmtsdmVsUjFNVFpGTlFwTmRucENkR041VkVGUFRtaE1ka1E0VUZsWVlrNUpWVmw2ZVhoNGVVOHdRamhUYlRacWFERk5kVEZwZW0xSlRFbG1RV05CWjA1elMwbGFXREZ6VHpWcENsUm5WVnBuWkVNMVdEQmFMM3AzY1c5SFRFRkpTbk12VkVsa2J6UkdUR1ZyWTNkRVExVnFhekVyVWtsdlRucEZiRkJTVm5aRVlURk1VamRZZG5GUlpERUtXbVpGUkVZeFlXaEZjbHBVUzNWTlUwcHZlSFE0VUU5R1kyUjZPWGtyWVhrM2EwWlpOMVU1YlcxTU1YZEhRVWRNYUdGNWQyaFRUWG8yVVVVNWNrMVRZd3A2TW04NE4wdEpaRkJ5Y0VwRmEzcE5ZMjlTYW5OR1RXRnJlRkJJU1ZndlUwRkpObnBsV25oSGFHUlhLMFJ4Um1nck5GUnhZMVoyWmpRNVZ6VkdiVzQ1Q2pNeldERkRkSGgyTTNSa2VuWlhXbTEyTmpGbk0yeFdZMGw1WVRWdldWUkRTak5NUmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzg3Y2U3ZWRlLWZkMWYtNGY0Mi1iZWEwLTY1YTM2OGUzZjM2Yi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB0d2NaZjhyOWxJa2ZVaUJ1eTBBMFJBNWxyWjhNMXlVVGJnOHJFNXVVdWQ1bXFwSG1BWnRGdXRKVA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2622"
+      - "2620"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:42 GMT
+      - Tue, 07 Nov 2023 16:20:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -401,7 +401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be0d43e7-aff8-4963-90e0-6b3b8efc3ac9
+      - 6bef6665-306d-4e70-8977-19d4f7847a4e
     status: 200 OK
     code: 200
     duration: ""
@@ -412,19 +412,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e119ab2a-cb88-4b75-b93d-94e1eabcf342
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/963ac687-26f9-42a1-87c7-0a8737d493be
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:43:35.686906Z","dhcp_enabled":true,"id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:35.686906Z","id":"6e957e34-653e-4fed-ad63-38ba4eb78285","subnet":"172.16.16.0/22","updated_at":"2023-10-18T16:43:35.686906Z"},{"created_at":"2023-10-18T16:43:35.686906Z","id":"975a8ca4-bf73-442f-8fed-25cd29f6029e","subnet":"fd63:256c:45f7:91b4::/64","updated_at":"2023-10-18T16:43:35.686906Z"}],"tags":[],"updated_at":"2023-10-18T16:43:35.686906Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2023-11-07T16:19:59.627263Z","dhcp_enabled":true,"id":"963ac687-26f9-42a1-87c7-0a8737d493be","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.627263Z","id":"8b424081-dce6-41f2-9807-d34dcf032f45","subnet":"172.16.12.0/22","updated_at":"2023-11-07T16:19:59.627263Z"},{"created_at":"2023-11-07T16:19:59.627263Z","id":"9a8f7905-ef99-4cb9-bed8-a31b86103108","subnet":"fd63:256c:45f7:6697::/64","updated_at":"2023-11-07T16:19:59.627263Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.627263Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "717"
+      - "700"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:42 GMT
+      - Tue, 07 Nov 2023 16:20:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -434,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9dcb100a-6b8f-4bc2-8b54-2cc87477d712
+      - d4cf0711-3b07-4274-bf48-d62bcef90d45
     status: 200 OK
     code: 200
     duration: ""
@@ -445,19 +445,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:43:36.596073Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-10-18T16:43:38.070338Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:00.701150Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.488508Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1508"
+      - "1463"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:42 GMT
+      - Tue, 07 Nov 2023 16:20:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -467,7 +467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49b07bec-4bb2-4dc7-b61e-0373a69745ad
+      - ecef82b6-4bd2-4118-b6ed-f40d60700cb4
     status: 200 OK
     code: 200
     duration: ""
@@ -478,19 +478,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUa1JOZWs0eGIxaEVWRTE2VFZSQmVFNTZSVEpPUkUxNlRqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNkckNsSTFSRGR4UjBvelkyVm1OMWR6VmxGM1RXSmxVMll3ZHpaVE0yOWFUSGhaTkZOSllVazBZMGhaY214aFFrUkNMMUExVWxOVU9TOVhaVlZaVFN0NVRsb0tNM1JUVmpOcFIydFBZWHBWTTA5TGJ6bHZRM0JyVnpneE5HdHVUamswUzJsM1kyTmlibEo1VVV4cFFXVkdRV2hIU0dOYU1FUlpOek5VUld4TlVVdENNZ3BTWjBkck5XTlRkVlZFY2pCa05rVlliRkU0YTNCU01XYzNTaXRIUm5VM1EydFlZVkZuZG5wcE5WTlRlVVE0U2taWGF6RnZabVU0UTJsTU1sVTRWMVEwQ2tRelMzRTNTVXN4Ynk4dlNGbExTalJDWlROa1dWa3lUV054U0d0cFRIQmlRbE5STkZoVmVqUjRVMUV4WmtSNVRuaHdSbkZ4ZUdaeFNraDNTelZZVGs4S2RqSlVTRkJoTXk5dWJEbHBRMk5ITjFCcFIwdDRORll5TlRFeVVGVlBiRkp3VlZacmQzTXdhMmcwWTFONWFFNXRRVkZHT1RRcllWUm1SRVI0WkdaQ2N3b3ZkV2hhTkVWNFNHZGhOemMyUkVNeFVrYzRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkVaV3B6UzJkVVIwWllhblppZHpFNVJXdDRTREZoWlM5RWNrRk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRTRTV5VUZKVWJqazJkM1ZvWlhKTFNXVmlUbnB4Ym1adlRtMW9iMkphZGxKNmRYcEVTRmhvWVRSdU5GbGFVMHhoVEFvM1RpOXpZbnBvZWpscFpYaHhObU53Y21WVmR6ZzFlRkU0TDJObldrRnVTSFpYV1VSRlRqaDNPVFpPZGk4MldIWjZOMXBZVUZvck5FcDJjbk5QU21SUENtSlRWbEYzWldOS2IwaHZZWEF3WjBGcWFHdDRZUzlLYlVoME0za3hObGhpV1dkVE0xaFdaWFEwWWl0R2IySlVXVGx5Tkc5aGNtdGFUMlF6VUZjNFoxY0tZa1U1UWtoYVNIUkJaM0kzUWpaSVpUVlBlazVFZWtWNGFuVlNVV04xV2pOSE5rNVNTRmgwVGxFeFFYUkdPR2RrVEdaR04zRkNNMVZCV0daTFJrWlRWd280YjBZeGVYaERTa3RIUzI0eWVuYzVaSFpGV1ZkWGExUmpPR3RFV1ZRdlkwOXRaakZWUm01MU0yaFRVelJpT0VScFR6QjJlRGhFYVdsQk4xRXlVRzVwQ25aeFltVjZTMDF2U1RKeFEyaENjbFJxTkRSWVVHSkNOalZ5WVdKME9YTnBiVk15THdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2JlNGFkMzI3LWU0Y2QtNDc2ZS1iMzdkLWUzMmUwMjA4NTAxNC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpZDJQcjRSbUNOY3hUd0ZKWE9BQXZ0QnRUWUFNanNxRm83T3ZoRGRTekVGWXhxNkRTZFlqbFY3MA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAxc2IxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxKS0NuWlZkVVJoUkUxMkwxZ3JaMHQyVTBkRGRsRkZNa0U1YzBSVE9IaE1jRVl5UTNaV1JFcHBVaXN5UzJ3elNEaHBNVEIxY1hSTldYVklWamROT1dkUloyOEtkbkJ2VG5FcmVHazJkazFPU0ZWbU5IcGhNR1ZqWlhWcFoxbEpiamxoT1RGRWRpdHJZekozYkZsUmNHTlRaMVY2VVhjclRtMHhSMk5wSzA1eFJYUlFaZ3AyYUZsaE1HMUdjV001U2xaa1UyeGhkVU0wVW5ocmVuZElhbEJtZW5GeVIxQTJVMGRZTlVGTVRXZEVibGxqVFRNMVR6Y3pSVzVSWWxKTWFuQktlRUZGQ2k5YVIxUmxVMlY1U1c0MU5rNXdkVXBYTlVJNWVVMUNkR2wyUWprdk5VeEtZMHRvUjFWaVoxTnViVkEwTWpsS1UyMVVkbE5PTkRSWVkxRk1OVnBOY25nS2FIRTJlSFl5WXpGalVWRmhSakZpTURKbVNERlZjbWQ2YzFwT1RqQnBhMVJPVERSU1QzRkJRbVZhVjBGR2NWSlNSSE16VVVzeVdEWXlNVVZoZUdoWVJBcE9Wa052Y0ZGV2MwbDVlV0ZHYURKUWQwZ3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhaMnRGUTJFdlpXTTBOSEp1UjFFMU5XaE9OazlwUlV4T1R6Qk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSM1JOWWtobGNuWm5lRTkzZEdseFZ6VjRNelZWT0Zwc2VVWTVSR3M1VGxOelRuRmFMelJMYmtsdmVsUjFNVFpGTlFwTmRucENkR041VkVGUFRtaE1ka1E0VUZsWVlrNUpWVmw2ZVhoNGVVOHdRamhUYlRacWFERk5kVEZwZW0xSlRFbG1RV05CWjA1elMwbGFXREZ6VHpWcENsUm5WVnBuWkVNMVdEQmFMM3AzY1c5SFRFRkpTbk12VkVsa2J6UkdUR1ZyWTNkRVExVnFhekVyVWtsdlRucEZiRkJTVm5aRVlURk1VamRZZG5GUlpERUtXbVpGUkVZeFlXaEZjbHBVUzNWTlUwcHZlSFE0VUU5R1kyUjZPWGtyWVhrM2EwWlpOMVU1YlcxTU1YZEhRVWRNYUdGNWQyaFRUWG8yVVVVNWNrMVRZd3A2TW04NE4wdEpaRkJ5Y0VwRmEzcE5ZMjlTYW5OR1RXRnJlRkJJU1ZndlUwRkpObnBsV25oSGFHUlhLMFJ4Um1nck5GUnhZMVoyWmpRNVZ6VkdiVzQ1Q2pNeldERkRkSGgyTTNSa2VuWlhXbTEyTmpGbk0yeFdZMGw1WVRWdldWUkRTak5NUmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzg3Y2U3ZWRlLWZkMWYtNGY0Mi1iZWEwLTY1YTM2OGUzZjM2Yi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB0d2NaZjhyOWxJa2ZVaUJ1eTBBMFJBNWxyWjhNMXlVVGJnOHJFNXVVdWQ1bXFwSG1BWnRGdXRKVA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2622"
+      - "2620"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:42 GMT
+      - Tue, 07 Nov 2023 16:20:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -500,7 +500,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8c89212-b65d-4893-89a0-70adfcd79d6e
+      - 99a6df06-cf20-4c61-8b35-929f5052d981
     status: 200 OK
     code: 200
     duration: ""
@@ -511,52 +511,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014/available-types
-    method: GET
-  response:
-    body: '{"cluster_types":[{"availability":"available","commitment_delay":"0s","dedicated":false,"max_nodes":150,"memory":4000000000,"name":"kapsule","resiliency":"standard","sla":0},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":250,"memory":4000000000,"name":"kapsule-dedicated-4","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":4}'
-    headers:
-      Content-Length:
-      - "780"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:43:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0f1f9940-f9b8-4526-86f0-7ec6654f2409
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"0s","dedicated":false,"max_nodes":150,"memory":4000000000,"name":"kapsule","resiliency":"standard","sla":0},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":250,"memory":4000000000,"name":"kapsule-dedicated-4","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":4}'
     headers:
       Content-Length:
-      - "780"
+      - "748"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:43 GMT
+      - Tue, 07 Nov 2023 16:20:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -566,7 +533,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c3ed2d6-d361-4638-b9a7-04efbda77d27
+      - 40e9bd1c-c90a-4237-b383-87cb3bee4356
     status: 200 OK
     code: 200
     duration: ""
@@ -577,19 +544,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"0s","dedicated":false,"max_nodes":150,"memory":4000000000,"name":"kapsule","resiliency":"standard","sla":0},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":250,"memory":4000000000,"name":"kapsule-dedicated-4","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":4}'
     headers:
       Content-Length:
-      - "780"
+      - "748"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:43 GMT
+      - Tue, 07 Nov 2023 16:20:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -599,7 +566,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dad99014-42d7-4a76-beb2-98d8ba4d6de0
+      - 9e50db1c-8ec6-4448-a7c4-70f69e6e63a2
     status: 200 OK
     code: 200
     duration: ""
@@ -610,19 +577,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/available-types
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-10-18T16:43:36.596073Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-10-18T16:43:38.070338Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"cluster_types":[{"availability":"available","commitment_delay":"0s","dedicated":false,"max_nodes":150,"memory":4000000000,"name":"kapsule","resiliency":"standard","sla":0},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":250,"memory":4000000000,"name":"kapsule-dedicated-4","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":4}'
     headers:
       Content-Length:
-      - "1508"
+      - "748"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:43 GMT
+      - Tue, 07 Nov 2023 16:20:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -632,7 +599,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e040e1af-e1c2-4c13-9ebe-0ac7b7b3b7b8
+      - 3865e472-ba3b-4f52-aeaa-39eb45f1e3fa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-07T16:20:00.701150Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"pool_required","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule","updated_at":"2023-11-07T16:20:02.488508Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1463"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:20:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ceae607d-8cc5-4a17-b227-591458c7b0b7
     status: 200 OK
     code: 200
     duration: ""
@@ -645,19 +645,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014/set-type
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/set-type
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038006659Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:43:44.096667753Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445498Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454120971Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1521"
+      - "1476"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:44 GMT
+      - Tue, 07 Nov 2023 16:20:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54bf71c4-133d-4e1f-bd11-f43df9401e28
+      - 89ed22e1-def7-4154-863a-8ed7ac2be693
     status: 200 OK
     code: 200
     duration: ""
@@ -678,19 +678,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038007Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:43:44.096668Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:44 GMT
+      - Tue, 07 Nov 2023 16:20:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56c76337-5108-4e0f-ba07-00c5ff5ba45f
+      - 890fefc7-79a8-402a-b30c-d056dfecf655
     status: 200 OK
     code: 200
     duration: ""
@@ -711,19 +711,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038007Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:43:44.096668Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:49 GMT
+      - Tue, 07 Nov 2023 16:20:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81e644fa-a46c-4f77-b626-23e495a92783
+      - d6190397-6f2c-470a-a656-437aad75eb02
     status: 200 OK
     code: 200
     duration: ""
@@ -744,19 +744,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038007Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:43:44.096668Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:54 GMT
+      - Tue, 07 Nov 2023 16:20:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74f54752-a907-4e15-8951-428a7cd7ea39
+      - 79b091e1-8c3e-4dee-9b6c-6b06548c355a
     status: 200 OK
     code: 200
     duration: ""
@@ -777,19 +777,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038007Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:43:44.096668Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:43:59 GMT
+      - Tue, 07 Nov 2023 16:20:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e77b51a8-b1cc-4272-8c23-47b3d6d3e93d
+      - d05a506b-2f17-43a4-b851-000997aeb1b1
     status: 200 OK
     code: 200
     duration: ""
@@ -810,19 +810,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038007Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:43:44.096668Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:04 GMT
+      - Tue, 07 Nov 2023 16:20:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0c932f5-2522-4813-afd3-2c7fa1928224
+      - 869778e6-872c-41d9-a538-f28f5582a9f6
     status: 200 OK
     code: 200
     duration: ""
@@ -843,19 +843,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038007Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:43:44.096668Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:09 GMT
+      - Tue, 07 Nov 2023 16:20:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6be01ee4-1d35-4c95-baa5-d8eaf172e059
+      - c76706cb-e20c-4efa-9967-bf8f5b1d8499
     status: 200 OK
     code: 200
     duration: ""
@@ -876,19 +876,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038007Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:43:44.096668Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:14 GMT
+      - Tue, 07 Nov 2023 16:20:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9596389f-25a1-400e-90d4-dd342c8bd61b
+      - 5afbcc0b-ce6e-40d0-bcb4-a3ebe9d34bcb
     status: 200 OK
     code: 200
     duration: ""
@@ -909,19 +909,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038007Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:43:44.096668Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:19 GMT
+      - Tue, 07 Nov 2023 16:20:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df2ff562-a67a-41b3-8c82-f59933ae93ef
+      - 63d4a9f5-d3c9-4f02-aa05-599c1acba71a
     status: 200 OK
     code: 200
     duration: ""
@@ -942,19 +942,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038007Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:43:44.096668Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:24 GMT
+      - Tue, 07 Nov 2023 16:20:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -964,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31175438-f794-4f48-852a-d2e4d21a94e1
+      - ce0fc65d-d4d4-4429-ae75-8ddef4ccb475
     status: 200 OK
     code: 200
     duration: ""
@@ -975,19 +975,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038007Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:43:44.096668Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:29 GMT
+      - Tue, 07 Nov 2023 16:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -997,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f171c24c-def0-491a-abb3-d409af98b1c9
+      - d95bba73-85bf-4e21-a197-72c92346b861
     status: 200 OK
     code: 200
     duration: ""
@@ -1008,19 +1008,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038007Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:44:33.741316Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1512"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:34 GMT
+      - Tue, 07 Nov 2023 16:20:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1030,12 +1030,144 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40b0b043-1dee-4fdb-a9eb-f9e836f988a2
+      - 927931d5-1f11-4cbe-8132-c1d7fda5152d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":null,"description":null,"tags":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":null,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":null},"auto_upgrade":{"enable":null,"maintenance_window":null},"feature_gates":null,"admission_plugins":null,"open_id_connect_config":{"issuer_url":null,"client_id":null,"username_claim":null,"username_prefix":null,"groups_claim":null,"groups_prefix":null,"required_claim":null},"apiserver_cert_sans":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1470"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:21:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f8cfe723-5449-4f09-a33a-54feb7ce8810
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1470"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:21:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 564f0ba6-b86c-477c-9811-8502d6f79a0e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:20:08.454121Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1470"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:21:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5358b7da-1d33-49de-8308-ef8c396dfdfa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:17.092870Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1467"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:21:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 92af251c-3c00-4e76-8b7c-89d04e73cc83
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":null,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":null},"auto_upgrade":{"enable":null,"maintenance_window":null},"open_id_connect_config":{"issuer_url":null,"client_id":null,"username_claim":null,"username_prefix":null,"groups_claim":null,"groups_prefix":null,"required_claim":null}}'
     form: {}
     headers:
       Content-Type:
@@ -1043,19 +1175,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038007Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:44:34.803686860Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:19.580044164Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1518"
+      - "1473"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:34 GMT
+      - Tue, 07 Nov 2023 16:21:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1065,7 +1197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f85401d-6448-4930-8395-c86f20f41b86
+      - b9930bfe-1008-4e6a-97da-5e73c738bfc5
     status: 200 OK
     code: 200
     duration: ""
@@ -1076,19 +1208,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038007Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:44:34.803687Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:19.580044Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:34 GMT
+      - Tue, 07 Nov 2023 16:21:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1098,7 +1230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2aef345-24b1-4cf2-881b-c2c444a991d0
+      - a9cfa96c-6d2f-46aa-856e-1aa8b9f2ed09
     status: 200 OK
     code: 200
     duration: ""
@@ -1109,19 +1241,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038007Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:44:34.803687Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:19.580044Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:39 GMT
+      - Tue, 07 Nov 2023 16:21:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1131,7 +1263,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 328709ec-71da-4a0c-b876-342a62a021e7
+      - 4f1cafb9-9de5-4373-9e37-cb2d06a1fc8d
     status: 200 OK
     code: 200
     duration: ""
@@ -1142,19 +1274,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038007Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:44:34.803687Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:19.580044Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:45 GMT
+      - Tue, 07 Nov 2023 16:21:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1164,7 +1296,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e16dea11-a659-4375-8c9c-b658c3466cac
+      - 7cd12ca5-8531-4599-b66f-f11199798053
     status: 200 OK
     code: 200
     duration: ""
@@ -1175,19 +1307,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038007Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:44:34.803687Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:19.580044Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:50 GMT
+      - Tue, 07 Nov 2023 16:21:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1197,7 +1329,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5dd0669c-6172-4cfb-9792-5d7d61716cc1
+      - bf837362-acca-4386-852b-108c31210a2e
     status: 200 OK
     code: 200
     duration: ""
@@ -1208,19 +1340,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038007Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:44:34.803687Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:19.580044Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:44:55 GMT
+      - Tue, 07 Nov 2023 16:21:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1230,7 +1362,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0da57a14-fa02-46dd-8711-e9706246ae9e
+      - 5a9b557d-daed-414d-a3f5-080ae58cf161
     status: 200 OK
     code: 200
     duration: ""
@@ -1241,19 +1373,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038007Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:44:34.803687Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:19.580044Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:00 GMT
+      - Tue, 07 Nov 2023 16:21:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1263,7 +1395,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0a1eb96-8a84-49e8-b160-5dbfab73128b
+      - 95e1cccf-7b9d-40c1-ba28-cc5c33c272bf
     status: 200 OK
     code: 200
     duration: ""
@@ -1274,19 +1406,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038007Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:44:34.803687Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:19.580044Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:05 GMT
+      - Tue, 07 Nov 2023 16:21:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1296,7 +1428,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb7eeef1-c9f1-41e2-a2ef-4054a3fd2e87
+      - 95c5c9ca-7a66-4c38-ab6a-9274c64432df
     status: 200 OK
     code: 200
     duration: ""
@@ -1307,19 +1439,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038007Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:45:06.181690Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:19.580044Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1512"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:10 GMT
+      - Tue, 07 Nov 2023 16:21:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1329,7 +1461,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a9c16a3-9027-4250-b441-4cdb3015dd0a
+      - 91539e3e-0676-4e82-8d52-899d482c7726
     status: 200 OK
     code: 200
     duration: ""
@@ -1340,19 +1472,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038007Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:45:06.181690Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:19.580044Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1512"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:10 GMT
+      - Tue, 07 Nov 2023 16:22:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1362,7 +1494,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f7431c5-35e0-4a90-8022-26568f1a7197
+      - ee7c9b83-765e-4a35-a4e5-bd5ae7ad1133
     status: 200 OK
     code: 200
     duration: ""
@@ -1373,19 +1505,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUa1JOZWs0eGIxaEVWRTE2VFZSQmVFNTZSVEpPUkUxNlRqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNkckNsSTFSRGR4UjBvelkyVm1OMWR6VmxGM1RXSmxVMll3ZHpaVE0yOWFUSGhaTkZOSllVazBZMGhaY214aFFrUkNMMUExVWxOVU9TOVhaVlZaVFN0NVRsb0tNM1JUVmpOcFIydFBZWHBWTTA5TGJ6bHZRM0JyVnpneE5HdHVUamswUzJsM1kyTmlibEo1VVV4cFFXVkdRV2hIU0dOYU1FUlpOek5VUld4TlVVdENNZ3BTWjBkck5XTlRkVlZFY2pCa05rVlliRkU0YTNCU01XYzNTaXRIUm5VM1EydFlZVkZuZG5wcE5WTlRlVVE0U2taWGF6RnZabVU0UTJsTU1sVTRWMVEwQ2tRelMzRTNTVXN4Ynk4dlNGbExTalJDWlROa1dWa3lUV054U0d0cFRIQmlRbE5STkZoVmVqUjRVMUV4WmtSNVRuaHdSbkZ4ZUdaeFNraDNTelZZVGs4S2RqSlVTRkJoTXk5dWJEbHBRMk5ITjFCcFIwdDRORll5TlRFeVVGVlBiRkp3VlZacmQzTXdhMmcwWTFONWFFNXRRVkZHT1RRcllWUm1SRVI0WkdaQ2N3b3ZkV2hhTkVWNFNHZGhOemMyUkVNeFVrYzRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkVaV3B6UzJkVVIwWllhblppZHpFNVJXdDRTREZoWlM5RWNrRk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRTRTV5VUZKVWJqazJkM1ZvWlhKTFNXVmlUbnB4Ym1adlRtMW9iMkphZGxKNmRYcEVTRmhvWVRSdU5GbGFVMHhoVEFvM1RpOXpZbnBvZWpscFpYaHhObU53Y21WVmR6ZzFlRkU0TDJObldrRnVTSFpYV1VSRlRqaDNPVFpPZGk4MldIWjZOMXBZVUZvck5FcDJjbk5QU21SUENtSlRWbEYzWldOS2IwaHZZWEF3WjBGcWFHdDRZUzlLYlVoME0za3hObGhpV1dkVE0xaFdaWFEwWWl0R2IySlVXVGx5Tkc5aGNtdGFUMlF6VUZjNFoxY0tZa1U1UWtoYVNIUkJaM0kzUWpaSVpUVlBlazVFZWtWNGFuVlNVV04xV2pOSE5rNVNTRmgwVGxFeFFYUkdPR2RrVEdaR04zRkNNMVZCV0daTFJrWlRWd280YjBZeGVYaERTa3RIUzI0eWVuYzVaSFpGV1ZkWGExUmpPR3RFV1ZRdlkwOXRaakZWUm01MU0yaFRVelJpT0VScFR6QjJlRGhFYVdsQk4xRXlVRzVwQ25aeFltVjZTMDF2U1RKeFEyaENjbFJxTkRSWVVHSkNOalZ5WVdKME9YTnBiVk15THdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2JlNGFkMzI3LWU0Y2QtNDc2ZS1iMzdkLWUzMmUwMjA4NTAxNC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpZDJQcjRSbUNOY3hUd0ZKWE9BQXZ0QnRUWUFNanNxRm83T3ZoRGRTekVGWXhxNkRTZFlqbFY3MA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:19.580044Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2622"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:10 GMT
+      - Tue, 07 Nov 2023 16:22:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1395,7 +1527,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08745099-1990-4b30-8e49-4d09e1f2098f
+      - ceb52a16-9069-4671-aa53-55665eac0a22
     status: 200 OK
     code: 200
     duration: ""
@@ -1406,19 +1538,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038007Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:45:06.181690Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:21:19.580044Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1512"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:10 GMT
+      - Tue, 07 Nov 2023 16:22:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1428,7 +1560,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23e7104f-8209-4da2-9938-62d1020b1857
+      - 25a70695-9944-4d4e-b49c-12cd9a774dbb
     status: 200 OK
     code: 200
     duration: ""
@@ -1439,19 +1571,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e119ab2a-cb88-4b75-b93d-94e1eabcf342
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:43:35.686906Z","dhcp_enabled":true,"id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:35.686906Z","id":"6e957e34-653e-4fed-ad63-38ba4eb78285","subnet":"172.16.16.0/22","updated_at":"2023-10-18T16:43:35.686906Z"},{"created_at":"2023-10-18T16:43:35.686906Z","id":"975a8ca4-bf73-442f-8fed-25cd29f6029e","subnet":"fd63:256c:45f7:91b4::/64","updated_at":"2023-10-18T16:43:35.686906Z"}],"tags":[],"updated_at":"2023-10-18T16:43:35.686906Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:22:11.725744Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "717"
+      - "1467"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:10 GMT
+      - Tue, 07 Nov 2023 16:22:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1461,7 +1593,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f860ea27-3889-464f-881d-92faee0c26bc
+      - 2bc7849f-80c4-48e6-8cc2-23ff32a31131
     status: 200 OK
     code: 200
     duration: ""
@@ -1472,19 +1604,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038007Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:45:06.181690Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:22:11.725744Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1512"
+      - "1467"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:10 GMT
+      - Tue, 07 Nov 2023 16:22:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1494,7 +1626,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - abf4d2cd-c376-431f-914d-b870c284276e
+      - 3cc20d50-ad54-4414-8d80-381b1b78985f
     status: 200 OK
     code: 200
     duration: ""
@@ -1505,19 +1637,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUa1JOZWs0eGIxaEVWRTE2VFZSQmVFNTZSVEpPUkUxNlRqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNkckNsSTFSRGR4UjBvelkyVm1OMWR6VmxGM1RXSmxVMll3ZHpaVE0yOWFUSGhaTkZOSllVazBZMGhaY214aFFrUkNMMUExVWxOVU9TOVhaVlZaVFN0NVRsb0tNM1JUVmpOcFIydFBZWHBWTTA5TGJ6bHZRM0JyVnpneE5HdHVUamswUzJsM1kyTmlibEo1VVV4cFFXVkdRV2hIU0dOYU1FUlpOek5VUld4TlVVdENNZ3BTWjBkck5XTlRkVlZFY2pCa05rVlliRkU0YTNCU01XYzNTaXRIUm5VM1EydFlZVkZuZG5wcE5WTlRlVVE0U2taWGF6RnZabVU0UTJsTU1sVTRWMVEwQ2tRelMzRTNTVXN4Ynk4dlNGbExTalJDWlROa1dWa3lUV054U0d0cFRIQmlRbE5STkZoVmVqUjRVMUV4WmtSNVRuaHdSbkZ4ZUdaeFNraDNTelZZVGs4S2RqSlVTRkJoTXk5dWJEbHBRMk5ITjFCcFIwdDRORll5TlRFeVVGVlBiRkp3VlZacmQzTXdhMmcwWTFONWFFNXRRVkZHT1RRcllWUm1SRVI0WkdaQ2N3b3ZkV2hhTkVWNFNHZGhOemMyUkVNeFVrYzRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkVaV3B6UzJkVVIwWllhblppZHpFNVJXdDRTREZoWlM5RWNrRk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRTRTV5VUZKVWJqazJkM1ZvWlhKTFNXVmlUbnB4Ym1adlRtMW9iMkphZGxKNmRYcEVTRmhvWVRSdU5GbGFVMHhoVEFvM1RpOXpZbnBvZWpscFpYaHhObU53Y21WVmR6ZzFlRkU0TDJObldrRnVTSFpYV1VSRlRqaDNPVFpPZGk4MldIWjZOMXBZVUZvck5FcDJjbk5QU21SUENtSlRWbEYzWldOS2IwaHZZWEF3WjBGcWFHdDRZUzlLYlVoME0za3hObGhpV1dkVE0xaFdaWFEwWWl0R2IySlVXVGx5Tkc5aGNtdGFUMlF6VUZjNFoxY0tZa1U1UWtoYVNIUkJaM0kzUWpaSVpUVlBlazVFZWtWNGFuVlNVV04xV2pOSE5rNVNTRmgwVGxFeFFYUkdPR2RrVEdaR04zRkNNMVZCV0daTFJrWlRWd280YjBZeGVYaERTa3RIUzI0eWVuYzVaSFpGV1ZkWGExUmpPR3RFV1ZRdlkwOXRaakZWUm01MU0yaFRVelJpT0VScFR6QjJlRGhFYVdsQk4xRXlVRzVwQ25aeFltVjZTMDF2U1RKeFEyaENjbFJxTkRSWVVHSkNOalZ5WVdKME9YTnBiVk15THdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2JlNGFkMzI3LWU0Y2QtNDc2ZS1iMzdkLWUzMmUwMjA4NTAxNC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpZDJQcjRSbUNOY3hUd0ZKWE9BQXZ0QnRUWUFNanNxRm83T3ZoRGRTekVGWXhxNkRTZFlqbFY3MA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAxc2IxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxKS0NuWlZkVVJoUkUxMkwxZ3JaMHQyVTBkRGRsRkZNa0U1YzBSVE9IaE1jRVl5UTNaV1JFcHBVaXN5UzJ3elNEaHBNVEIxY1hSTldYVklWamROT1dkUloyOEtkbkJ2VG5FcmVHazJkazFPU0ZWbU5IcGhNR1ZqWlhWcFoxbEpiamxoT1RGRWRpdHJZekozYkZsUmNHTlRaMVY2VVhjclRtMHhSMk5wSzA1eFJYUlFaZ3AyYUZsaE1HMUdjV001U2xaa1UyeGhkVU0wVW5ocmVuZElhbEJtZW5GeVIxQTJVMGRZTlVGTVRXZEVibGxqVFRNMVR6Y3pSVzVSWWxKTWFuQktlRUZGQ2k5YVIxUmxVMlY1U1c0MU5rNXdkVXBYTlVJNWVVMUNkR2wyUWprdk5VeEtZMHRvUjFWaVoxTnViVkEwTWpsS1UyMVVkbE5PTkRSWVkxRk1OVnBOY25nS2FIRTJlSFl5WXpGalVWRmhSakZpTURKbVNERlZjbWQ2YzFwT1RqQnBhMVJPVERSU1QzRkJRbVZhVjBGR2NWSlNSSE16VVVzeVdEWXlNVVZoZUdoWVJBcE9Wa052Y0ZGV2MwbDVlV0ZHYURKUWQwZ3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhaMnRGUTJFdlpXTTBOSEp1UjFFMU5XaE9OazlwUlV4T1R6Qk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSM1JOWWtobGNuWm5lRTkzZEdseFZ6VjRNelZWT0Zwc2VVWTVSR3M1VGxOelRuRmFMelJMYmtsdmVsUjFNVFpGTlFwTmRucENkR041VkVGUFRtaE1ka1E0VUZsWVlrNUpWVmw2ZVhoNGVVOHdRamhUYlRacWFERk5kVEZwZW0xSlRFbG1RV05CWjA1elMwbGFXREZ6VHpWcENsUm5WVnBuWkVNMVdEQmFMM3AzY1c5SFRFRkpTbk12VkVsa2J6UkdUR1ZyWTNkRVExVnFhekVyVWtsdlRucEZiRkJTVm5aRVlURk1VamRZZG5GUlpERUtXbVpGUkVZeFlXaEZjbHBVUzNWTlUwcHZlSFE0VUU5R1kyUjZPWGtyWVhrM2EwWlpOMVU1YlcxTU1YZEhRVWRNYUdGNWQyaFRUWG8yVVVVNWNrMVRZd3A2TW04NE4wdEpaRkJ5Y0VwRmEzcE5ZMjlTYW5OR1RXRnJlRkJJU1ZndlUwRkpObnBsV25oSGFHUlhLMFJ4Um1nck5GUnhZMVoyWmpRNVZ6VkdiVzQ1Q2pNeldERkRkSGgyTTNSa2VuWlhXbTEyTmpGbk0yeFdZMGw1WVRWdldWUkRTak5NUmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzg3Y2U3ZWRlLWZkMWYtNGY0Mi1iZWEwLTY1YTM2OGUzZjM2Yi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB0d2NaZjhyOWxJa2ZVaUJ1eTBBMFJBNWxyWjhNMXlVVGJnOHJFNXVVdWQ1bXFwSG1BWnRGdXRKVA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2622"
+      - "2620"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:10 GMT
+      - Tue, 07 Nov 2023 16:22:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1527,7 +1659,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - affe9e0b-54cd-4f63-97db-090be265a6bd
+      - 2ff7a2b0-bd51-4752-89ba-bab7d220b100
     status: 200 OK
     code: 200
     duration: ""
@@ -1538,19 +1670,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e119ab2a-cb88-4b75-b93d-94e1eabcf342
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:43:35.686906Z","dhcp_enabled":true,"id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:35.686906Z","id":"6e957e34-653e-4fed-ad63-38ba4eb78285","subnet":"172.16.16.0/22","updated_at":"2023-10-18T16:43:35.686906Z"},{"created_at":"2023-10-18T16:43:35.686906Z","id":"975a8ca4-bf73-442f-8fed-25cd29f6029e","subnet":"fd63:256c:45f7:91b4::/64","updated_at":"2023-10-18T16:43:35.686906Z"}],"tags":[],"updated_at":"2023-10-18T16:43:35.686906Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:22:11.725744Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "717"
+      - "1467"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:11 GMT
+      - Tue, 07 Nov 2023 16:22:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1560,7 +1692,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10663927-81b1-4c5c-8ad5-f0376927f141
+      - 7984e50e-e3ad-4229-88c5-f210414ea270
     status: 200 OK
     code: 200
     duration: ""
@@ -1571,19 +1703,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/963ac687-26f9-42a1-87c7-0a8737d493be
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038007Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:45:06.181690Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"created_at":"2023-11-07T16:19:59.627263Z","dhcp_enabled":true,"id":"963ac687-26f9-42a1-87c7-0a8737d493be","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.627263Z","id":"8b424081-dce6-41f2-9807-d34dcf032f45","subnet":"172.16.12.0/22","updated_at":"2023-11-07T16:19:59.627263Z"},{"created_at":"2023-11-07T16:19:59.627263Z","id":"9a8f7905-ef99-4cb9-bed8-a31b86103108","subnet":"fd63:256c:45f7:6697::/64","updated_at":"2023-11-07T16:19:59.627263Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.627263Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1512"
+      - "700"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:11 GMT
+      - Tue, 07 Nov 2023 16:22:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1593,7 +1725,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1353adec-19d0-4324-9841-adcbcf0a908d
+      - a3413446-1d1a-4263-ba85-446e00c15dd4
     status: 200 OK
     code: 200
     duration: ""
@@ -1604,19 +1736,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUa1JOZWs0eGIxaEVWRTE2VFZSQmVFNTZSVEpPUkUxNlRqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNkckNsSTFSRGR4UjBvelkyVm1OMWR6VmxGM1RXSmxVMll3ZHpaVE0yOWFUSGhaTkZOSllVazBZMGhaY214aFFrUkNMMUExVWxOVU9TOVhaVlZaVFN0NVRsb0tNM1JUVmpOcFIydFBZWHBWTTA5TGJ6bHZRM0JyVnpneE5HdHVUamswUzJsM1kyTmlibEo1VVV4cFFXVkdRV2hIU0dOYU1FUlpOek5VUld4TlVVdENNZ3BTWjBkck5XTlRkVlZFY2pCa05rVlliRkU0YTNCU01XYzNTaXRIUm5VM1EydFlZVkZuZG5wcE5WTlRlVVE0U2taWGF6RnZabVU0UTJsTU1sVTRWMVEwQ2tRelMzRTNTVXN4Ynk4dlNGbExTalJDWlROa1dWa3lUV054U0d0cFRIQmlRbE5STkZoVmVqUjRVMUV4WmtSNVRuaHdSbkZ4ZUdaeFNraDNTelZZVGs4S2RqSlVTRkJoTXk5dWJEbHBRMk5ITjFCcFIwdDRORll5TlRFeVVGVlBiRkp3VlZacmQzTXdhMmcwWTFONWFFNXRRVkZHT1RRcllWUm1SRVI0WkdaQ2N3b3ZkV2hhTkVWNFNHZGhOemMyUkVNeFVrYzRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkVaV3B6UzJkVVIwWllhblppZHpFNVJXdDRTREZoWlM5RWNrRk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRTRTV5VUZKVWJqazJkM1ZvWlhKTFNXVmlUbnB4Ym1adlRtMW9iMkphZGxKNmRYcEVTRmhvWVRSdU5GbGFVMHhoVEFvM1RpOXpZbnBvZWpscFpYaHhObU53Y21WVmR6ZzFlRkU0TDJObldrRnVTSFpYV1VSRlRqaDNPVFpPZGk4MldIWjZOMXBZVUZvck5FcDJjbk5QU21SUENtSlRWbEYzWldOS2IwaHZZWEF3WjBGcWFHdDRZUzlLYlVoME0za3hObGhpV1dkVE0xaFdaWFEwWWl0R2IySlVXVGx5Tkc5aGNtdGFUMlF6VUZjNFoxY0tZa1U1UWtoYVNIUkJaM0kzUWpaSVpUVlBlazVFZWtWNGFuVlNVV04xV2pOSE5rNVNTRmgwVGxFeFFYUkdPR2RrVEdaR04zRkNNMVZCV0daTFJrWlRWd280YjBZeGVYaERTa3RIUzI0eWVuYzVaSFpGV1ZkWGExUmpPR3RFV1ZRdlkwOXRaakZWUm01MU0yaFRVelJpT0VScFR6QjJlRGhFYVdsQk4xRXlVRzVwQ25aeFltVjZTMDF2U1RKeFEyaENjbFJxTkRSWVVHSkNOalZ5WVdKME9YTnBiVk15THdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2JlNGFkMzI3LWU0Y2QtNDc2ZS1iMzdkLWUzMmUwMjA4NTAxNC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpZDJQcjRSbUNOY3hUd0ZKWE9BQXZ0QnRUWUFNanNxRm83T3ZoRGRTekVGWXhxNkRTZFlqbFY3MA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:22:11.725744Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2622"
+      - "1467"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:15 GMT
+      - Tue, 07 Nov 2023 16:22:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1626,7 +1758,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d63fe7a-7dc5-455d-87b8-d8d7096aa09c
+      - 096a56b8-b098-4568-b9bb-566589db1618
     status: 200 OK
     code: 200
     duration: ""
@@ -1637,19 +1769,151 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAxc2IxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxKS0NuWlZkVVJoUkUxMkwxZ3JaMHQyVTBkRGRsRkZNa0U1YzBSVE9IaE1jRVl5UTNaV1JFcHBVaXN5UzJ3elNEaHBNVEIxY1hSTldYVklWamROT1dkUloyOEtkbkJ2VG5FcmVHazJkazFPU0ZWbU5IcGhNR1ZqWlhWcFoxbEpiamxoT1RGRWRpdHJZekozYkZsUmNHTlRaMVY2VVhjclRtMHhSMk5wSzA1eFJYUlFaZ3AyYUZsaE1HMUdjV001U2xaa1UyeGhkVU0wVW5ocmVuZElhbEJtZW5GeVIxQTJVMGRZTlVGTVRXZEVibGxqVFRNMVR6Y3pSVzVSWWxKTWFuQktlRUZGQ2k5YVIxUmxVMlY1U1c0MU5rNXdkVXBYTlVJNWVVMUNkR2wyUWprdk5VeEtZMHRvUjFWaVoxTnViVkEwTWpsS1UyMVVkbE5PTkRSWVkxRk1OVnBOY25nS2FIRTJlSFl5WXpGalVWRmhSakZpTURKbVNERlZjbWQ2YzFwT1RqQnBhMVJPVERSU1QzRkJRbVZhVjBGR2NWSlNSSE16VVVzeVdEWXlNVVZoZUdoWVJBcE9Wa052Y0ZGV2MwbDVlV0ZHYURKUWQwZ3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhaMnRGUTJFdlpXTTBOSEp1UjFFMU5XaE9OazlwUlV4T1R6Qk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSM1JOWWtobGNuWm5lRTkzZEdseFZ6VjRNelZWT0Zwc2VVWTVSR3M1VGxOelRuRmFMelJMYmtsdmVsUjFNVFpGTlFwTmRucENkR041VkVGUFRtaE1ka1E0VUZsWVlrNUpWVmw2ZVhoNGVVOHdRamhUYlRacWFERk5kVEZwZW0xSlRFbG1RV05CWjA1elMwbGFXREZ6VHpWcENsUm5WVnBuWkVNMVdEQmFMM3AzY1c5SFRFRkpTbk12VkVsa2J6UkdUR1ZyWTNkRVExVnFhekVyVWtsdlRucEZiRkJTVm5aRVlURk1VamRZZG5GUlpERUtXbVpGUkVZeFlXaEZjbHBVUzNWTlUwcHZlSFE0VUU5R1kyUjZPWGtyWVhrM2EwWlpOMVU1YlcxTU1YZEhRVWRNYUdGNWQyaFRUWG8yVVVVNWNrMVRZd3A2TW04NE4wdEpaRkJ5Y0VwRmEzcE5ZMjlTYW5OR1RXRnJlRkJJU1ZndlUwRkpObnBsV25oSGFHUlhLMFJ4Um1nck5GUnhZMVoyWmpRNVZ6VkdiVzQ1Q2pNeldERkRkSGgyTTNSa2VuWlhXbTEyTmpGbk0yeFdZMGw1WVRWdldWUkRTak5NUmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzg3Y2U3ZWRlLWZkMWYtNGY0Mi1iZWEwLTY1YTM2OGUzZjM2Yi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB0d2NaZjhyOWxJa2ZVaUJ1eTBBMFJBNWxyWjhNMXlVVGJnOHJFNXVVdWQ1bXFwSG1BWnRGdXRKVA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2620"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:22:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fbb7c909-a8e7-4de5-87d7-6925d6469b21
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/963ac687-26f9-42a1-87c7-0a8737d493be
+    method: GET
+  response:
+    body: '{"created_at":"2023-11-07T16:19:59.627263Z","dhcp_enabled":true,"id":"963ac687-26f9-42a1-87c7-0a8737d493be","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.627263Z","id":"8b424081-dce6-41f2-9807-d34dcf032f45","subnet":"172.16.12.0/22","updated_at":"2023-11-07T16:19:59.627263Z"},{"created_at":"2023-11-07T16:19:59.627263Z","id":"9a8f7905-ef99-4cb9-bed8-a31b86103108","subnet":"fd63:256c:45f7:6697::/64","updated_at":"2023-11-07T16:19:59.627263Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.627263Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "700"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:22:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 90879aa0-90dc-42bf-8673-c13b647afee2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:22:11.725744Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1467"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:22:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3a1e94df-bdca-46db-8c8c-778711428d21
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAxc2IxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxKS0NuWlZkVVJoUkUxMkwxZ3JaMHQyVTBkRGRsRkZNa0U1YzBSVE9IaE1jRVl5UTNaV1JFcHBVaXN5UzJ3elNEaHBNVEIxY1hSTldYVklWamROT1dkUloyOEtkbkJ2VG5FcmVHazJkazFPU0ZWbU5IcGhNR1ZqWlhWcFoxbEpiamxoT1RGRWRpdHJZekozYkZsUmNHTlRaMVY2VVhjclRtMHhSMk5wSzA1eFJYUlFaZ3AyYUZsaE1HMUdjV001U2xaa1UyeGhkVU0wVW5ocmVuZElhbEJtZW5GeVIxQTJVMGRZTlVGTVRXZEVibGxqVFRNMVR6Y3pSVzVSWWxKTWFuQktlRUZGQ2k5YVIxUmxVMlY1U1c0MU5rNXdkVXBYTlVJNWVVMUNkR2wyUWprdk5VeEtZMHRvUjFWaVoxTnViVkEwTWpsS1UyMVVkbE5PTkRSWVkxRk1OVnBOY25nS2FIRTJlSFl5WXpGalVWRmhSakZpTURKbVNERlZjbWQ2YzFwT1RqQnBhMVJPVERSU1QzRkJRbVZhVjBGR2NWSlNSSE16VVVzeVdEWXlNVVZoZUdoWVJBcE9Wa052Y0ZGV2MwbDVlV0ZHYURKUWQwZ3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhaMnRGUTJFdlpXTTBOSEp1UjFFMU5XaE9OazlwUlV4T1R6Qk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSM1JOWWtobGNuWm5lRTkzZEdseFZ6VjRNelZWT0Zwc2VVWTVSR3M1VGxOelRuRmFMelJMYmtsdmVsUjFNVFpGTlFwTmRucENkR041VkVGUFRtaE1ka1E0VUZsWVlrNUpWVmw2ZVhoNGVVOHdRamhUYlRacWFERk5kVEZwZW0xSlRFbG1RV05CWjA1elMwbGFXREZ6VHpWcENsUm5WVnBuWkVNMVdEQmFMM3AzY1c5SFRFRkpTbk12VkVsa2J6UkdUR1ZyWTNkRVExVnFhekVyVWtsdlRucEZiRkJTVm5aRVlURk1VamRZZG5GUlpERUtXbVpGUkVZeFlXaEZjbHBVUzNWTlUwcHZlSFE0VUU5R1kyUjZPWGtyWVhrM2EwWlpOMVU1YlcxTU1YZEhRVWRNYUdGNWQyaFRUWG8yVVVVNWNrMVRZd3A2TW04NE4wdEpaRkJ5Y0VwRmEzcE5ZMjlTYW5OR1RXRnJlRkJJU1ZndlUwRkpObnBsV25oSGFHUlhLMFJ4Um1nck5GUnhZMVoyWmpRNVZ6VkdiVzQ1Q2pNeldERkRkSGgyTTNSa2VuWlhXbTEyTmpGbk0yeFdZMGw1WVRWdldWUkRTak5NUmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzg3Y2U3ZWRlLWZkMWYtNGY0Mi1iZWEwLTY1YTM2OGUzZjM2Yi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB0d2NaZjhyOWxJa2ZVaUJ1eTBBMFJBNWxyWjhNMXlVVGJnOHJFNXVVdWQ1bXFwSG1BWnRGdXRKVA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2620"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:22:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ce662dd0-20f8-4a87-a459-13ea858d69ba
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":2}'
     headers:
       Content-Length:
-      - "423"
+      - "407"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:15 GMT
+      - Tue, 07 Nov 2023 16:22:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1659,7 +1923,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e2f7b21-4f34-4fa6-9fd6-99a6bd39a87d
+      - 2c9e4b0a-0696-4b9b-8745-e9b1b60b22f7
     status: 200 OK
     code: 200
     duration: ""
@@ -1670,19 +1934,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":2}'
     headers:
       Content-Length:
-      - "423"
+      - "407"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:16 GMT
+      - Tue, 07 Nov 2023 16:22:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1692,7 +1956,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6304f63f-457c-4193-9321-4b33b2706b9d
+      - 3eb8fce1-77e4-4750-a096-b744d05df93d
     status: 200 OK
     code: 200
     duration: ""
@@ -1703,19 +1967,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"kapsule-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":2}'
     headers:
       Content-Length:
-      - "423"
+      - "407"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:16 GMT
+      - Tue, 07 Nov 2023 16:22:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1725,7 +1989,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83235371-4aa7-40db-b165-cbdce129f7e6
+      - 72a9ef07-0dff-40d1-b0c9-cff4a38c29f0
     status: 200 OK
     code: 200
     duration: ""
@@ -1736,19 +2000,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:43:44.038007Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-10-18T16:45:06.181690Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:20:08.403445Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-4","updated_at":"2023-11-07T16:22:11.725744Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1512"
+      - "1467"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:16 GMT
+      - Tue, 07 Nov 2023 16:22:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1758,7 +2022,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2a30aa8-b8ff-4bcb-9487-7fa1c9be4de5
+      - dc0e00f4-426b-4ae2-8467-4cf78aa712b4
     status: 200 OK
     code: 200
     duration: ""
@@ -1771,19 +2035,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014/set-type
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/set-type
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441020Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:45:16.644907841Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527638748Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109254Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1522"
+      - "1477"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:16 GMT
+      - Tue, 07 Nov 2023 16:22:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1793,7 +2057,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6c64c28-085f-46ab-801b-b6c743813833
+      - 336b159b-73b1-4bf6-87c3-1e8477bc4fd8
     status: 200 OK
     code: 200
     duration: ""
@@ -1804,19 +2068,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:45:16.644908Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:16 GMT
+      - Tue, 07 Nov 2023 16:22:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1826,7 +2090,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da19e5fe-c1b9-46c8-9249-d318b58229e5
+      - 180e942f-39b8-4ccb-af15-a9577c5865ec
     status: 200 OK
     code: 200
     duration: ""
@@ -1837,19 +2101,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:45:16.644908Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:21 GMT
+      - Tue, 07 Nov 2023 16:22:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1859,7 +2123,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b895fb2d-ee40-4855-9093-4273cd8fa98e
+      - 8dc5eb26-92dd-4632-94b9-b4cd16fcb6dd
     status: 200 OK
     code: 200
     duration: ""
@@ -1870,19 +2134,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:45:16.644908Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:26 GMT
+      - Tue, 07 Nov 2023 16:22:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1892,7 +2156,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f69d601c-a372-43d0-b354-8e0e5cd732df
+      - c611e5e9-b131-4aa2-bb1b-af4bc4f2f6ac
     status: 200 OK
     code: 200
     duration: ""
@@ -1903,19 +2167,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:45:16.644908Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:31 GMT
+      - Tue, 07 Nov 2023 16:22:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1925,7 +2189,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9194d5eb-e854-419c-b5e5-7bba82e62a6b
+      - 5439940a-6c88-4789-8d02-86542ba7470d
     status: 200 OK
     code: 200
     duration: ""
@@ -1936,19 +2200,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:45:16.644908Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:36 GMT
+      - Tue, 07 Nov 2023 16:22:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1958,7 +2222,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc7bc716-8abd-49b9-abb5-61e04e4f50e0
+      - 52ca8be8-2707-440f-8dc4-80ebc48010d7
     status: 200 OK
     code: 200
     duration: ""
@@ -1969,19 +2233,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:45:16.644908Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:41 GMT
+      - Tue, 07 Nov 2023 16:22:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1991,7 +2255,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89c5ec20-b571-42c6-be6f-df39acbdc196
+      - c8a2c4ed-de8e-4dbb-8a4b-c642904f8355
     status: 200 OK
     code: 200
     duration: ""
@@ -2002,19 +2266,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:45:16.644908Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:47 GMT
+      - Tue, 07 Nov 2023 16:22:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2024,7 +2288,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe35ae60-f2b1-43c9-9883-52a0443f5dfc
+      - d9ffe454-09de-4aaa-b6cb-fd566cf6f540
     status: 200 OK
     code: 200
     duration: ""
@@ -2035,19 +2299,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:45:16.644908Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:52 GMT
+      - Tue, 07 Nov 2023 16:22:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2057,7 +2321,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce5bed5a-21b3-4d70-8234-6c3186785feb
+      - 5944bcec-20f8-4f8f-88cd-1339c49c667a
     status: 200 OK
     code: 200
     duration: ""
@@ -2068,19 +2332,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:45:16.644908Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:45:57 GMT
+      - Tue, 07 Nov 2023 16:22:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2090,7 +2354,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f20b3649-dcea-4fbf-af3f-e7d4979a1a22
+      - a2c7a4b0-1359-4f26-af74-60e1bb4aa0e2
     status: 200 OK
     code: 200
     duration: ""
@@ -2101,19 +2365,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:45:16.644908Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:02 GMT
+      - Tue, 07 Nov 2023 16:23:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2123,7 +2387,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d9e74d7-db42-4fb0-81bc-898edf279804
+      - 1662cf30-195c-42e3-947b-81149ad24fed
     status: 200 OK
     code: 200
     duration: ""
@@ -2134,19 +2398,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:45:16.644908Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:07 GMT
+      - Tue, 07 Nov 2023 16:23:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2156,7 +2420,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4b20c5f-c14c-404a-a41e-570e32d825a6
+      - 0adf2ac2-c856-4595-b150-788a81f34eaa
     status: 200 OK
     code: 200
     duration: ""
@@ -2167,19 +2431,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:45:16.644908Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:13 GMT
+      - Tue, 07 Nov 2023 16:23:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2189,7 +2453,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae20fe53-cb4e-46e3-b83d-94ece8524f8e
+      - bc70c54a-7048-45eb-a24c-a72d4e6d9920
     status: 200 OK
     code: 200
     duration: ""
@@ -2200,19 +2464,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:45:16.644908Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:18 GMT
+      - Tue, 07 Nov 2023 16:23:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2222,7 +2486,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e6afc39-5933-4e76-a286-03e9d4829e04
+      - e8fd21ea-e002-46a7-8a9e-eaf7e4f543fe
     status: 200 OK
     code: 200
     duration: ""
@@ -2233,19 +2497,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:46:21.537514Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:22:17.612109Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1513"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:23 GMT
+      - Tue, 07 Nov 2023 16:23:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2255,12 +2519,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63a675ee-0275-4cd9-ad3a-98271ab9b541
+      - fe802158-1edf-4a59-a66e-f0721462eb55
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":null,"description":null,"tags":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":null,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":null},"auto_upgrade":{"enable":null,"maintenance_window":null},"feature_gates":null,"admission_plugins":null,"open_id_connect_config":{"issuer_url":null,"client_id":null,"username_claim":null,"username_prefix":null,"groups_claim":null,"groups_prefix":null,"required_claim":null},"apiserver_cert_sans":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:23:24.762360Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1468"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:23:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9f945ff3-ed62-4295-9192-4f86dbb7b12a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":null,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":null},"auto_upgrade":{"enable":null,"maintenance_window":null},"open_id_connect_config":{"issuer_url":null,"client_id":null,"username_claim":null,"username_prefix":null,"groups_claim":null,"groups_prefix":null,"required_claim":null}}'
     form: {}
     headers:
       Content-Type:
@@ -2268,19 +2565,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:46:23.176032588Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:23:28.554338630Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1519"
+      - "1474"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:23 GMT
+      - Tue, 07 Nov 2023 16:23:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2290,7 +2587,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8d421a9-23a5-40ab-bcc8-7573b0842c20
+      - 9afd57af-04b3-494c-ae0e-2377a8ecb9d1
     status: 200 OK
     code: 200
     duration: ""
@@ -2301,19 +2598,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:46:23.176033Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:23:28.554339Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:23 GMT
+      - Tue, 07 Nov 2023 16:23:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2323,7 +2620,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 488b0539-8bb1-480b-a3f2-10722d938548
+      - 8c83b5d3-11fb-46cc-9022-acf677a8c97e
     status: 200 OK
     code: 200
     duration: ""
@@ -2334,19 +2631,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:46:23.176033Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:23:28.554339Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:28 GMT
+      - Tue, 07 Nov 2023 16:23:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2356,7 +2653,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 242dd8e8-5b70-4ebb-9ac3-8660cdb3aa4a
+      - f9920ec5-2f5e-45b6-8a77-9c8734138656
     status: 200 OK
     code: 200
     duration: ""
@@ -2367,19 +2664,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:46:23.176033Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:23:28.554339Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:33 GMT
+      - Tue, 07 Nov 2023 16:23:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2389,7 +2686,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4397770-13bc-4e12-9b96-d8f2eba9e548
+      - 48997637-4d6a-4b4f-afd1-084ca30b474c
     status: 200 OK
     code: 200
     duration: ""
@@ -2400,19 +2697,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:46:23.176033Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:23:28.554339Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:38 GMT
+      - Tue, 07 Nov 2023 16:23:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2422,7 +2719,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36a62052-3ebd-4030-8587-6c89c0ab475b
+      - 2c9520d8-66d8-41e8-a012-e07858f7f762
     status: 200 OK
     code: 200
     duration: ""
@@ -2433,19 +2730,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:46:23.176033Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:23:28.554339Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:43 GMT
+      - Tue, 07 Nov 2023 16:23:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2455,7 +2752,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d17fccb-cf35-436f-8034-65dc1d98054c
+      - 4dbd1458-6be2-4a27-8570-369aa80392fa
     status: 200 OK
     code: 200
     duration: ""
@@ -2466,19 +2763,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:46:23.176033Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:23:28.554339Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:48 GMT
+      - Tue, 07 Nov 2023 16:23:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2488,7 +2785,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e17eb57c-a1d3-41d3-bc71-5bb9cfc65316
+      - 77171913-ebcc-4efe-b045-0d5607974e03
     status: 200 OK
     code: 200
     duration: ""
@@ -2499,19 +2796,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:46:23.176033Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:23:28.554339Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:53 GMT
+      - Tue, 07 Nov 2023 16:23:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2521,7 +2818,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4578f640-12e5-40ae-9fed-d8e97545682b
+      - a26c5b54-3a55-4d94-99e2-afe79f083f9f
     status: 200 OK
     code: 200
     duration: ""
@@ -2532,19 +2829,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:46:23.176033Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:24:03.487411Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1468"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:46:58 GMT
+      - Tue, 07 Nov 2023 16:24:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2554,7 +2851,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1dde997-948a-4525-bddc-c96f095fa52e
+      - 38cb10c6-7178-49b3-a163-8b6c4eee591d
     status: 200 OK
     code: 200
     duration: ""
@@ -2565,19 +2862,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:46:23.176033Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:24:03.487411Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1468"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:03 GMT
+      - Tue, 07 Nov 2023 16:24:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2587,7 +2884,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 498ffba0-afc3-43f2-8e96-357e7f801046
+      - 24887a29-be67-4d7e-a366-e0caee6b712a
     status: 200 OK
     code: 200
     duration: ""
@@ -2598,19 +2895,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:46:23.176033Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAxc2IxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxKS0NuWlZkVVJoUkUxMkwxZ3JaMHQyVTBkRGRsRkZNa0U1YzBSVE9IaE1jRVl5UTNaV1JFcHBVaXN5UzJ3elNEaHBNVEIxY1hSTldYVklWamROT1dkUloyOEtkbkJ2VG5FcmVHazJkazFPU0ZWbU5IcGhNR1ZqWlhWcFoxbEpiamxoT1RGRWRpdHJZekozYkZsUmNHTlRaMVY2VVhjclRtMHhSMk5wSzA1eFJYUlFaZ3AyYUZsaE1HMUdjV001U2xaa1UyeGhkVU0wVW5ocmVuZElhbEJtZW5GeVIxQTJVMGRZTlVGTVRXZEVibGxqVFRNMVR6Y3pSVzVSWWxKTWFuQktlRUZGQ2k5YVIxUmxVMlY1U1c0MU5rNXdkVXBYTlVJNWVVMUNkR2wyUWprdk5VeEtZMHRvUjFWaVoxTnViVkEwTWpsS1UyMVVkbE5PTkRSWVkxRk1OVnBOY25nS2FIRTJlSFl5WXpGalVWRmhSakZpTURKbVNERlZjbWQ2YzFwT1RqQnBhMVJPVERSU1QzRkJRbVZhVjBGR2NWSlNSSE16VVVzeVdEWXlNVVZoZUdoWVJBcE9Wa052Y0ZGV2MwbDVlV0ZHYURKUWQwZ3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhaMnRGUTJFdlpXTTBOSEp1UjFFMU5XaE9OazlwUlV4T1R6Qk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSM1JOWWtobGNuWm5lRTkzZEdseFZ6VjRNelZWT0Zwc2VVWTVSR3M1VGxOelRuRmFMelJMYmtsdmVsUjFNVFpGTlFwTmRucENkR041VkVGUFRtaE1ka1E0VUZsWVlrNUpWVmw2ZVhoNGVVOHdRamhUYlRacWFERk5kVEZwZW0xSlRFbG1RV05CWjA1elMwbGFXREZ6VHpWcENsUm5WVnBuWkVNMVdEQmFMM3AzY1c5SFRFRkpTbk12VkVsa2J6UkdUR1ZyWTNkRVExVnFhekVyVWtsdlRucEZiRkJTVm5aRVlURk1VamRZZG5GUlpERUtXbVpGUkVZeFlXaEZjbHBVUzNWTlUwcHZlSFE0VUU5R1kyUjZPWGtyWVhrM2EwWlpOMVU1YlcxTU1YZEhRVWRNYUdGNWQyaFRUWG8yVVVVNWNrMVRZd3A2TW04NE4wdEpaRkJ5Y0VwRmEzcE5ZMjlTYW5OR1RXRnJlRkJJU1ZndlUwRkpObnBsV25oSGFHUlhLMFJ4Um1nck5GUnhZMVoyWmpRNVZ6VkdiVzQ1Q2pNeldERkRkSGgyTTNSa2VuWlhXbTEyTmpGbk0yeFdZMGw1WVRWdldWUkRTak5NUmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzg3Y2U3ZWRlLWZkMWYtNGY0Mi1iZWEwLTY1YTM2OGUzZjM2Yi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB0d2NaZjhyOWxJa2ZVaUJ1eTBBMFJBNWxyWjhNMXlVVGJnOHJFNXVVdWQ1bXFwSG1BWnRGdXRKVA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1516"
+      - "2620"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:08 GMT
+      - Tue, 07 Nov 2023 16:24:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2620,7 +2917,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a451546e-13e4-479a-b783-0e834389145c
+      - 51eecd34-3a39-49cc-be43-d3053e58486f
     status: 200 OK
     code: 200
     duration: ""
@@ -2631,19 +2928,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:46:23.176033Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:24:03.487411Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1468"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:13 GMT
+      - Tue, 07 Nov 2023 16:24:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2653,7 +2950,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 150a914e-4396-4159-82eb-cea3e7f8d7ea
+      - 5ffbb5ed-f1a0-49b9-a09a-54204d1c5b24
     status: 200 OK
     code: 200
     duration: ""
@@ -2664,19 +2961,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/963ac687-26f9-42a1-87c7-0a8737d493be
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:47:18.352539Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"created_at":"2023-11-07T16:19:59.627263Z","dhcp_enabled":true,"id":"963ac687-26f9-42a1-87c7-0a8737d493be","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.627263Z","id":"8b424081-dce6-41f2-9807-d34dcf032f45","subnet":"172.16.12.0/22","updated_at":"2023-11-07T16:19:59.627263Z"},{"created_at":"2023-11-07T16:19:59.627263Z","id":"9a8f7905-ef99-4cb9-bed8-a31b86103108","subnet":"fd63:256c:45f7:6697::/64","updated_at":"2023-11-07T16:19:59.627263Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.627263Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1513"
+      - "700"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:18 GMT
+      - Tue, 07 Nov 2023 16:24:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2686,7 +2983,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ab00fcd-451d-4603-a530-20e41eec4c58
+      - 59ed9774-e2ac-455e-a88f-58100c221baa
     status: 200 OK
     code: 200
     duration: ""
@@ -2697,19 +2994,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:47:18.352539Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:24:03.487411Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1513"
+      - "1468"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:18 GMT
+      - Tue, 07 Nov 2023 16:24:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2719,7 +3016,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea44bb10-eef4-4089-aeea-8bdcca900685
+      - 902221d8-b5f9-4175-8755-79d6fe57bfee
     status: 200 OK
     code: 200
     duration: ""
@@ -2730,19 +3027,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUa1JOZWs0eGIxaEVWRTE2VFZSQmVFNTZSVEpPUkUxNlRqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNkckNsSTFSRGR4UjBvelkyVm1OMWR6VmxGM1RXSmxVMll3ZHpaVE0yOWFUSGhaTkZOSllVazBZMGhaY214aFFrUkNMMUExVWxOVU9TOVhaVlZaVFN0NVRsb0tNM1JUVmpOcFIydFBZWHBWTTA5TGJ6bHZRM0JyVnpneE5HdHVUamswUzJsM1kyTmlibEo1VVV4cFFXVkdRV2hIU0dOYU1FUlpOek5VUld4TlVVdENNZ3BTWjBkck5XTlRkVlZFY2pCa05rVlliRkU0YTNCU01XYzNTaXRIUm5VM1EydFlZVkZuZG5wcE5WTlRlVVE0U2taWGF6RnZabVU0UTJsTU1sVTRWMVEwQ2tRelMzRTNTVXN4Ynk4dlNGbExTalJDWlROa1dWa3lUV054U0d0cFRIQmlRbE5STkZoVmVqUjRVMUV4WmtSNVRuaHdSbkZ4ZUdaeFNraDNTelZZVGs4S2RqSlVTRkJoTXk5dWJEbHBRMk5ITjFCcFIwdDRORll5TlRFeVVGVlBiRkp3VlZacmQzTXdhMmcwWTFONWFFNXRRVkZHT1RRcllWUm1SRVI0WkdaQ2N3b3ZkV2hhTkVWNFNHZGhOemMyUkVNeFVrYzRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkVaV3B6UzJkVVIwWllhblppZHpFNVJXdDRTREZoWlM5RWNrRk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRTRTV5VUZKVWJqazJkM1ZvWlhKTFNXVmlUbnB4Ym1adlRtMW9iMkphZGxKNmRYcEVTRmhvWVRSdU5GbGFVMHhoVEFvM1RpOXpZbnBvZWpscFpYaHhObU53Y21WVmR6ZzFlRkU0TDJObldrRnVTSFpYV1VSRlRqaDNPVFpPZGk4MldIWjZOMXBZVUZvck5FcDJjbk5QU21SUENtSlRWbEYzWldOS2IwaHZZWEF3WjBGcWFHdDRZUzlLYlVoME0za3hObGhpV1dkVE0xaFdaWFEwWWl0R2IySlVXVGx5Tkc5aGNtdGFUMlF6VUZjNFoxY0tZa1U1UWtoYVNIUkJaM0kzUWpaSVpUVlBlazVFZWtWNGFuVlNVV04xV2pOSE5rNVNTRmgwVGxFeFFYUkdPR2RrVEdaR04zRkNNMVZCV0daTFJrWlRWd280YjBZeGVYaERTa3RIUzI0eWVuYzVaSFpGV1ZkWGExUmpPR3RFV1ZRdlkwOXRaakZWUm01MU0yaFRVelJpT0VScFR6QjJlRGhFYVdsQk4xRXlVRzVwQ25aeFltVjZTMDF2U1RKeFEyaENjbFJxTkRSWVVHSkNOalZ5WVdKME9YTnBiVk15THdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2JlNGFkMzI3LWU0Y2QtNDc2ZS1iMzdkLWUzMmUwMjA4NTAxNC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpZDJQcjRSbUNOY3hUd0ZKWE9BQXZ0QnRUWUFNanNxRm83T3ZoRGRTekVGWXhxNkRTZFlqbFY3MA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAxc2IxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxKS0NuWlZkVVJoUkUxMkwxZ3JaMHQyVTBkRGRsRkZNa0U1YzBSVE9IaE1jRVl5UTNaV1JFcHBVaXN5UzJ3elNEaHBNVEIxY1hSTldYVklWamROT1dkUloyOEtkbkJ2VG5FcmVHazJkazFPU0ZWbU5IcGhNR1ZqWlhWcFoxbEpiamxoT1RGRWRpdHJZekozYkZsUmNHTlRaMVY2VVhjclRtMHhSMk5wSzA1eFJYUlFaZ3AyYUZsaE1HMUdjV001U2xaa1UyeGhkVU0wVW5ocmVuZElhbEJtZW5GeVIxQTJVMGRZTlVGTVRXZEVibGxqVFRNMVR6Y3pSVzVSWWxKTWFuQktlRUZGQ2k5YVIxUmxVMlY1U1c0MU5rNXdkVXBYTlVJNWVVMUNkR2wyUWprdk5VeEtZMHRvUjFWaVoxTnViVkEwTWpsS1UyMVVkbE5PTkRSWVkxRk1OVnBOY25nS2FIRTJlSFl5WXpGalVWRmhSakZpTURKbVNERlZjbWQ2YzFwT1RqQnBhMVJPVERSU1QzRkJRbVZhVjBGR2NWSlNSSE16VVVzeVdEWXlNVVZoZUdoWVJBcE9Wa052Y0ZGV2MwbDVlV0ZHYURKUWQwZ3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhaMnRGUTJFdlpXTTBOSEp1UjFFMU5XaE9OazlwUlV4T1R6Qk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSM1JOWWtobGNuWm5lRTkzZEdseFZ6VjRNelZWT0Zwc2VVWTVSR3M1VGxOelRuRmFMelJMYmtsdmVsUjFNVFpGTlFwTmRucENkR041VkVGUFRtaE1ka1E0VUZsWVlrNUpWVmw2ZVhoNGVVOHdRamhUYlRacWFERk5kVEZwZW0xSlRFbG1RV05CWjA1elMwbGFXREZ6VHpWcENsUm5WVnBuWkVNMVdEQmFMM3AzY1c5SFRFRkpTbk12VkVsa2J6UkdUR1ZyWTNkRVExVnFhekVyVWtsdlRucEZiRkJTVm5aRVlURk1VamRZZG5GUlpERUtXbVpGUkVZeFlXaEZjbHBVUzNWTlUwcHZlSFE0VUU5R1kyUjZPWGtyWVhrM2EwWlpOMVU1YlcxTU1YZEhRVWRNYUdGNWQyaFRUWG8yVVVVNWNrMVRZd3A2TW04NE4wdEpaRkJ5Y0VwRmEzcE5ZMjlTYW5OR1RXRnJlRkJJU1ZndlUwRkpObnBsV25oSGFHUlhLMFJ4Um1nck5GUnhZMVoyWmpRNVZ6VkdiVzQ1Q2pNeldERkRkSGgyTTNSa2VuWlhXbTEyTmpGbk0yeFdZMGw1WVRWdldWUkRTak5NUmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzg3Y2U3ZWRlLWZkMWYtNGY0Mi1iZWEwLTY1YTM2OGUzZjM2Yi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB0d2NaZjhyOWxJa2ZVaUJ1eTBBMFJBNWxyWjhNMXlVVGJnOHJFNXVVdWQ1bXFwSG1BWnRGdXRKVA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2622"
+      - "2620"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:19 GMT
+      - Tue, 07 Nov 2023 16:24:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2752,7 +3049,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dad24f1d-72fa-413b-ad5e-b38d15ebb0f9
+      - ce18feb1-2281-49d8-9787-f6ce9d526242
     status: 200 OK
     code: 200
     duration: ""
@@ -2763,19 +3060,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/963ac687-26f9-42a1-87c7-0a8737d493be
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:47:18.352539Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"created_at":"2023-11-07T16:19:59.627263Z","dhcp_enabled":true,"id":"963ac687-26f9-42a1-87c7-0a8737d493be","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.627263Z","id":"8b424081-dce6-41f2-9807-d34dcf032f45","subnet":"172.16.12.0/22","updated_at":"2023-11-07T16:19:59.627263Z"},{"created_at":"2023-11-07T16:19:59.627263Z","id":"9a8f7905-ef99-4cb9-bed8-a31b86103108","subnet":"fd63:256c:45f7:6697::/64","updated_at":"2023-11-07T16:19:59.627263Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.627263Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1513"
+      - "700"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:19 GMT
+      - Tue, 07 Nov 2023 16:24:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2785,7 +3082,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f262474a-9fec-43ef-8bc3-eac7314ef835
+      - a12f690f-58eb-4f32-b2f9-30d324fae2a7
     status: 200 OK
     code: 200
     duration: ""
@@ -2796,19 +3093,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e119ab2a-cb88-4b75-b93d-94e1eabcf342
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"created_at":"2023-10-18T16:43:35.686906Z","dhcp_enabled":true,"id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:35.686906Z","id":"6e957e34-653e-4fed-ad63-38ba4eb78285","subnet":"172.16.16.0/22","updated_at":"2023-10-18T16:43:35.686906Z"},{"created_at":"2023-10-18T16:43:35.686906Z","id":"975a8ca4-bf73-442f-8fed-25cd29f6029e","subnet":"fd63:256c:45f7:91b4::/64","updated_at":"2023-10-18T16:43:35.686906Z"}],"tags":[],"updated_at":"2023-10-18T16:43:35.686906Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:24:03.487411Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "717"
+      - "1468"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:19 GMT
+      - Tue, 07 Nov 2023 16:24:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2818,7 +3115,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b618e448-050d-4cb8-8b52-638ef9f280c9
+      - 6aacfc0a-d68f-4647-9102-ebb929b30efe
     status: 200 OK
     code: 200
     duration: ""
@@ -2829,19 +3126,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:47:18.352539Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BCZDAxc2IxaEVWRTE2VFZSRmQwNXFSVEpOYWtGM1RXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVGxKS0NuWlZkVVJoUkUxMkwxZ3JaMHQyVTBkRGRsRkZNa0U1YzBSVE9IaE1jRVl5UTNaV1JFcHBVaXN5UzJ3elNEaHBNVEIxY1hSTldYVklWamROT1dkUloyOEtkbkJ2VG5FcmVHazJkazFPU0ZWbU5IcGhNR1ZqWlhWcFoxbEpiamxoT1RGRWRpdHJZekozYkZsUmNHTlRaMVY2VVhjclRtMHhSMk5wSzA1eFJYUlFaZ3AyYUZsaE1HMUdjV001U2xaa1UyeGhkVU0wVW5ocmVuZElhbEJtZW5GeVIxQTJVMGRZTlVGTVRXZEVibGxqVFRNMVR6Y3pSVzVSWWxKTWFuQktlRUZGQ2k5YVIxUmxVMlY1U1c0MU5rNXdkVXBYTlVJNWVVMUNkR2wyUWprdk5VeEtZMHRvUjFWaVoxTnViVkEwTWpsS1UyMVVkbE5PTkRSWVkxRk1OVnBOY25nS2FIRTJlSFl5WXpGalVWRmhSakZpTURKbVNERlZjbWQ2YzFwT1RqQnBhMVJPVERSU1QzRkJRbVZhVjBGR2NWSlNSSE16VVVzeVdEWXlNVVZoZUdoWVJBcE9Wa052Y0ZGV2MwbDVlV0ZHYURKUWQwZ3dRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkhaMnRGUTJFdlpXTTBOSEp1UjFFMU5XaE9OazlwUlV4T1R6Qk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJSM1JOWWtobGNuWm5lRTkzZEdseFZ6VjRNelZWT0Zwc2VVWTVSR3M1VGxOelRuRmFMelJMYmtsdmVsUjFNVFpGTlFwTmRucENkR041VkVGUFRtaE1ka1E0VUZsWVlrNUpWVmw2ZVhoNGVVOHdRamhUYlRacWFERk5kVEZwZW0xSlRFbG1RV05CWjA1elMwbGFXREZ6VHpWcENsUm5WVnBuWkVNMVdEQmFMM3AzY1c5SFRFRkpTbk12VkVsa2J6UkdUR1ZyWTNkRVExVnFhekVyVWtsdlRucEZiRkJTVm5aRVlURk1VamRZZG5GUlpERUtXbVpGUkVZeFlXaEZjbHBVUzNWTlUwcHZlSFE0VUU5R1kyUjZPWGtyWVhrM2EwWlpOMVU1YlcxTU1YZEhRVWRNYUdGNWQyaFRUWG8yVVVVNWNrMVRZd3A2TW04NE4wdEpaRkJ5Y0VwRmEzcE5ZMjlTYW5OR1RXRnJlRkJJU1ZndlUwRkpObnBsV25oSGFHUlhLMFJ4Um1nck5GUnhZMVoyWmpRNVZ6VkdiVzQ1Q2pNeldERkRkSGgyTTNSa2VuWlhXbTEyTmpGbk0yeFdZMGw1WVRWdldWUkRTak5NUmdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzg3Y2U3ZWRlLWZkMWYtNGY0Mi1iZWEwLTY1YTM2OGUzZjM2Yi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiB0d2NaZjhyOWxJa2ZVaUJ1eTBBMFJBNWxyWjhNMXlVVGJnOHJFNXVVdWQ1bXFwSG1BWnRGdXRKVA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1513"
+      - "2620"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:19 GMT
+      - Tue, 07 Nov 2023 16:24:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2851,7 +3148,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e2df4b6-38ab-4685-b4df-e42920fdbac8
+      - be8f7429-1eb7-4753-b37d-2c9c9ad826c9
     status: 200 OK
     code: 200
     duration: ""
@@ -2862,151 +3159,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUa1JOZWs0eGIxaEVWRTE2VFZSQmVFNTZSVEpPUkUxNlRqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNkckNsSTFSRGR4UjBvelkyVm1OMWR6VmxGM1RXSmxVMll3ZHpaVE0yOWFUSGhaTkZOSllVazBZMGhaY214aFFrUkNMMUExVWxOVU9TOVhaVlZaVFN0NVRsb0tNM1JUVmpOcFIydFBZWHBWTTA5TGJ6bHZRM0JyVnpneE5HdHVUamswUzJsM1kyTmlibEo1VVV4cFFXVkdRV2hIU0dOYU1FUlpOek5VUld4TlVVdENNZ3BTWjBkck5XTlRkVlZFY2pCa05rVlliRkU0YTNCU01XYzNTaXRIUm5VM1EydFlZVkZuZG5wcE5WTlRlVVE0U2taWGF6RnZabVU0UTJsTU1sVTRWMVEwQ2tRelMzRTNTVXN4Ynk4dlNGbExTalJDWlROa1dWa3lUV054U0d0cFRIQmlRbE5STkZoVmVqUjRVMUV4WmtSNVRuaHdSbkZ4ZUdaeFNraDNTelZZVGs4S2RqSlVTRkJoTXk5dWJEbHBRMk5ITjFCcFIwdDRORll5TlRFeVVGVlBiRkp3VlZacmQzTXdhMmcwWTFONWFFNXRRVkZHT1RRcllWUm1SRVI0WkdaQ2N3b3ZkV2hhTkVWNFNHZGhOemMyUkVNeFVrYzRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkVaV3B6UzJkVVIwWllhblppZHpFNVJXdDRTREZoWlM5RWNrRk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRTRTV5VUZKVWJqazJkM1ZvWlhKTFNXVmlUbnB4Ym1adlRtMW9iMkphZGxKNmRYcEVTRmhvWVRSdU5GbGFVMHhoVEFvM1RpOXpZbnBvZWpscFpYaHhObU53Y21WVmR6ZzFlRkU0TDJObldrRnVTSFpYV1VSRlRqaDNPVFpPZGk4MldIWjZOMXBZVUZvck5FcDJjbk5QU21SUENtSlRWbEYzWldOS2IwaHZZWEF3WjBGcWFHdDRZUzlLYlVoME0za3hObGhpV1dkVE0xaFdaWFEwWWl0R2IySlVXVGx5Tkc5aGNtdGFUMlF6VUZjNFoxY0tZa1U1UWtoYVNIUkJaM0kzUWpaSVpUVlBlazVFZWtWNGFuVlNVV04xV2pOSE5rNVNTRmgwVGxFeFFYUkdPR2RrVEdaR04zRkNNMVZCV0daTFJrWlRWd280YjBZeGVYaERTa3RIUzI0eWVuYzVaSFpGV1ZkWGExUmpPR3RFV1ZRdlkwOXRaakZWUm01MU0yaFRVelJpT0VScFR6QjJlRGhFYVdsQk4xRXlVRzVwQ25aeFltVjZTMDF2U1RKeFEyaENjbFJxTkRSWVVHSkNOalZ5WVdKME9YTnBiVk15THdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2JlNGFkMzI3LWU0Y2QtNDc2ZS1iMzdkLWUzMmUwMjA4NTAxNC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpZDJQcjRSbUNOY3hUd0ZKWE9BQXZ0QnRUWUFNanNxRm83T3ZoRGRTekVGWXhxNkRTZFlqbFY3MA==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2622"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3ddb389f-12ed-4beb-be97-eb4166e26e3f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e119ab2a-cb88-4b75-b93d-94e1eabcf342
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-18T16:43:35.686906Z","dhcp_enabled":true,"id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:35.686906Z","id":"6e957e34-653e-4fed-ad63-38ba4eb78285","subnet":"172.16.16.0/22","updated_at":"2023-10-18T16:43:35.686906Z"},{"created_at":"2023-10-18T16:43:35.686906Z","id":"975a8ca4-bf73-442f-8fed-25cd29f6029e","subnet":"fd63:256c:45f7:91b4::/64","updated_at":"2023-10-18T16:43:35.686906Z"}],"tags":[],"updated_at":"2023-10-18T16:43:35.686906Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "717"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:47:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 263d5d1b-941e-4dae-896d-ae96a7ea7b02
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:47:18.352539Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1513"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:47:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f26ea807-afd1-4672-8257-a851a9897975
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUa1JOZWs0eGIxaEVWRTE2VFZSQmVFNTZSVEpPUkUxNlRqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCUzNkckNsSTFSRGR4UjBvelkyVm1OMWR6VmxGM1RXSmxVMll3ZHpaVE0yOWFUSGhaTkZOSllVazBZMGhaY214aFFrUkNMMUExVWxOVU9TOVhaVlZaVFN0NVRsb0tNM1JUVmpOcFIydFBZWHBWTTA5TGJ6bHZRM0JyVnpneE5HdHVUamswUzJsM1kyTmlibEo1VVV4cFFXVkdRV2hIU0dOYU1FUlpOek5VUld4TlVVdENNZ3BTWjBkck5XTlRkVlZFY2pCa05rVlliRkU0YTNCU01XYzNTaXRIUm5VM1EydFlZVkZuZG5wcE5WTlRlVVE0U2taWGF6RnZabVU0UTJsTU1sVTRWMVEwQ2tRelMzRTNTVXN4Ynk4dlNGbExTalJDWlROa1dWa3lUV054U0d0cFRIQmlRbE5STkZoVmVqUjRVMUV4WmtSNVRuaHdSbkZ4ZUdaeFNraDNTelZZVGs4S2RqSlVTRkJoTXk5dWJEbHBRMk5ITjFCcFIwdDRORll5TlRFeVVGVlBiRkp3VlZacmQzTXdhMmcwWTFONWFFNXRRVkZHT1RRcllWUm1SRVI0WkdaQ2N3b3ZkV2hhTkVWNFNHZGhOemMyUkVNeFVrYzRRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkVaV3B6UzJkVVIwWllhblppZHpFNVJXdDRTREZoWlM5RWNrRk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRTRTV5VUZKVWJqazJkM1ZvWlhKTFNXVmlUbnB4Ym1adlRtMW9iMkphZGxKNmRYcEVTRmhvWVRSdU5GbGFVMHhoVEFvM1RpOXpZbnBvZWpscFpYaHhObU53Y21WVmR6ZzFlRkU0TDJObldrRnVTSFpYV1VSRlRqaDNPVFpPZGk4MldIWjZOMXBZVUZvck5FcDJjbk5QU21SUENtSlRWbEYzWldOS2IwaHZZWEF3WjBGcWFHdDRZUzlLYlVoME0za3hObGhpV1dkVE0xaFdaWFEwWWl0R2IySlVXVGx5Tkc5aGNtdGFUMlF6VUZjNFoxY0tZa1U1UWtoYVNIUkJaM0kzUWpaSVpUVlBlazVFZWtWNGFuVlNVV04xV2pOSE5rNVNTRmgwVGxFeFFYUkdPR2RrVEdaR04zRkNNMVZCV0daTFJrWlRWd280YjBZeGVYaERTa3RIUzI0eWVuYzVaSFpGV1ZkWGExUmpPR3RFV1ZRdlkwOXRaakZWUm01MU0yaFRVelJpT0VScFR6QjJlRGhFYVdsQk4xRXlVRzVwQ25aeFltVjZTMDF2U1RKeFEyaENjbFJxTkRSWVVHSkNOalZ5WVdKME9YTnBiVk15THdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2JlNGFkMzI3LWU0Y2QtNDc2ZS1iMzdkLWUzMmUwMjA4NTAxNC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBpZDJQcjRSbUNOY3hUd0ZKWE9BQXZ0QnRUWUFNanNxRm83T3ZoRGRTekVGWXhxNkRTZFlqbFY3MA==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2622"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:47:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 416464bc-2e04-42b2-9669-8e540f3aa866
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/available-types
     method: GET
   response:
     body: '{"cluster_types":[],"total_count":0}'
     headers:
       Content-Length:
-      - "37"
+      - "36"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:20 GMT
+      - Tue, 07 Nov 2023 16:24:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3016,7 +3181,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb393e36-88e2-47b8-8a55-55763b25c5db
+      - 340aa7aa-e53b-4257-a577-07ba52e213b5
     status: 200 OK
     code: 200
     duration: ""
@@ -3027,19 +3192,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b/available-types
     method: GET
   response:
     body: '{"cluster_types":[],"total_count":0}'
     headers:
       Content-Length:
-      - "37"
+      - "36"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:20 GMT
+      - Tue, 07 Nov 2023 16:24:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3049,7 +3214,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 173391d9-80bb-4b6b-ab8b-5346adc2a8a8
+      - e65f0436-4153-4473-a725-2971c7528ad8
     status: 200 OK
     code: 200
     duration: ""
@@ -3060,19 +3225,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b?with_additional_resources=false
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:47:21.000641494Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:24:05.847617783Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1519"
+      - "1474"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:21 GMT
+      - Tue, 07 Nov 2023 16:24:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3082,7 +3247,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0f13616-a133-4474-9a0a-2195dcd4252c
+      - 74f75e44-1ba0-419e-8c2d-d34d1b58107f
     status: 200 OK
     code: 200
     duration: ""
@@ -3093,19 +3258,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:47:21.000641Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:24:05.847618Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:21 GMT
+      - Tue, 07 Nov 2023 16:24:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3115,7 +3280,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d1d7c95-b501-4a8c-827b-fc0bbe32e5ba
+      - dad27172-e169-4d97-ba1a-7cb8c8edf813
     status: 200 OK
     code: 200
     duration: ""
@@ -3126,19 +3291,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://be4ad327-e4cd-476e-b37d-e32e02085014.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:45:16.553441Z","created_at":"2023-10-18T16:43:36.596073Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.be4ad327-e4cd-476e-b37d-e32e02085014.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"be4ad327-e4cd-476e-b37d-e32e02085014","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-10-18T16:47:21.000641Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://87ce7ede-fd1f-4f42-bea0-65a368e3f36b.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:22:17.527639Z","created_at":"2023-11-07T16:20:00.701150Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.87ce7ede-fd1f-4f42-bea0-65a368e3f36b.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-16","updated_at":"2023-11-07T16:24:05.847618Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1516"
+      - "1471"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:26 GMT
+      - Tue, 07 Nov 2023 16:24:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3148,7 +3313,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55aa0464-9f33-4236-a9ee-e8eeb267f5d4
+      - 090630b1-0fbf-4f9f-a9e0-7253fa3533f6
     status: 200 OK
     code: 200
     duration: ""
@@ -3159,10 +3324,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/be4ad327-e4cd-476e-b37d-e32e02085014
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/87ce7ede-fd1f-4f42-bea0-65a368e3f36b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"be4ad327-e4cd-476e-b37d-e32e02085014","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"87ce7ede-fd1f-4f42-bea0-65a368e3f36b","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3171,7 +3336,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:31 GMT
+      - Tue, 07 Nov 2023 16:24:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3181,12 +3346,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85a261d0-bb51-4bc5-9b9a-42931c8ade13
+      - 4f49263c-1b8f-4c4d-88df-9670c71be721
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"kapsule-dedicated-8","name":"test-type-change","description":"","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342"}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"kapsule-dedicated-8","name":"test-type-change","description":"","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"version":"1.28.2","cni":"cilium","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null,"private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be"}'
     form: {}
     headers:
       Content-Type:
@@ -3197,16 +3362,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574105Z","created_at":"2023-10-18T16:47:31.489574105Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:47:31.504260600Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828085Z","created_at":"2023-11-07T16:24:16.189828085Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004268Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1524"
+      - "1479"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:31 GMT
+      - Tue, 07 Nov 2023 16:24:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3216,7 +3381,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cbc9b68e-c041-44fc-aff5-12473e09e480
+      - 6ea97534-3af2-4ec6-bbec-8f71e63c4d7a
     status: 200 OK
     code: 200
     duration: ""
@@ -3227,19 +3392,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:47:31.504261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:31 GMT
+      - Tue, 07 Nov 2023 16:24:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3249,7 +3414,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36cebf58-872e-4a70-8575-970d709c99cf
+      - f4ce5953-3fb6-4b0a-a8af-4d60d4b511a1
     status: 200 OK
     code: 200
     duration: ""
@@ -3260,19 +3425,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:47:31.504261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:36 GMT
+      - Tue, 07 Nov 2023 16:24:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3282,7 +3447,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa3680c2-61e9-447e-b6f1-45d919e9df84
+      - 1c56e04d-7d22-4d9d-a029-e36f0409086b
     status: 200 OK
     code: 200
     duration: ""
@@ -3293,19 +3458,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:47:31.504261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:41 GMT
+      - Tue, 07 Nov 2023 16:24:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3315,7 +3480,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e60bf42-1fb8-440b-9c92-e486fe02491a
+      - ce5ed4be-b473-4cfa-ad04-3fb18751deca
     status: 200 OK
     code: 200
     duration: ""
@@ -3326,19 +3491,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:47:31.504261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:46 GMT
+      - Tue, 07 Nov 2023 16:24:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3348,7 +3513,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f13d4f29-52b3-4ce2-9366-a7feccf5a6e4
+      - 9fa6df5f-32b2-493d-aa45-9d5692c8df1d
     status: 200 OK
     code: 200
     duration: ""
@@ -3359,19 +3524,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:47:31.504261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:51 GMT
+      - Tue, 07 Nov 2023 16:24:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3381,7 +3546,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e53b88f-1e23-4cfc-857a-430532c6ea57
+      - 356d73b7-fea7-4074-b4ab-92238bdc5230
     status: 200 OK
     code: 200
     duration: ""
@@ -3392,19 +3557,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:47:31.504261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:47:56 GMT
+      - Tue, 07 Nov 2023 16:24:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3414,7 +3579,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e3c9262-ce13-45eb-b6c0-06af80ebbb0c
+      - 3327920c-d7a5-4183-8fe5-281998e73719
     status: 200 OK
     code: 200
     duration: ""
@@ -3425,19 +3590,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:47:31.504261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:48:01 GMT
+      - Tue, 07 Nov 2023 16:24:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3447,7 +3612,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 931363a6-567d-4576-a69c-cef669bf5158
+      - aa693255-5ab4-4faa-9dba-1096e20258da
     status: 200 OK
     code: 200
     duration: ""
@@ -3458,19 +3623,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:47:31.504261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:48:06 GMT
+      - Tue, 07 Nov 2023 16:24:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3480,7 +3645,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b31061f-ef46-41ba-bfb4-8e8407e9189e
+      - 8489452b-0abe-4096-9df5-d28b08076848
     status: 200 OK
     code: 200
     duration: ""
@@ -3491,19 +3656,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:47:31.504261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:48:12 GMT
+      - Tue, 07 Nov 2023 16:24:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3513,7 +3678,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7ccbb9d-d92b-4984-8345-32e4c781b74e
+      - a787b1be-e0c0-4d6a-8527-40ed4a7a49d8
     status: 200 OK
     code: 200
     duration: ""
@@ -3524,19 +3689,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:47:31.504261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:48:17 GMT
+      - Tue, 07 Nov 2023 16:25:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3546,7 +3711,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1527c37c-ca97-4613-8793-87987fb3c67a
+      - a816ba2b-c9cf-40c8-b481-2fa9daba30e4
     status: 200 OK
     code: 200
     duration: ""
@@ -3557,19 +3722,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:47:31.504261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:48:22 GMT
+      - Tue, 07 Nov 2023 16:25:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3579,7 +3744,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c38fbc62-4464-4be0-958b-b6a2701b366d
+      - 56a1fd88-f55f-47b5-9d9a-fbfedc4e4206
     status: 200 OK
     code: 200
     duration: ""
@@ -3590,19 +3755,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:47:31.504261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:48:27 GMT
+      - Tue, 07 Nov 2023 16:25:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3612,7 +3777,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed5f51dc-4ffe-4ab6-adf4-e716af7b3dcc
+      - 1b169e65-ee80-4b3c-a328-14831b6fb281
     status: 200 OK
     code: 200
     duration: ""
@@ -3623,19 +3788,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:47:31.504261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:48:32 GMT
+      - Tue, 07 Nov 2023 16:25:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3645,7 +3810,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c5c7d11-0e99-44fd-b5a5-cbf342c7e1ec
+      - a83ba6f9-11c8-44f7-b7ab-eb5f8ab31399
     status: 200 OK
     code: 200
     duration: ""
@@ -3656,19 +3821,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:47:31.504261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:24:16.207004Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:48:37 GMT
+      - Tue, 07 Nov 2023 16:25:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3678,7 +3843,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1feba1c-45df-42b1-b5df-fc8aa15e2f4c
+      - dffd0bec-c737-40ec-a33a-e4a40baa49cd
     status: 200 OK
     code: 200
     duration: ""
@@ -3689,19 +3854,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:47:31.504261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:25:25.082614Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1467"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:48:42 GMT
+      - Tue, 07 Nov 2023 16:25:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3711,7 +3876,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 064156b0-02de-4682-a3f4-ffe9956be356
+      - 6d499682-d5a8-48e7-a837-c911695761f4
     status: 200 OK
     code: 200
     duration: ""
@@ -3722,19 +3887,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:47:31.504261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:25:25.082614Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1467"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:48:47 GMT
+      - Tue, 07 Nov 2023 16:25:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3744,7 +3909,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9e12c67-2173-48c8-adbe-ec63ca4e73de
+      - f06d2a58-4f4f-46b0-aef4-72df8dd5c9ec
     status: 200 OK
     code: 200
     duration: ""
@@ -3755,19 +3920,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:47:31.504261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BSZUU0eGIxaEVWRTE2VFZSRmQwNXFSVEpOYWxGNFRqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVDJaakNsTkNjekpqYzFSQ01HWk5kME5vVXpOclJTdHFTRWRFVlZGSGIzQnlVV1JLU0N0U2RVVnVTbXg1TjFFNFdrbFJTemR3Y0doME1rUlllbFF4WTFvek9Va0tWV0V5ZEZWVFZHcHZOVWhTV1RONVFXZFJLMkpIWkdWVGJuUTRjaTg0ZFVSUFIyaGFVMEowUWtrNGRGcEZNVFJvVEhGTlZtbHZPRU5FWVUxNFZERjZRd3BhUTB4cE9WRm1ZeTlPV0RsWk1FUkljV3R0U1ZoV2RGbFVSbmh0V25sMmMzTkZaa2hrVmtSemJ6ZEdXVEZLYlVkc056QkpNekZQVVc1YVEycDFhSGRLQ2pKNFNHRlBTemR5VFRSMGIxWjVZblZ1Y0hkc1NXRnlVVlJpVldGcVRHdExVbkpzU0dkYVZTOTJZM1JPUldGU1NYbG1TMW96YTFkeFNtUnhURVZZTXpFS01EWllhVlpzYm0xSEwwaFZjVzVvY0hOVVdIUXhiSEV6TVZCMlJuRTROMVo2UWxWWFpGTXhZa1ZuWTJkVk5YUkpjbm95UmtjMWNsSXphbll2ZW5GblJRbzNRa05PUmpoNE1WbFhhMGg0ZERKSlZFSk5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkdjVEEyVkVJMlkxUllRazB5VFVka1FscGFRakZxWW14b1ZreE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkVWaTl6UWxCUVYwaEpSeTkzTlUxRk0zRndhbXg1Y2tob2VFbHRlblV5YkRWS1lYcEtZV2x1ZUc5c1YycFdSM1UzUWdwdllVY3dWak12YzBoT2FVdzJXbTVyZFcxUk9GSlpORllyUW5aWFNURjNjVlpuWWtwU1duSmhXRWw0TjFZd1l6RlZiMUJGYVU4clptbFhWbGhDYldGMENtNVBSeTkxYW5sWVEwZ3ZRVFYyVWpGMlMwaERiM1JqVTJSWlRYUkVXbTF4TUhGaGNuRnZZMFp6T1ZOTVJYcERRbkpPUldGdE9DdFljemc0TkRSb1kwOEtibGhUVDBkTVpWUnZUM0ZzV21oNlEyVnRjalZMY2xReU9VbFlNRFJRT0hnNE1qRm1ZWE5MZEV0dGQybEJlRmx1SzJReVkyNWhjVzF0THpGRFVUaEdUQXBGYTNkblZGa3dlak5xWjJ0bGQxbExTVlF6YW1WSmNXVjJVME5MZEVNMmVtczNZbFp1VVVZM1RrUjBTWHBuUkhwbmNWVnRNVkkzU3k5NlVVTlFZbWt2Q2xCdk9YUXZXbTl3U2xGRE9YTnVVWGxRWlhkdFdsaDJUR3Q2WkZWaU4yWmlRVEZCZFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2U0NWM5NTY5LWExOWItNDE5ZC1iMjhlLTQ2MjBjNTY2ZGNlZi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA3S005UE5YWkJtbmhXaXJKS0VITnJOTjZHSE5XbTI1SFczU2hscnYxbWZqb2NSeTJHSE5hM2ozVw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1515"
+      - "2620"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:48:52 GMT
+      - Tue, 07 Nov 2023 16:25:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3777,7 +3942,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 353cfc5f-2291-4d9b-aee8-e473f565e99e
+      - e0d0c5d1-01d0-4cce-9dc8-100eee4fecae
     status: 200 OK
     code: 200
     duration: ""
@@ -3788,19 +3953,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:47:31.504261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:25:25.082614Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1467"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:48:57 GMT
+      - Tue, 07 Nov 2023 16:25:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3810,7 +3975,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e2b3e9c-f6bf-40bc-aaf0-c92046d462b6
+      - 9f1d2960-50fa-4983-9cf7-a2d6d96b0d00
     status: 200 OK
     code: 200
     duration: ""
@@ -3821,19 +3986,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/963ac687-26f9-42a1-87c7-0a8737d493be
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:47:31.504261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"created_at":"2023-11-07T16:19:59.627263Z","dhcp_enabled":true,"id":"963ac687-26f9-42a1-87c7-0a8737d493be","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.627263Z","id":"8b424081-dce6-41f2-9807-d34dcf032f45","subnet":"172.16.12.0/22","updated_at":"2023-11-07T16:19:59.627263Z"},{"created_at":"2023-11-07T16:19:59.627263Z","id":"9a8f7905-ef99-4cb9-bed8-a31b86103108","subnet":"fd63:256c:45f7:6697::/64","updated_at":"2023-11-07T16:19:59.627263Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.627263Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1515"
+      - "700"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:02 GMT
+      - Tue, 07 Nov 2023 16:25:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3843,7 +4008,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 546efd9d-e00b-4739-a641-f13a68f40d01
+      - d6938649-4514-47aa-af2b-98bd8eca6076
     status: 200 OK
     code: 200
     duration: ""
@@ -3854,19 +4019,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:47:31.504261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:25:25.082614Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1467"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:07 GMT
+      - Tue, 07 Nov 2023 16:25:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3876,7 +4041,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b40dc460-c1b4-4a09-aefb-7a17f98e1bb7
+      - eba493a0-600d-4e9b-b480-29cb08d1420c
     status: 200 OK
     code: 200
     duration: ""
@@ -3887,19 +4052,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:47:31.504261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BSZUU0eGIxaEVWRTE2VFZSRmQwNXFSVEpOYWxGNFRqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVDJaakNsTkNjekpqYzFSQ01HWk5kME5vVXpOclJTdHFTRWRFVlZGSGIzQnlVV1JLU0N0U2RVVnVTbXg1TjFFNFdrbFJTemR3Y0doME1rUlllbFF4WTFvek9Va0tWV0V5ZEZWVFZHcHZOVWhTV1RONVFXZFJLMkpIWkdWVGJuUTRjaTg0ZFVSUFIyaGFVMEowUWtrNGRGcEZNVFJvVEhGTlZtbHZPRU5FWVUxNFZERjZRd3BhUTB4cE9WRm1ZeTlPV0RsWk1FUkljV3R0U1ZoV2RGbFVSbmh0V25sMmMzTkZaa2hrVmtSemJ6ZEdXVEZLYlVkc056QkpNekZQVVc1YVEycDFhSGRLQ2pKNFNHRlBTemR5VFRSMGIxWjVZblZ1Y0hkc1NXRnlVVlJpVldGcVRHdExVbkpzU0dkYVZTOTJZM1JPUldGU1NYbG1TMW96YTFkeFNtUnhURVZZTXpFS01EWllhVlpzYm0xSEwwaFZjVzVvY0hOVVdIUXhiSEV6TVZCMlJuRTROMVo2UWxWWFpGTXhZa1ZuWTJkVk5YUkpjbm95UmtjMWNsSXphbll2ZW5GblJRbzNRa05PUmpoNE1WbFhhMGg0ZERKSlZFSk5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkdjVEEyVkVJMlkxUllRazB5VFVka1FscGFRakZxWW14b1ZreE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkVWaTl6UWxCUVYwaEpSeTkzTlUxRk0zRndhbXg1Y2tob2VFbHRlblV5YkRWS1lYcEtZV2x1ZUc5c1YycFdSM1UzUWdwdllVY3dWak12YzBoT2FVdzJXbTVyZFcxUk9GSlpORllyUW5aWFNURjNjVlpuWWtwU1duSmhXRWw0TjFZd1l6RlZiMUJGYVU4clptbFhWbGhDYldGMENtNVBSeTkxYW5sWVEwZ3ZRVFYyVWpGMlMwaERiM1JqVTJSWlRYUkVXbTF4TUhGaGNuRnZZMFp6T1ZOTVJYcERRbkpPUldGdE9DdFljemc0TkRSb1kwOEtibGhUVDBkTVpWUnZUM0ZzV21oNlEyVnRjalZMY2xReU9VbFlNRFJRT0hnNE1qRm1ZWE5MZEV0dGQybEJlRmx1SzJReVkyNWhjVzF0THpGRFVUaEdUQXBGYTNkblZGa3dlak5xWjJ0bGQxbExTVlF6YW1WSmNXVjJVME5MZEVNMmVtczNZbFp1VVVZM1RrUjBTWHBuUkhwbmNWVnRNVkkzU3k5NlVVTlFZbWt2Q2xCdk9YUXZXbTl3U2xGRE9YTnVVWGxRWlhkdFdsaDJUR3Q2WkZWaU4yWmlRVEZCZFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2U0NWM5NTY5LWExOWItNDE5ZC1iMjhlLTQ2MjBjNTY2ZGNlZi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA3S005UE5YWkJtbmhXaXJKS0VITnJOTjZHSE5XbTI1SFczU2hscnYxbWZqb2NSeTJHSE5hM2ozVw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1515"
+      - "2620"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:12 GMT
+      - Tue, 07 Nov 2023 16:25:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3909,7 +4074,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0fdfa74f-f0cf-4bc7-9766-cb575ae254df
+      - 3cb77a76-b396-4f9f-a23e-102528b4242a
     status: 200 OK
     code: 200
     duration: ""
@@ -3920,19 +4085,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/963ac687-26f9-42a1-87c7-0a8737d493be
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:47:31.504261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"created_at":"2023-11-07T16:19:59.627263Z","dhcp_enabled":true,"id":"963ac687-26f9-42a1-87c7-0a8737d493be","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-11-07T16:19:59.627263Z","id":"8b424081-dce6-41f2-9807-d34dcf032f45","subnet":"172.16.12.0/22","updated_at":"2023-11-07T16:19:59.627263Z"},{"created_at":"2023-11-07T16:19:59.627263Z","id":"9a8f7905-ef99-4cb9-bed8-a31b86103108","subnet":"fd63:256c:45f7:6697::/64","updated_at":"2023-11-07T16:19:59.627263Z"}],"tags":[],"updated_at":"2023-11-07T16:19:59.627263Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1515"
+      - "700"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:17 GMT
+      - Tue, 07 Nov 2023 16:25:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3942,7 +4107,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e963d21-ff5b-48d0-b453-f43534d72df6
+      - 2bb8efab-d3c3-48a5-96be-68c6dc2b28d6
     status: 200 OK
     code: 200
     duration: ""
@@ -3953,19 +4118,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:47:31.504261Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:25:25.082614Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1467"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:22 GMT
+      - Tue, 07 Nov 2023 16:25:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3975,7 +4140,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e4bf897-ea3c-4b45-b682-3a393a0a3ad8
+      - dc598348-9cf1-46a2-a46e-ae395d4e59d9
     status: 200 OK
     code: 200
     duration: ""
@@ -3986,19 +4151,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:49:25.310321Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BSZUU0eGIxaEVWRTE2VFZSRmQwNXFSVEpOYWxGNFRqRnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVDJaakNsTkNjekpqYzFSQ01HWk5kME5vVXpOclJTdHFTRWRFVlZGSGIzQnlVV1JLU0N0U2RVVnVTbXg1TjFFNFdrbFJTemR3Y0doME1rUlllbFF4WTFvek9Va0tWV0V5ZEZWVFZHcHZOVWhTV1RONVFXZFJLMkpIWkdWVGJuUTRjaTg0ZFVSUFIyaGFVMEowUWtrNGRGcEZNVFJvVEhGTlZtbHZPRU5FWVUxNFZERjZRd3BhUTB4cE9WRm1ZeTlPV0RsWk1FUkljV3R0U1ZoV2RGbFVSbmh0V25sMmMzTkZaa2hrVmtSemJ6ZEdXVEZLYlVkc056QkpNekZQVVc1YVEycDFhSGRLQ2pKNFNHRlBTemR5VFRSMGIxWjVZblZ1Y0hkc1NXRnlVVlJpVldGcVRHdExVbkpzU0dkYVZTOTJZM1JPUldGU1NYbG1TMW96YTFkeFNtUnhURVZZTXpFS01EWllhVlpzYm0xSEwwaFZjVzVvY0hOVVdIUXhiSEV6TVZCMlJuRTROMVo2UWxWWFpGTXhZa1ZuWTJkVk5YUkpjbm95UmtjMWNsSXphbll2ZW5GblJRbzNRa05PUmpoNE1WbFhhMGg0ZERKSlZFSk5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkdjVEEyVkVJMlkxUllRazB5VFVka1FscGFRakZxWW14b1ZreE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkVWaTl6UWxCUVYwaEpSeTkzTlUxRk0zRndhbXg1Y2tob2VFbHRlblV5YkRWS1lYcEtZV2x1ZUc5c1YycFdSM1UzUWdwdllVY3dWak12YzBoT2FVdzJXbTVyZFcxUk9GSlpORllyUW5aWFNURjNjVlpuWWtwU1duSmhXRWw0TjFZd1l6RlZiMUJGYVU4clptbFhWbGhDYldGMENtNVBSeTkxYW5sWVEwZ3ZRVFYyVWpGMlMwaERiM1JqVTJSWlRYUkVXbTF4TUhGaGNuRnZZMFp6T1ZOTVJYcERRbkpPUldGdE9DdFljemc0TkRSb1kwOEtibGhUVDBkTVpWUnZUM0ZzV21oNlEyVnRjalZMY2xReU9VbFlNRFJRT0hnNE1qRm1ZWE5MZEV0dGQybEJlRmx1SzJReVkyNWhjVzF0THpGRFVUaEdUQXBGYTNkblZGa3dlak5xWjJ0bGQxbExTVlF6YW1WSmNXVjJVME5MZEVNMmVtczNZbFp1VVVZM1RrUjBTWHBuUkhwbmNWVnRNVkkzU3k5NlVVTlFZbWt2Q2xCdk9YUXZXbTl3U2xGRE9YTnVVWGxRWlhkdFdsaDJUR3Q2WkZWaU4yWmlRVEZCZFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2U0NWM5NTY5LWExOWItNDE5ZC1iMjhlLTQ2MjBjNTY2ZGNlZi5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiA3S005UE5YWkJtbmhXaXJKS0VITnJOTjZHSE5XbTI1SFczU2hscnYxbWZqb2NSeTJHSE5hM2ozVw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1512"
+      - "2620"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:27 GMT
+      - Tue, 07 Nov 2023 16:25:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4008,7 +4173,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb7ae884-5ea0-4b8f-b561-90ffdaeae164
+      - 54bec5b0-95a2-427c-ae0f-e76e07615a7d
     status: 200 OK
     code: 200
     duration: ""
@@ -4019,316 +4184,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:49:25.310321Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1512"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f094f993-9eb8-4c62-a025-9e7e432003a8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUa1JqZWsweGIxaEVWRTE2VFZSQmVFNTZSVEpPUkdONlRURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEhwc0NtRkVkVlZRVm1GNFpVOWtXREJtWkhocWEyeGxaVGQxYlU0NVkycFVkWFUzYzNVM1MzRmlkeXRGY0hBM1pEVlZWVXRyUkZWT1MySkxNVTA0VGt0SlZXY0tNRkpRUTFkbGRYQmFkVlJsVkhSd1MzaG5iSGx2VjJOa1VEQlpaRGhtVVVoUlpITmthRmd6YVhkNGVGRnhTelJTWmxWeVZGTm1ZMjVUVlZKa1JXeDRjQXBHS3psbmVFSm9UWGx2TW5oeE1WaHRSVVk0Vld3eU9WVTRLemRyVW1OSE1tczRlVWRRYlZKRU16aEtNVk5HWW5CTWRFRjVSMFJITXpsU1ZrNW1RV2xEQ21wYVVGZG5kRTkwVTJoV2RUSTJiMFJSYzI1a1NFcExZakI2V2s1bWJtMVVOVVpqUTBsdWJUWnJURzlZUmpob1Qyc3laekZYUVdWb05URXdiVmxOVjNBS1IyZHNhemRGV2pOVWVXaE9ja2xPZVdSVGFYZzJSSFJKWjFSQk0ybGtUMlYxVW5sTGEwMTFURXBHVTNoalYzcElSbE5QYm5KcFkwZ3pSM1l6ZW1OS05BcHlTVTVIUlRaMFlrTkJRVnB3TUU1QmFqVnJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWlBkVkExWkdrclIxWXdXbWxNYTFkV2JVWTVNMU0xTkZGMWRuRk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRZVVZXZUZGc1RscFFNVmhJV0UxUVNuRnZkbVJRTDNaSE5rTkJTMVYxWTJSMmNETkxRell4V2xWSVRtWTNibEpNVWdwMGJYQkJMekl5TTNZdldVeHRUbFJHZVhjd1dERTBiM1pJUVRGMldWbENhbFJOVFdGdmJHVmlkVVJzWld4UWFqSlhSR2hvUW10UWFtcGxXbWt2VkRkdENuUk5NSEl3TTJNM1JYcHVkbXc0VEdOWlZDdHZWa2xWZVdGcWVreGlhMmd6WVVwWGVtUnRSRWM1VTFsSFUydzJhMUpIY2t0WlRXc3JNVFJzYm5aTFpXNEtNQ3RZVFU5bFltRjBUbHBIU0V4SVpsVkxWMDl1TWpWeE1XOU9TV2xsTDJ3NVNsVkROM3BOYmpOMGFHOXZZVFZVYUVwalMzTnNWRFZKVUdsd2JuaEtkd3BRZW1veVJ6ZHVjVk5rY0hkbFVHWTRZWFZoUVZaVUsxWTNNMWt2T0dKbVkzTTBlVTV1VkM5MGVXNXlTMXBqVDAxVE4zQnBja2RhTUdWQmQwMDFNekJoQ2sxek1tUkJaelo1VVZGRFptOXBOQzkzYkZONk1pOHZhMXBVVkhOaVJYVkRabTVQZUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzljZjU0ZTc1LWUwZTgtNDBmOC1iZWM4LTk0M2JjOGYzYjU0MC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBVekVhN29uZXhUcHVpSUtUN2R3V0NvSDFob1NiUlByODNleHdDdGdPWU91YU9XWUN3UXJ4UVdBTQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2622"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 007b7b5d-5608-49bc-9057-94453a53f7d7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:49:25.310321Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1512"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2249de1e-fe80-4f17-afd2-5d57616d9731
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e119ab2a-cb88-4b75-b93d-94e1eabcf342
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-18T16:43:35.686906Z","dhcp_enabled":true,"id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:35.686906Z","id":"6e957e34-653e-4fed-ad63-38ba4eb78285","subnet":"172.16.16.0/22","updated_at":"2023-10-18T16:43:35.686906Z"},{"created_at":"2023-10-18T16:43:35.686906Z","id":"975a8ca4-bf73-442f-8fed-25cd29f6029e","subnet":"fd63:256c:45f7:91b4::/64","updated_at":"2023-10-18T16:43:35.686906Z"}],"tags":[],"updated_at":"2023-10-18T16:43:35.686906Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "717"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 99afc388-2e7a-48fe-905d-dc1336580b26
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:49:25.310321Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1512"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1a4ddc06-1bc8-4c32-b326-10b9f4de2250
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUa1JqZWsweGIxaEVWRTE2VFZSQmVFNTZSVEpPUkdONlRURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEhwc0NtRkVkVlZRVm1GNFpVOWtXREJtWkhocWEyeGxaVGQxYlU0NVkycFVkWFUzYzNVM1MzRmlkeXRGY0hBM1pEVlZWVXRyUkZWT1MySkxNVTA0VGt0SlZXY0tNRkpRUTFkbGRYQmFkVlJsVkhSd1MzaG5iSGx2VjJOa1VEQlpaRGhtVVVoUlpITmthRmd6YVhkNGVGRnhTelJTWmxWeVZGTm1ZMjVUVlZKa1JXeDRjQXBHS3psbmVFSm9UWGx2TW5oeE1WaHRSVVk0Vld3eU9WVTRLemRyVW1OSE1tczRlVWRRYlZKRU16aEtNVk5HWW5CTWRFRjVSMFJITXpsU1ZrNW1RV2xEQ21wYVVGZG5kRTkwVTJoV2RUSTJiMFJSYzI1a1NFcExZakI2V2s1bWJtMVVOVVpqUTBsdWJUWnJURzlZUmpob1Qyc3laekZYUVdWb05URXdiVmxOVjNBS1IyZHNhemRGV2pOVWVXaE9ja2xPZVdSVGFYZzJSSFJKWjFSQk0ybGtUMlYxVW5sTGEwMTFURXBHVTNoalYzcElSbE5QYm5KcFkwZ3pSM1l6ZW1OS05BcHlTVTVIUlRaMFlrTkJRVnB3TUU1QmFqVnJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWlBkVkExWkdrclIxWXdXbWxNYTFkV2JVWTVNMU0xTkZGMWRuRk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRZVVZXZUZGc1RscFFNVmhJV0UxUVNuRnZkbVJRTDNaSE5rTkJTMVYxWTJSMmNETkxRell4V2xWSVRtWTNibEpNVWdwMGJYQkJMekl5TTNZdldVeHRUbFJHZVhjd1dERTBiM1pJUVRGMldWbENhbFJOVFdGdmJHVmlkVVJzWld4UWFqSlhSR2hvUW10UWFtcGxXbWt2VkRkdENuUk5NSEl3TTJNM1JYcHVkbXc0VEdOWlZDdHZWa2xWZVdGcWVreGlhMmd6WVVwWGVtUnRSRWM1VTFsSFUydzJhMUpIY2t0WlRXc3JNVFJzYm5aTFpXNEtNQ3RZVFU5bFltRjBUbHBIU0V4SVpsVkxWMDl1TWpWeE1XOU9TV2xsTDJ3NVNsVkROM3BOYmpOMGFHOXZZVFZVYUVwalMzTnNWRFZKVUdsd2JuaEtkd3BRZW1veVJ6ZHVjVk5rY0hkbFVHWTRZWFZoUVZaVUsxWTNNMWt2T0dKbVkzTTBlVTV1VkM5MGVXNXlTMXBqVDAxVE4zQnBja2RhTUdWQmQwMDFNekJoQ2sxek1tUkJaelo1VVZGRFptOXBOQzkzYkZONk1pOHZhMXBVVkhOaVJYVkRabTVQZUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzljZjU0ZTc1LWUwZTgtNDBmOC1iZWM4LTk0M2JjOGYzYjU0MC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBVekVhN29uZXhUcHVpSUtUN2R3V0NvSDFob1NiUlByODNleHdDdGdPWU91YU9XWUN3UXJ4UVdBTQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2622"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a31dd3ab-7808-40d8-8c60-33301f1769a2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e119ab2a-cb88-4b75-b93d-94e1eabcf342
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-18T16:43:35.686906Z","dhcp_enabled":true,"id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","name":"test-type-change","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2023-10-18T16:43:35.686906Z","id":"6e957e34-653e-4fed-ad63-38ba4eb78285","subnet":"172.16.16.0/22","updated_at":"2023-10-18T16:43:35.686906Z"},{"created_at":"2023-10-18T16:43:35.686906Z","id":"975a8ca4-bf73-442f-8fed-25cd29f6029e","subnet":"fd63:256c:45f7:91b4::/64","updated_at":"2023-10-18T16:43:35.686906Z"}],"tags":[],"updated_at":"2023-10-18T16:43:35.686906Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "717"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 14bf58cf-cf0c-409c-aef3-aa4d4ef174b3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
-    method: GET
-  response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:49:25.310321Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1512"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6533282b-8ca4-4556-9b99-f99b9fe91146
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540/kubeconfig
-    method: GET
-  response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUa1JqZWsweGIxaEVWRTE2VFZSQmVFNTZSVEpPUkdONlRURnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEhwc0NtRkVkVlZRVm1GNFpVOWtXREJtWkhocWEyeGxaVGQxYlU0NVkycFVkWFUzYzNVM1MzRmlkeXRGY0hBM1pEVlZWVXRyUkZWT1MySkxNVTA0VGt0SlZXY0tNRkpRUTFkbGRYQmFkVlJsVkhSd1MzaG5iSGx2VjJOa1VEQlpaRGhtVVVoUlpITmthRmd6YVhkNGVGRnhTelJTWmxWeVZGTm1ZMjVUVlZKa1JXeDRjQXBHS3psbmVFSm9UWGx2TW5oeE1WaHRSVVk0Vld3eU9WVTRLemRyVW1OSE1tczRlVWRRYlZKRU16aEtNVk5HWW5CTWRFRjVSMFJITXpsU1ZrNW1RV2xEQ21wYVVGZG5kRTkwVTJoV2RUSTJiMFJSYzI1a1NFcExZakI2V2s1bWJtMVVOVVpqUTBsdWJUWnJURzlZUmpob1Qyc3laekZYUVdWb05URXdiVmxOVjNBS1IyZHNhemRGV2pOVWVXaE9ja2xPZVdSVGFYZzJSSFJKWjFSQk0ybGtUMlYxVW5sTGEwMTFURXBHVTNoalYzcElSbE5QYm5KcFkwZ3pSM1l6ZW1OS05BcHlTVTVIUlRaMFlrTkJRVnB3TUU1QmFqVnJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWlBkVkExWkdrclIxWXdXbWxNYTFkV2JVWTVNMU0xTkZGMWRuRk5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRZVVZXZUZGc1RscFFNVmhJV0UxUVNuRnZkbVJRTDNaSE5rTkJTMVYxWTJSMmNETkxRell4V2xWSVRtWTNibEpNVWdwMGJYQkJMekl5TTNZdldVeHRUbFJHZVhjd1dERTBiM1pJUVRGMldWbENhbFJOVFdGdmJHVmlkVVJzWld4UWFqSlhSR2hvUW10UWFtcGxXbWt2VkRkdENuUk5NSEl3TTJNM1JYcHVkbXc0VEdOWlZDdHZWa2xWZVdGcWVreGlhMmd6WVVwWGVtUnRSRWM1VTFsSFUydzJhMUpIY2t0WlRXc3JNVFJzYm5aTFpXNEtNQ3RZVFU5bFltRjBUbHBIU0V4SVpsVkxWMDl1TWpWeE1XOU9TV2xsTDJ3NVNsVkROM3BOYmpOMGFHOXZZVFZVYUVwalMzTnNWRFZKVUdsd2JuaEtkd3BRZW1veVJ6ZHVjVk5rY0hkbFVHWTRZWFZoUVZaVUsxWTNNMWt2T0dKbVkzTTBlVTV1VkM5MGVXNXlTMXBqVDAxVE4zQnBja2RhTUdWQmQwMDFNekJoQ2sxek1tUkJaelo1VVZGRFptOXBOQzkzYkZONk1pOHZhMXBVVkhOaVJYVkRabTVQZUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzljZjU0ZTc1LWUwZTgtNDBmOC1iZWM4LTk0M2JjOGYzYjU0MC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBVekVhN29uZXhUcHVpSUtUN2R3V0NvSDFob1NiUlByODNleHdDdGdPWU91YU9XWUN3UXJ4UVdBTQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
-    headers:
-      Content-Length:
-      - "2622"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:49:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 587bf5e6-f7ab-4c42-8448-92353e266336
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":1}'
     headers:
       Content-Length:
-      - "230"
+      - "222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:32 GMT
+      - Tue, 07 Nov 2023 16:25:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4338,7 +4206,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d895df3e-047d-4271-89d9-3c38aef3286c
+      - aacd14ca-33cc-4fcf-8753-447d294fc57b
     status: 200 OK
     code: 200
     duration: ""
@@ -4349,19 +4217,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"kapsule-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":1}'
     headers:
       Content-Length:
-      - "230"
+      - "222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:33 GMT
+      - Tue, 07 Nov 2023 16:25:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4371,7 +4239,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9abdc8d2-89e1-471b-b19b-f84620f1a3a3
+      - c4698ca2-30f2-4e22-ba1b-9772e5297189
     status: 200 OK
     code: 200
     duration: ""
@@ -4382,19 +4250,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef?with_additional_resources=false
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:49:33.428604812Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:25:28.775901095Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1518"
+      - "1473"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:33 GMT
+      - Tue, 07 Nov 2023 16:25:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4404,7 +4272,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d81c0e3-0aa8-47db-bb5a-e2206d66fe04
+      - b028bb23-7390-481f-a20a-45b851a8a09e
     status: 200 OK
     code: 200
     duration: ""
@@ -4415,19 +4283,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:49:33.428605Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:25:28.775901Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:33 GMT
+      - Tue, 07 Nov 2023 16:25:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4437,7 +4305,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7604385b-be54-46fa-a4cf-49cace7d4ad5
+      - ad24b1d6-333c-482d-82cb-e3a7c12fdf67
     status: 200 OK
     code: 200
     duration: ""
@@ -4448,19 +4316,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://9cf54e75-e0e8-40f8-bec8-943bc8f3b540.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-11-17T16:47:31.489574Z","created_at":"2023-10-18T16:47:31.489574Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.9cf54e75-e0e8-40f8-bec8-943bc8f3b540.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"e119ab2a-cb88-4b75-b93d-94e1eabcf342","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-10-18T16:49:33.428605Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://e45c9569-a19b-419d-b28e-4620c566dcef.api.k8s.fr-par.scw.cloud:6443","cni":"cilium","commitment_ends_at":"2023-12-07T16:24:16.189828Z","created_at":"2023-11-07T16:24:16.189828Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.e45c9569-a19b-419d-b28e-4620c566dcef.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"e45c9569-a19b-419d-b28e-4620c566dcef","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":"963ac687-26f9-42a1-87c7-0a8737d493be","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"kapsule-dedicated-8","updated_at":"2023-11-07T16:25:28.775901Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1515"
+      - "1470"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:38 GMT
+      - Tue, 07 Nov 2023 16:25:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4470,7 +4338,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3a71b54-c44e-4767-bd67-9d30a0ca18cf
+      - ec68cdad-ff6f-4fdd-99d0-14a90707a9fe
     status: 200 OK
     code: 200
     duration: ""
@@ -4481,10 +4349,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/9cf54e75-e0e8-40f8-bec8-943bc8f3b540
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/e45c9569-a19b-419d-b28e-4620c566dcef
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"9cf54e75-e0e8-40f8-bec8-943bc8f3b540","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"e45c9569-a19b-419d-b28e-4620c566dcef","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -4493,7 +4361,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:43 GMT
+      - Tue, 07 Nov 2023 16:25:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4503,7 +4371,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3c6e94e-406d-4e12-a30d-6f7ed665eece
+      - fe26f38d-b8ed-4b36-952e-c1e074bbf4b2
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4514,7 +4382,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e119ab2a-cb88-4b75-b93d-94e1eabcf342
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/963ac687-26f9-42a1-87c7-0a8737d493be
     method: DELETE
   response:
     body: ""
@@ -4524,7 +4392,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:44 GMT
+      - Tue, 07 Nov 2023 16:25:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4534,12 +4402,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38793e19-05b7-4463-ab08-4fe115ca2fb3
+      - ce170a23-647c-4196-a7d2-ec527b3d1446
     status: 204 No Content
     code: 204
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"multicloud-dedicated-4","name":"test-type-change","description":"","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"version":"1.28.2","cni":"kilo","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":null}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"multicloud-dedicated-4","name":"test-type-change","description":"","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"version":"1.28.2","cni":"kilo","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null}'
     form: {}
     headers:
       Content-Type:
@@ -4550,16 +4418,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:49:44.298736533Z","created_at":"2023-10-18T16:49:44.298736533Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-10-18T16:49:44.310402696Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750423899Z","created_at":"2023-11-07T16:25:39.750423899Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760340954Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1491"
+      - "1446"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:44 GMT
+      - Tue, 07 Nov 2023 16:25:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4569,7 +4437,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10e97114-4f64-4d48-b08a-db442559039c
+      - a55b18ca-a2da-4757-8fc7-38adef513c64
     status: 200 OK
     code: 200
     duration: ""
@@ -4580,19 +4448,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:49:44.298737Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-10-18T16:49:44.310403Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:44 GMT
+      - Tue, 07 Nov 2023 16:25:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4602,7 +4470,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b70ad633-f471-48fb-b901-5815a531bb00
+      - a82d147e-79ab-40d6-b39e-0de75337c7e3
     status: 200 OK
     code: 200
     duration: ""
@@ -4613,19 +4481,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:49:44.298737Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-10-18T16:49:44.310403Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:49 GMT
+      - Tue, 07 Nov 2023 16:25:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4635,7 +4503,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d34a04e7-f69d-4826-95ca-3622df15a453
+      - aa9b2c3d-4c79-4e12-b8d0-ed99251160ec
     status: 200 OK
     code: 200
     duration: ""
@@ -4646,19 +4514,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:49:44.298737Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-10-18T16:49:44.310403Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:54 GMT
+      - Tue, 07 Nov 2023 16:25:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4668,7 +4536,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e474f30a-3b2a-46ff-a344-50f00c3ec6bf
+      - 23d6c560-f893-45e8-b73b-c1af8beb6058
     status: 200 OK
     code: 200
     duration: ""
@@ -4679,19 +4547,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:49:44.298737Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-10-18T16:49:44.310403Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:49:59 GMT
+      - Tue, 07 Nov 2023 16:25:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4701,7 +4569,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 890f9fc9-e643-49f7-b41b-7e02f74e99ba
+      - afef12ab-4d5e-4ff0-9c45-6b6ea7997153
     status: 200 OK
     code: 200
     duration: ""
@@ -4712,19 +4580,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:49:44.298737Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-10-18T16:49:44.310403Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:50:04 GMT
+      - Tue, 07 Nov 2023 16:26:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4734,7 +4602,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 477f5eaa-1dea-44fa-bfc1-a2b2af6a6d1a
+      - 77ae03a1-37ac-4847-b048-3a9dce38cb35
     status: 200 OK
     code: 200
     duration: ""
@@ -4745,19 +4613,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:49:44.298737Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-10-18T16:49:44.310403Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:50:09 GMT
+      - Tue, 07 Nov 2023 16:26:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4767,7 +4635,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51fa31a8-685d-4c71-8734-967e993501c8
+      - 11ef3b85-bf5b-4099-9857-290e93fce274
     status: 200 OK
     code: 200
     duration: ""
@@ -4778,19 +4646,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:49:44.298737Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-10-18T16:49:44.310403Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:50:14 GMT
+      - Tue, 07 Nov 2023 16:26:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4800,7 +4668,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a7694b9-573f-4006-8b42-72a1fc0f2f95
+      - 836b66e3-8e29-4f01-8238-b91bdd9f1b40
     status: 200 OK
     code: 200
     duration: ""
@@ -4811,19 +4679,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:49:44.298737Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-10-18T16:49:44.310403Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:50:19 GMT
+      - Tue, 07 Nov 2023 16:26:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4833,7 +4701,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96658670-5d18-46c3-bab2-e3f027c13c4c
+      - be5f35fc-a654-403d-a24c-b15446f86576
     status: 200 OK
     code: 200
     duration: ""
@@ -4844,19 +4712,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:49:44.298737Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-10-18T16:49:44.310403Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:50:24 GMT
+      - Tue, 07 Nov 2023 16:26:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4866,7 +4734,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc47e26d-a447-4210-bf29-d27d0aeee64e
+      - a61416e9-7e6c-44d4-9009-2b58b942eff5
     status: 200 OK
     code: 200
     duration: ""
@@ -4877,19 +4745,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:49:44.298737Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-10-18T16:49:44.310403Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:50:29 GMT
+      - Tue, 07 Nov 2023 16:26:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4899,7 +4767,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f7784b0-d066-467b-a64b-2177fe0a0206
+      - e17dd193-c72f-41e7-a244-4b5f60d40050
     status: 200 OK
     code: 200
     duration: ""
@@ -4910,19 +4778,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:49:44.298737Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-10-18T16:49:44.310403Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:50:34 GMT
+      - Tue, 07 Nov 2023 16:26:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4932,7 +4800,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec86c06f-5850-4237-ab1f-62df5c8c6081
+      - 31f95cb7-0c05-49bf-95b1-ad768b11a982
     status: 200 OK
     code: 200
     duration: ""
@@ -4943,19 +4811,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:49:44.298737Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-10-18T16:49:44.310403Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:50:39 GMT
+      - Tue, 07 Nov 2023 16:26:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4965,7 +4833,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6443928-a917-4c28-bcaf-2251e39bad61
+      - b373dc7b-eef4-4ded-a556-f839c730dd95
     status: 200 OK
     code: 200
     duration: ""
@@ -4976,19 +4844,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:49:44.298737Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-10-18T16:49:44.310403Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:50:45 GMT
+      - Tue, 07 Nov 2023 16:26:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4998,7 +4866,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7c7a4f8-6747-4ad3-804a-f14b72cb23e5
+      - a5c518ee-79c2-4653-8a81-8621a5b20528
     status: 200 OK
     code: 200
     duration: ""
@@ -5009,19 +4877,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:49:44.298737Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-10-18T16:49:44.310403Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:50:50 GMT
+      - Tue, 07 Nov 2023 16:26:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5031,7 +4899,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e76148ca-0d1e-42f6-8922-f4f18ec13e93
+      - dd73925d-fc93-44aa-a35a-2d91e128b74c
     status: 200 OK
     code: 200
     duration: ""
@@ -5042,19 +4910,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:49:44.298737Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-10-18T16:49:44.310403Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:50:55 GMT
+      - Tue, 07 Nov 2023 16:26:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5064,7 +4932,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fc19744-4f7d-4577-ac1e-13893fc3c662
+      - 199a2fce-62fa-45be-8b04-55d38dfad155
     status: 200 OK
     code: 200
     duration: ""
@@ -5075,19 +4943,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:49:44.298737Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-10-18T16:50:58.570529Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:25:39.760341Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1479"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:00 GMT
+      - Tue, 07 Nov 2023 16:26:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5097,7 +4965,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a53343da-039e-44de-9d57-3c1d92d916bb
+      - 70601d34-3c35-47e5-9987-754a9efbfaec
     status: 200 OK
     code: 200
     duration: ""
@@ -5108,19 +4976,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:49:44.298737Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-10-18T16:50:58.570529Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:26:58.795435Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1479"
+      - "1434"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:00 GMT
+      - Tue, 07 Nov 2023 16:27:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5130,7 +4998,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f4d016f-410e-4691-a362-a60cda4337f5
+      - a8e9f7e4-6b49-4c02-9a64-4c680b39a7c2
     status: 200 OK
     code: 200
     duration: ""
@@ -5141,19 +5009,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUa1JyTUU1V2IxaEVWRTE2VFZSQmVFNTZSVEpPUkdzd1RsWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEdnNUNqZ3lWVzFzVW5Bek0zaHdXVzVQUjJWUmFrVlhSbmxwYUd0YWFtNXpMME5CTDBaSll6ZzBNMnRxTmpWMWMyMVhTMnBuY0dOUlFuSlNkU3RVTkdZNWNGY0tUbWRoU25OemFVMXZXRmx4WjBjMFMyeHRibGxrTm5ZeE0xUXJPVkZNWjNsc1lqVnZVVzlNV1V4eWVuVktZMFZRYldObmNYQlBRelpQSzNWUUwyODFSUXBDTkRKbU1IWkZiVmh2VjBSVWRub3lVekZzYVdKclNtSTVNRWMyVUdaWWEycDBkMUJ5Y0RWWU16UkpjQ3R0YjFwbFVEQlhSbEV6ZGl0MlVHTTNTSEpaQ2tZeWFtZENPRGRCUmt3Mk1qTkhSVlpWWmtVNUt6ZG9abEJYU0hSTVpWQnlZalpUTkVVelJXa3dOeTl1TmpkR05EaDNSM0ZEYlhsMEwzUmFOeTgwVW04S1FWSmFUMDV6WlZselFVdFNVRFV6U0ZwbGNtVldibEU1ZVVob1VuTlhkekpHYTFBMU5rdGhjakZZUWxWVllrMUVaMDVOWmlzeVN6Qk9RblI1TTI0NU1BcG9TbWxKYUhsTFpqSXhXVlI1TDJ4bkszVk5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWktOV0YxU1VsTFp6UnRLMnhJTDNScFVUTnROVU4wVTFKVVVVZE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJPR2hHUldGU01tOTVSM1owT0hwQ1FtSmhNMnRqZEhoSWN5OXVUbXRtTUhGTGNTdHBhSEowZERKeFEwUkdaakZvTkFwdmFXcG9NRWxVTTFwVlJ6QjRTMlZaWWtGdVRXVk9VRVJGVld0bVRGSnFZbk50U0ZweVdGSllSVU4wWmxwamRIQlJlWEpKVW14Wk4wVlhaa2hvVUhWVkNtVm1hV1ZMVVZoNWFHSkJkWFJ5U2tGaVQxVjJSa2xtVGpOR2N6aHBiek5QTTFSbk9ISTNlRzEyVWpaYVFuTTNkekl6UkVwRlptUXhZbTFMYTBKMFIyOEtSQ3RoWWxrd1ZqVXZVWGRuWm5aTVFrNVdkR2R5VFdJMlJXUklNRWt4VEdkc016UnBhVE50TlUxMFlWaEhhV1ZRVm5OeE9GUTBkMDFrUjJWMU5teFZUQW8zT1RSNVQwNU5TRXhpV0Roc1NtOWpNRU42SzJaa2RGZHJlVVZVZEV0NFRubDJiVFJZUlU1QlFsWkRhR1ZhZVZaYVJVZFNRbWhQTVhNclNFOVZRVTB6Q21aM01GaDNMMnBqTTBjMk5HVlVVV1ZhVDI5M2RGaEZibXR1WTI1aWVrUnZXVEJ4VXdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzhhMWY2YjU4LTI1ZWQtNGY4Zi1iNzlhLTYwNDFkYTlhMmVlZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiTDJEdzNwZXZxRXlNcGhnc0N0dlExNVd0bm81U0ZLSHVLbXpmanM1b0QxY1VveVpqMU53dHRYYQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:26:58.795435Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2622"
+      - "1434"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:00 GMT
+      - Tue, 07 Nov 2023 16:27:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5163,7 +5031,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da14934f-4971-43e9-977a-e357e16f5022
+      - 5fe72da2-8e23-48f5-8427-9ac0d144f338
     status: 200 OK
     code: 200
     duration: ""
@@ -5174,19 +5042,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:49:44.298737Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-10-18T16:50:58.570529Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BWTUUxV2IxaEVWRTE2VFZSRmQwNXFSVEpOYWxVd1RWWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEc1ckNrSm5TRWsyVFhoWk1tNVZMMlIxWkVSdVJsSkNSRVJTWm5wWFMxbEZSM2hVTkhWU01WbFdWVWxKY21GVlZVRjFZWEZSYUhZd1ZqSmpTM2RYY1U5cFNGa0tha3RKYkhScFVHMW9ZMWt5WTNSd1puWjJUekkzU1dWRmVrZENTbVZ3VWs5U05ucGFUR1ppY0RCeWFIY3ZZME0yV1hvd1VuTTNlbmN5Y21aR2JUWlFkd3AzUnpaRFJXUjJaeTlNU1RkR2MxZ3hjMDlSU1VZNGNYUnZNelJaTWprNUwybzVaVk51YTFwQ1RGSlNZbWRDY0VGSVlUTm9USGRtVURkbGIxSm9TVzluQ2xKT2RVWnRjbFpMZUZaYVVrdGxlRE5EUnpJME0yTXlaSGh2ZUVsc01rOVNhRXBYTmtFM2EzTm9lR3hSY21OWFoydzNUV1JSU3pKcFZWQmFOSGx1TUc4S2FsQmFRbTlNYmpVdmIwNWpRV0ZtWXpNeEwySlhhRkJsU1hwMmNFNHZRMDE0VUdONWVFWmtaelpHT0VWRWN5ODNRVEpXT1dNMmRWVTBOM0l3ZGs1a2NRcEdhVGQwVUZsbmRuaE5kbnBEV0hCbk1XUnJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpXR3BOYkVOTGFXVkxhV281YjFobVZsUlVRak4yZDFjM2RFdE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJhVGxyV2t0U05qVnNSRFp4VFU1dVVqTlJUbEJWYTJnMlNtNDNNMWRxWkROTllYRTNjMDVoZUVKSWJrMU1aRUZDWXdvemNqQkpjM1pQYkZvMVRDczFaelp3U1ZGalMzSktXRzB4VDJGclN5dFlWVlJ1YUdGcllXVXhZMGhVYVdwb2JrOTRhVTE0TUhWaWIzZHRNRzFEVHpFNENsTm9Takp0VlM5RU1rNW5aVzlpV1VSR2FFbHBSbnAyTWpnNGEzUndUa0V5VEhWT1lqTnlkVkp4U2tkT1oyeERNbXRQZDNWNE5VTnJhWGhUTUc5Q2IzY0tSekpsYWxodlRVWjVSRGg1V0M5Uk5GbHNSMlpRYTBGRlJqQnBLMFJoV2pjMGJYaGhTbkJ3WW1GSlJuY3JMM1JzZWpscFQwOU9RV2hOZFdWNmFUWXZWZ293TjI5TlNVWldUWFZqTUZkU2FrZHZWVzlvVGs0eFMwVkJWa2R4UW1sU09UaDFSbFZwTWxvME1FaGxjMFJEV2xJM1ZHRk1iblpSZEc1amJuQmlZMGw1Q200eksyVXJUbE56V1ZNeU9YSlZiR05TVG1acFNWRk5TMVEzZDNGTFpIQldSbWw1Y1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzAwZTVhYmE3LWIzM2EtNDQyOS04YTU2LWJlYWVlNTFlZGE1ZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnQ1NzVVI5MnBTalhsQXplNHdsQm5KOEVCMFFYbVJua0dQbFNEWkdsV2s2TnV6OE1jUzZBVkNtZA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1479"
+      - "2620"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:00 GMT
+      - Tue, 07 Nov 2023 16:27:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5196,7 +5064,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e09e3ccb-8f37-4e1c-ba00-f0aaef66d4fb
+      - 5546e6de-2c0a-4211-86cc-237eeab04dce
     status: 200 OK
     code: 200
     duration: ""
@@ -5207,19 +5075,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:49:44.298737Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-10-18T16:50:58.570529Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:26:58.795435Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1479"
+      - "1434"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:00 GMT
+      - Tue, 07 Nov 2023 16:27:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5229,7 +5097,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc5870a3-9aa1-4df1-8260-49f94f9f0204
+      - 5ee7abd4-eb9c-490a-96c0-c6eacc032c87
     status: 200 OK
     code: 200
     duration: ""
@@ -5240,19 +5108,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUa1JyTUU1V2IxaEVWRTE2VFZSQmVFNTZSVEpPUkdzd1RsWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEdnNUNqZ3lWVzFzVW5Bek0zaHdXVzVQUjJWUmFrVlhSbmxwYUd0YWFtNXpMME5CTDBaSll6ZzBNMnRxTmpWMWMyMVhTMnBuY0dOUlFuSlNkU3RVTkdZNWNGY0tUbWRoU25OemFVMXZXRmx4WjBjMFMyeHRibGxrTm5ZeE0xUXJPVkZNWjNsc1lqVnZVVzlNV1V4eWVuVktZMFZRYldObmNYQlBRelpQSzNWUUwyODFSUXBDTkRKbU1IWkZiVmh2VjBSVWRub3lVekZzYVdKclNtSTVNRWMyVUdaWWEycDBkMUJ5Y0RWWU16UkpjQ3R0YjFwbFVEQlhSbEV6ZGl0MlVHTTNTSEpaQ2tZeWFtZENPRGRCUmt3Mk1qTkhSVlpWWmtVNUt6ZG9abEJYU0hSTVpWQnlZalpUTkVVelJXa3dOeTl1TmpkR05EaDNSM0ZEYlhsMEwzUmFOeTgwVW04S1FWSmFUMDV6WlZselFVdFNVRFV6U0ZwbGNtVldibEU1ZVVob1VuTlhkekpHYTFBMU5rdGhjakZZUWxWVllrMUVaMDVOWmlzeVN6Qk9RblI1TTI0NU1BcG9TbWxKYUhsTFpqSXhXVlI1TDJ4bkszVk5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWktOV0YxU1VsTFp6UnRLMnhJTDNScFVUTnROVU4wVTFKVVVVZE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJPR2hHUldGU01tOTVSM1owT0hwQ1FtSmhNMnRqZEhoSWN5OXVUbXRtTUhGTGNTdHBhSEowZERKeFEwUkdaakZvTkFwdmFXcG9NRWxVTTFwVlJ6QjRTMlZaWWtGdVRXVk9VRVJGVld0bVRGSnFZbk50U0ZweVdGSllSVU4wWmxwamRIQlJlWEpKVW14Wk4wVlhaa2hvVUhWVkNtVm1hV1ZMVVZoNWFHSkJkWFJ5U2tGaVQxVjJSa2xtVGpOR2N6aHBiek5QTTFSbk9ISTNlRzEyVWpaYVFuTTNkekl6UkVwRlptUXhZbTFMYTBKMFIyOEtSQ3RoWWxrd1ZqVXZVWGRuWm5aTVFrNVdkR2R5VFdJMlJXUklNRWt4VEdkc016UnBhVE50TlUxMFlWaEhhV1ZRVm5OeE9GUTBkMDFrUjJWMU5teFZUQW8zT1RSNVQwNU5TRXhpV0Roc1NtOWpNRU42SzJaa2RGZHJlVVZVZEV0NFRubDJiVFJZUlU1QlFsWkRhR1ZhZVZaYVJVZFNRbWhQTVhNclNFOVZRVTB6Q21aM01GaDNMMnBqTTBjMk5HVlVVV1ZhVDI5M2RGaEZibXR1WTI1aWVrUnZXVEJ4VXdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzhhMWY2YjU4LTI1ZWQtNGY4Zi1iNzlhLTYwNDFkYTlhMmVlZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiTDJEdzNwZXZxRXlNcGhnc0N0dlExNVd0bm81U0ZLSHVLbXpmanM1b0QxY1VveVpqMU53dHRYYQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:26:58.795435Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2622"
+      - "1434"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:00 GMT
+      - Tue, 07 Nov 2023 16:27:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5262,7 +5130,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56fae452-e8c8-4e87-9d37-684a66e7b379
+      - b967faf6-b44c-441c-b8b3-6edcc8ceae87
     status: 200 OK
     code: 200
     duration: ""
@@ -5273,19 +5141,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:49:44.298737Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-10-18T16:50:58.570529Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BWTUUxV2IxaEVWRTE2VFZSRmQwNXFSVEpOYWxVd1RWWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEc1ckNrSm5TRWsyVFhoWk1tNVZMMlIxWkVSdVJsSkNSRVJTWm5wWFMxbEZSM2hVTkhWU01WbFdWVWxKY21GVlZVRjFZWEZSYUhZd1ZqSmpTM2RYY1U5cFNGa0tha3RKYkhScFVHMW9ZMWt5WTNSd1puWjJUekkzU1dWRmVrZENTbVZ3VWs5U05ucGFUR1ppY0RCeWFIY3ZZME0yV1hvd1VuTTNlbmN5Y21aR2JUWlFkd3AzUnpaRFJXUjJaeTlNU1RkR2MxZ3hjMDlSU1VZNGNYUnZNelJaTWprNUwybzVaVk51YTFwQ1RGSlNZbWRDY0VGSVlUTm9USGRtVURkbGIxSm9TVzluQ2xKT2RVWnRjbFpMZUZaYVVrdGxlRE5EUnpJME0yTXlaSGh2ZUVsc01rOVNhRXBYTmtFM2EzTm9lR3hSY21OWFoydzNUV1JSU3pKcFZWQmFOSGx1TUc4S2FsQmFRbTlNYmpVdmIwNWpRV0ZtWXpNeEwySlhhRkJsU1hwMmNFNHZRMDE0VUdONWVFWmtaelpHT0VWRWN5ODNRVEpXT1dNMmRWVTBOM0l3ZGs1a2NRcEdhVGQwVUZsbmRuaE5kbnBEV0hCbk1XUnJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpXR3BOYkVOTGFXVkxhV281YjFobVZsUlVRak4yZDFjM2RFdE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJhVGxyV2t0U05qVnNSRFp4VFU1dVVqTlJUbEJWYTJnMlNtNDNNMWRxWkROTllYRTNjMDVoZUVKSWJrMU1aRUZDWXdvemNqQkpjM1pQYkZvMVRDczFaelp3U1ZGalMzSktXRzB4VDJGclN5dFlWVlJ1YUdGcllXVXhZMGhVYVdwb2JrOTRhVTE0TUhWaWIzZHRNRzFEVHpFNENsTm9Takp0VlM5RU1rNW5aVzlpV1VSR2FFbHBSbnAyTWpnNGEzUndUa0V5VEhWT1lqTnlkVkp4U2tkT1oyeERNbXRQZDNWNE5VTnJhWGhUTUc5Q2IzY0tSekpsYWxodlRVWjVSRGg1V0M5Uk5GbHNSMlpRYTBGRlJqQnBLMFJoV2pjMGJYaGhTbkJ3WW1GSlJuY3JMM1JzZWpscFQwOU9RV2hOZFdWNmFUWXZWZ293TjI5TlNVWldUWFZqTUZkU2FrZHZWVzlvVGs0eFMwVkJWa2R4UW1sU09UaDFSbFZwTWxvME1FaGxjMFJEV2xJM1ZHRk1iblpSZEc1amJuQmlZMGw1Q200eksyVXJUbE56V1ZNeU9YSlZiR05TVG1acFNWRk5TMVEzZDNGTFpIQldSbWw1Y1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzAwZTVhYmE3LWIzM2EtNDQyOS04YTU2LWJlYWVlNTFlZGE1ZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnQ1NzVVI5MnBTalhsQXplNHdsQm5KOEVCMFFYbVJua0dQbFNEWkdsV2s2TnV6OE1jUzZBVkNtZA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1479"
+      - "2620"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:01 GMT
+      - Tue, 07 Nov 2023 16:27:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5295,7 +5163,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7f15986-58de-45a7-98c2-aa13573f4c8e
+      - aafcec44-dd3c-4b58-8bcf-b36622a4cd38
     status: 200 OK
     code: 200
     duration: ""
@@ -5306,19 +5174,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUa1JyTUU1V2IxaEVWRTE2VFZSQmVFNTZSVEpPUkdzd1RsWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEdnNUNqZ3lWVzFzVW5Bek0zaHdXVzVQUjJWUmFrVlhSbmxwYUd0YWFtNXpMME5CTDBaSll6ZzBNMnRxTmpWMWMyMVhTMnBuY0dOUlFuSlNkU3RVTkdZNWNGY0tUbWRoU25OemFVMXZXRmx4WjBjMFMyeHRibGxrTm5ZeE0xUXJPVkZNWjNsc1lqVnZVVzlNV1V4eWVuVktZMFZRYldObmNYQlBRelpQSzNWUUwyODFSUXBDTkRKbU1IWkZiVmh2VjBSVWRub3lVekZzYVdKclNtSTVNRWMyVUdaWWEycDBkMUJ5Y0RWWU16UkpjQ3R0YjFwbFVEQlhSbEV6ZGl0MlVHTTNTSEpaQ2tZeWFtZENPRGRCUmt3Mk1qTkhSVlpWWmtVNUt6ZG9abEJYU0hSTVpWQnlZalpUTkVVelJXa3dOeTl1TmpkR05EaDNSM0ZEYlhsMEwzUmFOeTgwVW04S1FWSmFUMDV6WlZselFVdFNVRFV6U0ZwbGNtVldibEU1ZVVob1VuTlhkekpHYTFBMU5rdGhjakZZUWxWVllrMUVaMDVOWmlzeVN6Qk9RblI1TTI0NU1BcG9TbWxKYUhsTFpqSXhXVlI1TDJ4bkszVk5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWktOV0YxU1VsTFp6UnRLMnhJTDNScFVUTnROVU4wVTFKVVVVZE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJPR2hHUldGU01tOTVSM1owT0hwQ1FtSmhNMnRqZEhoSWN5OXVUbXRtTUhGTGNTdHBhSEowZERKeFEwUkdaakZvTkFwdmFXcG9NRWxVTTFwVlJ6QjRTMlZaWWtGdVRXVk9VRVJGVld0bVRGSnFZbk50U0ZweVdGSllSVU4wWmxwamRIQlJlWEpKVW14Wk4wVlhaa2hvVUhWVkNtVm1hV1ZMVVZoNWFHSkJkWFJ5U2tGaVQxVjJSa2xtVGpOR2N6aHBiek5QTTFSbk9ISTNlRzEyVWpaYVFuTTNkekl6UkVwRlptUXhZbTFMYTBKMFIyOEtSQ3RoWWxrd1ZqVXZVWGRuWm5aTVFrNVdkR2R5VFdJMlJXUklNRWt4VEdkc016UnBhVE50TlUxMFlWaEhhV1ZRVm5OeE9GUTBkMDFrUjJWMU5teFZUQW8zT1RSNVQwNU5TRXhpV0Roc1NtOWpNRU42SzJaa2RGZHJlVVZVZEV0NFRubDJiVFJZUlU1QlFsWkRhR1ZhZVZaYVJVZFNRbWhQTVhNclNFOVZRVTB6Q21aM01GaDNMMnBqTTBjMk5HVlVVV1ZhVDI5M2RGaEZibXR1WTI1aWVrUnZXVEJ4VXdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzhhMWY2YjU4LTI1ZWQtNGY4Zi1iNzlhLTYwNDFkYTlhMmVlZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiTDJEdzNwZXZxRXlNcGhnc0N0dlExNVd0bm81U0ZLSHVLbXpmanM1b0QxY1VveVpqMU53dHRYYQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:26:58.795435Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2622"
+      - "1434"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:01 GMT
+      - Tue, 07 Nov 2023 16:27:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5328,7 +5196,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 449d7a15-2ac6-4d35-8443-244c6a03b08c
+      - c92e5eef-309c-4075-99e3-8d8b718a7065
     status: 200 OK
     code: 200
     duration: ""
@@ -5339,19 +5207,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e/kubeconfig
     method: GET
   response:
-    body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"multicloud-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"multicloud-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":2}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BWTUUxV2IxaEVWRTE2VFZSRmQwNXFSVEpOYWxVd1RWWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEc1ckNrSm5TRWsyVFhoWk1tNVZMMlIxWkVSdVJsSkNSRVJTWm5wWFMxbEZSM2hVTkhWU01WbFdWVWxKY21GVlZVRjFZWEZSYUhZd1ZqSmpTM2RYY1U5cFNGa0tha3RKYkhScFVHMW9ZMWt5WTNSd1puWjJUekkzU1dWRmVrZENTbVZ3VWs5U05ucGFUR1ppY0RCeWFIY3ZZME0yV1hvd1VuTTNlbmN5Y21aR2JUWlFkd3AzUnpaRFJXUjJaeTlNU1RkR2MxZ3hjMDlSU1VZNGNYUnZNelJaTWprNUwybzVaVk51YTFwQ1RGSlNZbWRDY0VGSVlUTm9USGRtVURkbGIxSm9TVzluQ2xKT2RVWnRjbFpMZUZaYVVrdGxlRE5EUnpJME0yTXlaSGh2ZUVsc01rOVNhRXBYTmtFM2EzTm9lR3hSY21OWFoydzNUV1JSU3pKcFZWQmFOSGx1TUc4S2FsQmFRbTlNYmpVdmIwNWpRV0ZtWXpNeEwySlhhRkJsU1hwMmNFNHZRMDE0VUdONWVFWmtaelpHT0VWRWN5ODNRVEpXT1dNMmRWVTBOM0l3ZGs1a2NRcEdhVGQwVUZsbmRuaE5kbnBEV0hCbk1XUnJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpXR3BOYkVOTGFXVkxhV281YjFobVZsUlVRak4yZDFjM2RFdE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJhVGxyV2t0U05qVnNSRFp4VFU1dVVqTlJUbEJWYTJnMlNtNDNNMWRxWkROTllYRTNjMDVoZUVKSWJrMU1aRUZDWXdvemNqQkpjM1pQYkZvMVRDczFaelp3U1ZGalMzSktXRzB4VDJGclN5dFlWVlJ1YUdGcllXVXhZMGhVYVdwb2JrOTRhVTE0TUhWaWIzZHRNRzFEVHpFNENsTm9Takp0VlM5RU1rNW5aVzlpV1VSR2FFbHBSbnAyTWpnNGEzUndUa0V5VEhWT1lqTnlkVkp4U2tkT1oyeERNbXRQZDNWNE5VTnJhWGhUTUc5Q2IzY0tSekpsYWxodlRVWjVSRGg1V0M5Uk5GbHNSMlpRYTBGRlJqQnBLMFJoV2pjMGJYaGhTbkJ3WW1GSlJuY3JMM1JzZWpscFQwOU9RV2hOZFdWNmFUWXZWZ293TjI5TlNVWldUWFZqTUZkU2FrZHZWVzlvVGs0eFMwVkJWa2R4UW1sU09UaDFSbFZwTWxvME1FaGxjMFJEV2xJM1ZHRk1iblpSZEc1amJuQmlZMGw1Q200eksyVXJUbE56V1ZNeU9YSlZiR05TVG1acFNWRk5TMVEzZDNGTFpIQldSbWw1Y1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzAwZTVhYmE3LWIzM2EtNDQyOS04YTU2LWJlYWVlNTFlZGE1ZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnQ1NzVVI5MnBTalhsQXplNHdsQm5KOEVCMFFYbVJua0dQbFNEWkdsV2s2TnV6OE1jUzZBVkNtZA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "429"
+      - "2620"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:01 GMT
+      - Tue, 07 Nov 2023 16:27:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5361,7 +5229,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3944738c-e87e-4a1f-a107-8d8ea069d935
+      - c9477d43-8f9e-4dc7-80af-02872899740e
     status: 200 OK
     code: 200
     duration: ""
@@ -5372,52 +5240,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee/available-types
-    method: GET
-  response:
-    body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"multicloud-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"multicloud-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "429"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:51:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 247f3002-0ef6-4f9a-97e2-3e378e3aac14
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"multicloud-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"multicloud-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":2}'
     headers:
       Content-Length:
-      - "429"
+      - "413"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:01 GMT
+      - Tue, 07 Nov 2023 16:27:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5427,7 +5262,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9028a225-fe84-435d-898e-c4893e2b21bb
+      - 688a3500-73fb-480a-9f6e-735d0aa6f580
     status: 200 OK
     code: 200
     duration: ""
@@ -5438,19 +5273,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e/available-types
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:49:44.298737Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-10-18T16:50:58.570529Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"multicloud-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"multicloud-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":2}'
     headers:
       Content-Length:
-      - "1479"
+      - "413"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:02 GMT
+      - Tue, 07 Nov 2023 16:27:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5460,7 +5295,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0df0443a-e3d0-4454-ac51-e62b4b4285c6
+      - 7aa1a465-e9ea-4917-83f0-1191c27aaee9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e/available-types
+    method: GET
+  response:
+    body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":8000000000,"name":"multicloud-dedicated-8","resiliency":"high_availability","sla":99.5},{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"multicloud-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "413"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:27:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a6d8ba82-06fb-421b-9ca4-7459e52313bd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:25:39.750424Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-4","updated_at":"2023-11-07T16:26:58.795435Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1434"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:27:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fd62efb0-eb3e-4b60-a942-21d47c3fb079
     status: 200 OK
     code: 200
     duration: ""
@@ -5473,19 +5374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee/set-type
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e/set-type
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585080Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:51:02.231660631Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930080903Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001137647Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1488"
+      - "1443"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:02 GMT
+      - Tue, 07 Nov 2023 16:27:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5495,7 +5396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b56ee086-71ee-4015-b663-2868bbf5604b
+      - 87cd14f9-06b0-4da9-b85d-52d166f0f070
     status: 200 OK
     code: 200
     duration: ""
@@ -5506,19 +5407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:51:02.231661Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:02 GMT
+      - Tue, 07 Nov 2023 16:27:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5528,7 +5429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1561fa51-eeb1-448a-8b85-dfda9a71a886
+      - 270a57c0-9dda-4a77-ac4d-31948661d5aa
     status: 200 OK
     code: 200
     duration: ""
@@ -5539,19 +5440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:51:02.231661Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:07 GMT
+      - Tue, 07 Nov 2023 16:27:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5561,7 +5462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 921e575a-9b7f-4e97-a004-04f3fd96d685
+      - 88881f72-9d42-44c0-8727-4ae41105fe36
     status: 200 OK
     code: 200
     duration: ""
@@ -5572,19 +5473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:51:02.231661Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:12 GMT
+      - Tue, 07 Nov 2023 16:27:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5594,7 +5495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a51bdc20-2c9c-447a-8bbb-19013e854af2
+      - 5d827202-1295-49d5-80fc-2b02afd4e0a4
     status: 200 OK
     code: 200
     duration: ""
@@ -5605,19 +5506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:51:02.231661Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:17 GMT
+      - Tue, 07 Nov 2023 16:27:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5627,7 +5528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b35ca807-5683-4f66-b6b9-e090cca3a8f9
+      - 3ba68025-0506-4bfa-b853-c446aa8e4d0d
     status: 200 OK
     code: 200
     duration: ""
@@ -5638,19 +5539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:51:02.231661Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:22 GMT
+      - Tue, 07 Nov 2023 16:27:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5660,7 +5561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1736414a-aeb1-4216-a227-a3849dc75854
+      - a09d50ce-2a92-4db8-9269-6fda5c2580e6
     status: 200 OK
     code: 200
     duration: ""
@@ -5671,19 +5572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:51:02.231661Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:27 GMT
+      - Tue, 07 Nov 2023 16:27:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5693,7 +5594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c9ebd24-5f6a-4aa7-89ba-0e2df061cf86
+      - e8d7ab5b-1467-4979-813a-a162da9f1467
     status: 200 OK
     code: 200
     duration: ""
@@ -5704,19 +5605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:51:02.231661Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:32 GMT
+      - Tue, 07 Nov 2023 16:27:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5726,7 +5627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 044afcff-4b02-4c1a-84e6-42d0d5841012
+      - bd91e50c-6a94-41ea-b0b1-4168cf22f0c8
     status: 200 OK
     code: 200
     duration: ""
@@ -5737,19 +5638,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:51:02.231661Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:37 GMT
+      - Tue, 07 Nov 2023 16:27:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5759,7 +5660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f227532f-90ef-4335-bb00-bd3a3ee4673c
+      - dfd9d0a6-0ab4-4fa6-9069-d5acb81ac1d1
     status: 200 OK
     code: 200
     duration: ""
@@ -5770,19 +5671,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:51:02.231661Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:42 GMT
+      - Tue, 07 Nov 2023 16:27:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5792,7 +5693,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 329c61c7-1781-43e8-a1dd-d0a3d6cda114
+      - b74527ed-7dd9-40dc-81de-7b4165291c75
     status: 200 OK
     code: 200
     duration: ""
@@ -5803,19 +5704,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:51:02.231661Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:47 GMT
+      - Tue, 07 Nov 2023 16:27:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5825,7 +5726,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8ff20d1-2044-4e79-bcaa-5b79cb6ccbdf
+      - d1d74e08-60a7-4847-96f8-d873e977b6b6
     status: 200 OK
     code: 200
     duration: ""
@@ -5836,19 +5737,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:51:02.231661Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:52 GMT
+      - Tue, 07 Nov 2023 16:27:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5858,7 +5759,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be2aa18d-f6a0-4cc5-9498-09349365ce67
+      - 2c3bd1f8-a717-4c3c-9e12-5f32302da553
     status: 200 OK
     code: 200
     duration: ""
@@ -5869,19 +5770,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:51:02.231661Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:51:57 GMT
+      - Tue, 07 Nov 2023 16:27:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5891,7 +5792,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e18d61c7-2b6d-47c5-81dd-f3c649d60a1a
+      - 33637e42-624d-4be0-9e76-baf55fa4afa6
     status: 200 OK
     code: 200
     duration: ""
@@ -5902,19 +5803,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:51:02.231661Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:02 GMT
+      - Tue, 07 Nov 2023 16:28:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5924,7 +5825,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65688c50-92d0-4fb2-9100-970b25f22cc8
+      - 031d8e2a-3905-4175-af84-49c2f0103a01
     status: 200 OK
     code: 200
     duration: ""
@@ -5935,19 +5836,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:51:02.231661Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:08 GMT
+      - Tue, 07 Nov 2023 16:28:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5957,7 +5858,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0e2509a-c234-4cc0-98e6-12da423f83db
+      - 553a2d7b-34eb-4f44-9699-7054c1ba716f
     status: 200 OK
     code: 200
     duration: ""
@@ -5968,19 +5869,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:51:02.231661Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:13 GMT
+      - Tue, 07 Nov 2023 16:28:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5990,7 +5891,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e81acb11-1ffe-40d2-a9f1-22f9ade08099
+      - 86fa23b6-e9a0-46a6-8f4a-2dbfc0ab8ab6
     status: 200 OK
     code: 200
     duration: ""
@@ -6001,19 +5902,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:51:02.231661Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:18 GMT
+      - Tue, 07 Nov 2023 16:28:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6023,7 +5924,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce615e0f-d052-4074-95c2-cfef3fecdffd
+      - d6e3937a-807f-4803-98eb-dde3283da6c8
     status: 200 OK
     code: 200
     duration: ""
@@ -6034,19 +5935,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:52:22.667211Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:27:03.001138Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1479"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:23 GMT
+      - Tue, 07 Nov 2023 16:28:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6056,12 +5957,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02ffb550-23a5-434c-9a0b-e509cf9b6a6f
+      - 697728be-b0bf-4ae3-be2c-c976cc81e3c5
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":null,"description":null,"tags":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":null,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":null},"auto_upgrade":{"enable":null,"maintenance_window":null},"feature_gates":null,"admission_plugins":null,"open_id_connect_config":{"issuer_url":null,"client_id":null,"username_claim":null,"username_prefix":null,"groups_claim":null,"groups_prefix":null,"required_claim":null},"apiserver_cert_sans":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:28:28.525155Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1434"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:28:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d4367150-7572-4ec8-a635-a69944fb8afa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":null,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":null},"auto_upgrade":{"enable":null,"maintenance_window":null},"open_id_connect_config":{"issuer_url":null,"client_id":null,"username_claim":null,"username_prefix":null,"groups_claim":null,"groups_prefix":null,"required_claim":null}}'
     form: {}
     headers:
       Content-Type:
@@ -6069,19 +6003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: PATCH
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:52:23.181422618Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:28:29.115275818Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1485"
+      - "1440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:23 GMT
+      - Tue, 07 Nov 2023 16:28:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6091,7 +6025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ccd775eb-61b0-4242-9911-da23c1ca8bfa
+      - 97ee7bd7-7584-4a90-aa7c-9b2e5553ef07
     status: 200 OK
     code: 200
     duration: ""
@@ -6102,19 +6036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:52:23.181423Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:28:29.115276Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:23 GMT
+      - Tue, 07 Nov 2023 16:28:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6124,7 +6058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2aebcbb6-a0e1-49cd-9ffa-b3caaced6c5d
+      - cf2a645b-fdbb-47b3-8a91-af18cf0322f0
     status: 200 OK
     code: 200
     duration: ""
@@ -6135,19 +6069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:52:23.181423Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:28:29.115276Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:28 GMT
+      - Tue, 07 Nov 2023 16:28:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6157,7 +6091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f124d30-55c2-40ee-8f74-97da9b672153
+      - 883b56b4-2808-4166-a5bb-a13a3eaf698c
     status: 200 OK
     code: 200
     duration: ""
@@ -6168,19 +6102,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:52:23.181423Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:28:29.115276Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:33 GMT
+      - Tue, 07 Nov 2023 16:28:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6190,7 +6124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d48b3c8e-8e03-41cc-987d-06490a42ec03
+      - 770ca229-b970-4bc0-bf96-526f41cbb352
     status: 200 OK
     code: 200
     duration: ""
@@ -6201,19 +6135,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:52:23.181423Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:28:29.115276Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:38 GMT
+      - Tue, 07 Nov 2023 16:28:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6223,7 +6157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d57a140-a920-43af-a09a-42a9eb0a46dd
+      - ba055f4e-3ea4-4c08-94c9-afc72fc0f989
     status: 200 OK
     code: 200
     duration: ""
@@ -6234,19 +6168,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:52:23.181423Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:28:29.115276Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:43 GMT
+      - Tue, 07 Nov 2023 16:28:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6256,7 +6190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23f9a36d-b4df-4c50-b6af-abca2a1ce8ba
+      - 114cd0c3-ec01-4787-b160-c5bce9fc8bd7
     status: 200 OK
     code: 200
     duration: ""
@@ -6267,19 +6201,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:52:23.181423Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:28:29.115276Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:48 GMT
+      - Tue, 07 Nov 2023 16:28:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6289,7 +6223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3864f5e5-4605-4349-85c6-040bf506e367
+      - 216a4875-e80a-4e7a-b192-c4012bbd7fe4
     status: 200 OK
     code: 200
     duration: ""
@@ -6300,19 +6234,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:52:23.181423Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:28:29.115276Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:53 GMT
+      - Tue, 07 Nov 2023 16:28:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6322,7 +6256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 682104f6-de03-4a24-a378-162be6762c3a
+      - a54b73ee-9c9d-49c2-aefc-090bef96673a
     status: 200 OK
     code: 200
     duration: ""
@@ -6333,19 +6267,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:52:55.548103Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:28:29.115276Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1479"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:58 GMT
+      - Tue, 07 Nov 2023 16:29:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6355,7 +6289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5eee1011-ed09-43dc-879f-bf820141342f
+      - 1a3876d7-f8c9-4fca-951a-1603c0058efb
     status: 200 OK
     code: 200
     duration: ""
@@ -6366,19 +6300,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:52:55.548103Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"updating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:28:29.115276Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1479"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:58 GMT
+      - Tue, 07 Nov 2023 16:29:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6388,7 +6322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57d52c7b-1157-4f2b-b779-5da6ce4890a4
+      - a6973119-feb4-401a-8488-29216919c610
     status: 200 OK
     code: 200
     duration: ""
@@ -6399,19 +6333,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUa1JyTUU1V2IxaEVWRTE2VFZSQmVFNTZSVEpPUkdzd1RsWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEdnNUNqZ3lWVzFzVW5Bek0zaHdXVzVQUjJWUmFrVlhSbmxwYUd0YWFtNXpMME5CTDBaSll6ZzBNMnRxTmpWMWMyMVhTMnBuY0dOUlFuSlNkU3RVTkdZNWNGY0tUbWRoU25OemFVMXZXRmx4WjBjMFMyeHRibGxrTm5ZeE0xUXJPVkZNWjNsc1lqVnZVVzlNV1V4eWVuVktZMFZRYldObmNYQlBRelpQSzNWUUwyODFSUXBDTkRKbU1IWkZiVmh2VjBSVWRub3lVekZzYVdKclNtSTVNRWMyVUdaWWEycDBkMUJ5Y0RWWU16UkpjQ3R0YjFwbFVEQlhSbEV6ZGl0MlVHTTNTSEpaQ2tZeWFtZENPRGRCUmt3Mk1qTkhSVlpWWmtVNUt6ZG9abEJYU0hSTVpWQnlZalpUTkVVelJXa3dOeTl1TmpkR05EaDNSM0ZEYlhsMEwzUmFOeTgwVW04S1FWSmFUMDV6WlZselFVdFNVRFV6U0ZwbGNtVldibEU1ZVVob1VuTlhkekpHYTFBMU5rdGhjakZZUWxWVllrMUVaMDVOWmlzeVN6Qk9RblI1TTI0NU1BcG9TbWxKYUhsTFpqSXhXVlI1TDJ4bkszVk5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWktOV0YxU1VsTFp6UnRLMnhJTDNScFVUTnROVU4wVTFKVVVVZE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJPR2hHUldGU01tOTVSM1owT0hwQ1FtSmhNMnRqZEhoSWN5OXVUbXRtTUhGTGNTdHBhSEowZERKeFEwUkdaakZvTkFwdmFXcG9NRWxVTTFwVlJ6QjRTMlZaWWtGdVRXVk9VRVJGVld0bVRGSnFZbk50U0ZweVdGSllSVU4wWmxwamRIQlJlWEpKVW14Wk4wVlhaa2hvVUhWVkNtVm1hV1ZMVVZoNWFHSkJkWFJ5U2tGaVQxVjJSa2xtVGpOR2N6aHBiek5QTTFSbk9ISTNlRzEyVWpaYVFuTTNkekl6UkVwRlptUXhZbTFMYTBKMFIyOEtSQ3RoWWxrd1ZqVXZVWGRuWm5aTVFrNVdkR2R5VFdJMlJXUklNRWt4VEdkc016UnBhVE50TlUxMFlWaEhhV1ZRVm5OeE9GUTBkMDFrUjJWMU5teFZUQW8zT1RSNVQwNU5TRXhpV0Roc1NtOWpNRU42SzJaa2RGZHJlVVZVZEV0NFRubDJiVFJZUlU1QlFsWkRhR1ZhZVZaYVJVZFNRbWhQTVhNclNFOVZRVTB6Q21aM01GaDNMMnBqTTBjMk5HVlVVV1ZhVDI5M2RGaEZibXR1WTI1aWVrUnZXVEJ4VXdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzhhMWY2YjU4LTI1ZWQtNGY4Zi1iNzlhLTYwNDFkYTlhMmVlZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiTDJEdzNwZXZxRXlNcGhnc0N0dlExNVd0bm81U0ZLSHVLbXpmanM1b0QxY1VveVpqMU53dHRYYQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:29:10.768442Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2622"
+      - "1434"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:58 GMT
+      - Tue, 07 Nov 2023 16:29:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6421,7 +6355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d14264ea-765d-47ee-b7b8-e630a15428ec
+      - 9abd487d-e3e8-4b05-8383-3690cabc26d5
     status: 200 OK
     code: 200
     duration: ""
@@ -6432,19 +6366,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:52:55.548103Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:29:10.768442Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1479"
+      - "1434"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:58 GMT
+      - Tue, 07 Nov 2023 16:29:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6454,7 +6388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6009bec-19dc-445c-8e3f-129d572cc977
+      - c7a61ab3-6d9e-4c9c-8994-bcb60dffeaa0
     status: 200 OK
     code: 200
     duration: ""
@@ -6465,19 +6399,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e/kubeconfig
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:52:55.548103Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BWTUUxV2IxaEVWRTE2VFZSRmQwNXFSVEpOYWxVd1RWWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEc1ckNrSm5TRWsyVFhoWk1tNVZMMlIxWkVSdVJsSkNSRVJTWm5wWFMxbEZSM2hVTkhWU01WbFdWVWxKY21GVlZVRjFZWEZSYUhZd1ZqSmpTM2RYY1U5cFNGa0tha3RKYkhScFVHMW9ZMWt5WTNSd1puWjJUekkzU1dWRmVrZENTbVZ3VWs5U05ucGFUR1ppY0RCeWFIY3ZZME0yV1hvd1VuTTNlbmN5Y21aR2JUWlFkd3AzUnpaRFJXUjJaeTlNU1RkR2MxZ3hjMDlSU1VZNGNYUnZNelJaTWprNUwybzVaVk51YTFwQ1RGSlNZbWRDY0VGSVlUTm9USGRtVURkbGIxSm9TVzluQ2xKT2RVWnRjbFpMZUZaYVVrdGxlRE5EUnpJME0yTXlaSGh2ZUVsc01rOVNhRXBYTmtFM2EzTm9lR3hSY21OWFoydzNUV1JSU3pKcFZWQmFOSGx1TUc4S2FsQmFRbTlNYmpVdmIwNWpRV0ZtWXpNeEwySlhhRkJsU1hwMmNFNHZRMDE0VUdONWVFWmtaelpHT0VWRWN5ODNRVEpXT1dNMmRWVTBOM0l3ZGs1a2NRcEdhVGQwVUZsbmRuaE5kbnBEV0hCbk1XUnJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpXR3BOYkVOTGFXVkxhV281YjFobVZsUlVRak4yZDFjM2RFdE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJhVGxyV2t0U05qVnNSRFp4VFU1dVVqTlJUbEJWYTJnMlNtNDNNMWRxWkROTllYRTNjMDVoZUVKSWJrMU1aRUZDWXdvemNqQkpjM1pQYkZvMVRDczFaelp3U1ZGalMzSktXRzB4VDJGclN5dFlWVlJ1YUdGcllXVXhZMGhVYVdwb2JrOTRhVTE0TUhWaWIzZHRNRzFEVHpFNENsTm9Takp0VlM5RU1rNW5aVzlpV1VSR2FFbHBSbnAyTWpnNGEzUndUa0V5VEhWT1lqTnlkVkp4U2tkT1oyeERNbXRQZDNWNE5VTnJhWGhUTUc5Q2IzY0tSekpsYWxodlRVWjVSRGg1V0M5Uk5GbHNSMlpRYTBGRlJqQnBLMFJoV2pjMGJYaGhTbkJ3WW1GSlJuY3JMM1JzZWpscFQwOU9RV2hOZFdWNmFUWXZWZ293TjI5TlNVWldUWFZqTUZkU2FrZHZWVzlvVGs0eFMwVkJWa2R4UW1sU09UaDFSbFZwTWxvME1FaGxjMFJEV2xJM1ZHRk1iblpSZEc1amJuQmlZMGw1Q200eksyVXJUbE56V1ZNeU9YSlZiR05TVG1acFNWRk5TMVEzZDNGTFpIQldSbWw1Y1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzAwZTVhYmE3LWIzM2EtNDQyOS04YTU2LWJlYWVlNTFlZGE1ZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnQ1NzVVI5MnBTalhsQXplNHdsQm5KOEVCMFFYbVJua0dQbFNEWkdsV2s2TnV6OE1jUzZBVkNtZA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "1479"
+      - "2620"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:59 GMT
+      - Tue, 07 Nov 2023 16:29:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6487,7 +6421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dba7f92d-6c82-40b5-b38f-8f1aaef9a02d
+      - c913685b-e0a1-446e-846e-d55fefe68e61
     status: 200 OK
     code: 200
     duration: ""
@@ -6498,19 +6432,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUa1JyTUU1V2IxaEVWRTE2VFZSQmVFNTZSVEpPUkdzd1RsWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEdnNUNqZ3lWVzFzVW5Bek0zaHdXVzVQUjJWUmFrVlhSbmxwYUd0YWFtNXpMME5CTDBaSll6ZzBNMnRxTmpWMWMyMVhTMnBuY0dOUlFuSlNkU3RVTkdZNWNGY0tUbWRoU25OemFVMXZXRmx4WjBjMFMyeHRibGxrTm5ZeE0xUXJPVkZNWjNsc1lqVnZVVzlNV1V4eWVuVktZMFZRYldObmNYQlBRelpQSzNWUUwyODFSUXBDTkRKbU1IWkZiVmh2VjBSVWRub3lVekZzYVdKclNtSTVNRWMyVUdaWWEycDBkMUJ5Y0RWWU16UkpjQ3R0YjFwbFVEQlhSbEV6ZGl0MlVHTTNTSEpaQ2tZeWFtZENPRGRCUmt3Mk1qTkhSVlpWWmtVNUt6ZG9abEJYU0hSTVpWQnlZalpUTkVVelJXa3dOeTl1TmpkR05EaDNSM0ZEYlhsMEwzUmFOeTgwVW04S1FWSmFUMDV6WlZselFVdFNVRFV6U0ZwbGNtVldibEU1ZVVob1VuTlhkekpHYTFBMU5rdGhjakZZUWxWVllrMUVaMDVOWmlzeVN6Qk9RblI1TTI0NU1BcG9TbWxKYUhsTFpqSXhXVlI1TDJ4bkszVk5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWktOV0YxU1VsTFp6UnRLMnhJTDNScFVUTnROVU4wVTFKVVVVZE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJPR2hHUldGU01tOTVSM1owT0hwQ1FtSmhNMnRqZEhoSWN5OXVUbXRtTUhGTGNTdHBhSEowZERKeFEwUkdaakZvTkFwdmFXcG9NRWxVTTFwVlJ6QjRTMlZaWWtGdVRXVk9VRVJGVld0bVRGSnFZbk50U0ZweVdGSllSVU4wWmxwamRIQlJlWEpKVW14Wk4wVlhaa2hvVUhWVkNtVm1hV1ZMVVZoNWFHSkJkWFJ5U2tGaVQxVjJSa2xtVGpOR2N6aHBiek5QTTFSbk9ISTNlRzEyVWpaYVFuTTNkekl6UkVwRlptUXhZbTFMYTBKMFIyOEtSQ3RoWWxrd1ZqVXZVWGRuWm5aTVFrNVdkR2R5VFdJMlJXUklNRWt4VEdkc016UnBhVE50TlUxMFlWaEhhV1ZRVm5OeE9GUTBkMDFrUjJWMU5teFZUQW8zT1RSNVQwNU5TRXhpV0Roc1NtOWpNRU42SzJaa2RGZHJlVVZVZEV0NFRubDJiVFJZUlU1QlFsWkRhR1ZhZVZaYVJVZFNRbWhQTVhNclNFOVZRVTB6Q21aM01GaDNMMnBqTTBjMk5HVlVVV1ZhVDI5M2RGaEZibXR1WTI1aWVrUnZXVEJ4VXdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzhhMWY2YjU4LTI1ZWQtNGY4Zi1iNzlhLTYwNDFkYTlhMmVlZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiTDJEdzNwZXZxRXlNcGhnc0N0dlExNVd0bm81U0ZLSHVLbXpmanM1b0QxY1VveVpqMU53dHRYYQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:29:10.768442Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2622"
+      - "1434"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:59 GMT
+      - Tue, 07 Nov 2023 16:29:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6520,7 +6454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7b0aea5-7970-466d-b4d1-e0aa2e62f979
+      - 760e4051-979f-4982-9a72-83364288bc30
     status: 200 OK
     code: 200
     duration: ""
@@ -6531,19 +6465,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:52:55.548103Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:29:10.768442Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1479"
+      - "1434"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:59 GMT
+      - Tue, 07 Nov 2023 16:29:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6553,7 +6487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8669097-8d86-4159-851f-557c02b53e5a
+      - 95851621-c98c-4428-b7b3-95c09bf0c041
     status: 200 OK
     code: 200
     duration: ""
@@ -6564,19 +6498,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUa1JyTUU1V2IxaEVWRTE2VFZSQmVFNTZSVEpPUkdzd1RsWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEdnNUNqZ3lWVzFzVW5Bek0zaHdXVzVQUjJWUmFrVlhSbmxwYUd0YWFtNXpMME5CTDBaSll6ZzBNMnRxTmpWMWMyMVhTMnBuY0dOUlFuSlNkU3RVTkdZNWNGY0tUbWRoU25OemFVMXZXRmx4WjBjMFMyeHRibGxrTm5ZeE0xUXJPVkZNWjNsc1lqVnZVVzlNV1V4eWVuVktZMFZRYldObmNYQlBRelpQSzNWUUwyODFSUXBDTkRKbU1IWkZiVmh2VjBSVWRub3lVekZzYVdKclNtSTVNRWMyVUdaWWEycDBkMUJ5Y0RWWU16UkpjQ3R0YjFwbFVEQlhSbEV6ZGl0MlVHTTNTSEpaQ2tZeWFtZENPRGRCUmt3Mk1qTkhSVlpWWmtVNUt6ZG9abEJYU0hSTVpWQnlZalpUTkVVelJXa3dOeTl1TmpkR05EaDNSM0ZEYlhsMEwzUmFOeTgwVW04S1FWSmFUMDV6WlZselFVdFNVRFV6U0ZwbGNtVldibEU1ZVVob1VuTlhkekpHYTFBMU5rdGhjakZZUWxWVllrMUVaMDVOWmlzeVN6Qk9RblI1TTI0NU1BcG9TbWxKYUhsTFpqSXhXVlI1TDJ4bkszVk5RMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWktOV0YxU1VsTFp6UnRLMnhJTDNScFVUTnROVU4wVTFKVVVVZE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJPR2hHUldGU01tOTVSM1owT0hwQ1FtSmhNMnRqZEhoSWN5OXVUbXRtTUhGTGNTdHBhSEowZERKeFEwUkdaakZvTkFwdmFXcG9NRWxVTTFwVlJ6QjRTMlZaWWtGdVRXVk9VRVJGVld0bVRGSnFZbk50U0ZweVdGSllSVU4wWmxwamRIQlJlWEpKVW14Wk4wVlhaa2hvVUhWVkNtVm1hV1ZMVVZoNWFHSkJkWFJ5U2tGaVQxVjJSa2xtVGpOR2N6aHBiek5QTTFSbk9ISTNlRzEyVWpaYVFuTTNkekl6UkVwRlptUXhZbTFMYTBKMFIyOEtSQ3RoWWxrd1ZqVXZVWGRuWm5aTVFrNVdkR2R5VFdJMlJXUklNRWt4VEdkc016UnBhVE50TlUxMFlWaEhhV1ZRVm5OeE9GUTBkMDFrUjJWMU5teFZUQW8zT1RSNVQwNU5TRXhpV0Roc1NtOWpNRU42SzJaa2RGZHJlVVZVZEV0NFRubDJiVFJZUlU1QlFsWkRhR1ZhZVZaYVJVZFNRbWhQTVhNclNFOVZRVTB6Q21aM01GaDNMMnBqTTBjMk5HVlVVV1ZhVDI5M2RGaEZibXR1WTI1aWVrUnZXVEJ4VXdvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzhhMWY2YjU4LTI1ZWQtNGY4Zi1iNzlhLTYwNDFkYTlhMmVlZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBiTDJEdzNwZXZxRXlNcGhnc0N0dlExNVd0bm81U0ZLSHVLbXpmanM1b0QxY1VveVpqMU53dHRYYQ==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BWTUUxV2IxaEVWRTE2VFZSRmQwNXFSVEpOYWxVd1RWWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEc1ckNrSm5TRWsyVFhoWk1tNVZMMlIxWkVSdVJsSkNSRVJTWm5wWFMxbEZSM2hVTkhWU01WbFdWVWxKY21GVlZVRjFZWEZSYUhZd1ZqSmpTM2RYY1U5cFNGa0tha3RKYkhScFVHMW9ZMWt5WTNSd1puWjJUekkzU1dWRmVrZENTbVZ3VWs5U05ucGFUR1ppY0RCeWFIY3ZZME0yV1hvd1VuTTNlbmN5Y21aR2JUWlFkd3AzUnpaRFJXUjJaeTlNU1RkR2MxZ3hjMDlSU1VZNGNYUnZNelJaTWprNUwybzVaVk51YTFwQ1RGSlNZbWRDY0VGSVlUTm9USGRtVURkbGIxSm9TVzluQ2xKT2RVWnRjbFpMZUZaYVVrdGxlRE5EUnpJME0yTXlaSGh2ZUVsc01rOVNhRXBYTmtFM2EzTm9lR3hSY21OWFoydzNUV1JSU3pKcFZWQmFOSGx1TUc4S2FsQmFRbTlNYmpVdmIwNWpRV0ZtWXpNeEwySlhhRkJsU1hwMmNFNHZRMDE0VUdONWVFWmtaelpHT0VWRWN5ODNRVEpXT1dNMmRWVTBOM0l3ZGs1a2NRcEdhVGQwVUZsbmRuaE5kbnBEV0hCbk1XUnJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpXR3BOYkVOTGFXVkxhV281YjFobVZsUlVRak4yZDFjM2RFdE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJhVGxyV2t0U05qVnNSRFp4VFU1dVVqTlJUbEJWYTJnMlNtNDNNMWRxWkROTllYRTNjMDVoZUVKSWJrMU1aRUZDWXdvemNqQkpjM1pQYkZvMVRDczFaelp3U1ZGalMzSktXRzB4VDJGclN5dFlWVlJ1YUdGcllXVXhZMGhVYVdwb2JrOTRhVTE0TUhWaWIzZHRNRzFEVHpFNENsTm9Takp0VlM5RU1rNW5aVzlpV1VSR2FFbHBSbnAyTWpnNGEzUndUa0V5VEhWT1lqTnlkVkp4U2tkT1oyeERNbXRQZDNWNE5VTnJhWGhUTUc5Q2IzY0tSekpsYWxodlRVWjVSRGg1V0M5Uk5GbHNSMlpRYTBGRlJqQnBLMFJoV2pjMGJYaGhTbkJ3WW1GSlJuY3JMM1JzZWpscFQwOU9RV2hOZFdWNmFUWXZWZ293TjI5TlNVWldUWFZqTUZkU2FrZHZWVzlvVGs0eFMwVkJWa2R4UW1sU09UaDFSbFZwTWxvME1FaGxjMFJEV2xJM1ZHRk1iblpSZEc1amJuQmlZMGw1Q200eksyVXJUbE56V1ZNeU9YSlZiR05TVG1acFNWRk5TMVEzZDNGTFpIQldSbWw1Y1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzAwZTVhYmE3LWIzM2EtNDQyOS04YTU2LWJlYWVlNTFlZGE1ZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnQ1NzVVI5MnBTalhsQXplNHdsQm5KOEVCMFFYbVJua0dQbFNEWkdsV2s2TnV6OE1jUzZBVkNtZA==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2622"
+      - "2620"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:59 GMT
+      - Tue, 07 Nov 2023 16:29:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6586,7 +6520,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2cce756c-e61b-4e63-8e9e-2aae82920286
+      - a8d350b5-2d2d-4e20-93aa-96af3a89cfc7
     status: 200 OK
     code: 200
     duration: ""
@@ -6597,19 +6531,85 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:29:10.768442Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1434"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:29:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ae27ee1a-4ef8-43cc-8917-49262d3b54a5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3BWTUUxV2IxaEVWRTE2VFZSRmQwNXFSVEpOYWxVd1RWWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEc1ckNrSm5TRWsyVFhoWk1tNVZMMlIxWkVSdVJsSkNSRVJTWm5wWFMxbEZSM2hVTkhWU01WbFdWVWxKY21GVlZVRjFZWEZSYUhZd1ZqSmpTM2RYY1U5cFNGa0tha3RKYkhScFVHMW9ZMWt5WTNSd1puWjJUekkzU1dWRmVrZENTbVZ3VWs5U05ucGFUR1ppY0RCeWFIY3ZZME0yV1hvd1VuTTNlbmN5Y21aR2JUWlFkd3AzUnpaRFJXUjJaeTlNU1RkR2MxZ3hjMDlSU1VZNGNYUnZNelJaTWprNUwybzVaVk51YTFwQ1RGSlNZbWRDY0VGSVlUTm9USGRtVURkbGIxSm9TVzluQ2xKT2RVWnRjbFpMZUZaYVVrdGxlRE5EUnpJME0yTXlaSGh2ZUVsc01rOVNhRXBYTmtFM2EzTm9lR3hSY21OWFoydzNUV1JSU3pKcFZWQmFOSGx1TUc4S2FsQmFRbTlNYmpVdmIwNWpRV0ZtWXpNeEwySlhhRkJsU1hwMmNFNHZRMDE0VUdONWVFWmtaelpHT0VWRWN5ODNRVEpXT1dNMmRWVTBOM0l3ZGs1a2NRcEdhVGQwVUZsbmRuaE5kbnBEV0hCbk1XUnJRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkpXR3BOYkVOTGFXVkxhV281YjFobVZsUlVRak4yZDFjM2RFdE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkJhVGxyV2t0U05qVnNSRFp4VFU1dVVqTlJUbEJWYTJnMlNtNDNNMWRxWkROTllYRTNjMDVoZUVKSWJrMU1aRUZDWXdvemNqQkpjM1pQYkZvMVRDczFaelp3U1ZGalMzSktXRzB4VDJGclN5dFlWVlJ1YUdGcllXVXhZMGhVYVdwb2JrOTRhVTE0TUhWaWIzZHRNRzFEVHpFNENsTm9Takp0VlM5RU1rNW5aVzlpV1VSR2FFbHBSbnAyTWpnNGEzUndUa0V5VEhWT1lqTnlkVkp4U2tkT1oyeERNbXRQZDNWNE5VTnJhWGhUTUc5Q2IzY0tSekpsYWxodlRVWjVSRGg1V0M5Uk5GbHNSMlpRYTBGRlJqQnBLMFJoV2pjMGJYaGhTbkJ3WW1GSlJuY3JMM1JzZWpscFQwOU9RV2hOZFdWNmFUWXZWZ293TjI5TlNVWldUWFZqTUZkU2FrZHZWVzlvVGs0eFMwVkJWa2R4UW1sU09UaDFSbFZwTWxvME1FaGxjMFJEV2xJM1ZHRk1iblpSZEc1amJuQmlZMGw1Q200eksyVXJUbE56V1ZNeU9YSlZiR05TVG1acFNWRk5TMVEzZDNGTFpIQldSbWw1Y1FvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzAwZTVhYmE3LWIzM2EtNDQyOS04YTU2LWJlYWVlNTFlZGE1ZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBnQ1NzVVI5MnBTalhsQXplNHdsQm5KOEVCMFFYbVJua0dQbFNEWkdsV2s2TnV6OE1jUzZBVkNtZA==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2620"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:29:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 22a1fd86-0b9b-4a1e-a7b8-3d926f8f7d5d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"multicloud-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":1}'
     headers:
       Content-Length:
-      - "233"
+      - "225"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:59 GMT
+      - Tue, 07 Nov 2023 16:29:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6619,7 +6619,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5e46e15-d9eb-4b6e-86ce-781d88d53d24
+      - e95f3549-1146-4a8a-8691-8c4b2e039044
     status: 200 OK
     code: 200
     duration: ""
@@ -6630,19 +6630,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee/available-types
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e/available-types
     method: GET
   response:
     body: '{"cluster_types":[{"availability":"available","commitment_delay":"2592000s","dedicated":true,"max_nodes":500,"memory":16000000000,"name":"multicloud-dedicated-16","resiliency":"high_availability","sla":99.5}],"total_count":1}'
     headers:
       Content-Length:
-      - "233"
+      - "225"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:52:59 GMT
+      - Tue, 07 Nov 2023 16:29:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6652,7 +6652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8eedbeeb-3f06-49c0-a844-5eeadfac425f
+      - e2b9d65c-8c25-4138-8b01-5f7fc83515d2
     status: 200 OK
     code: 200
     duration: ""
@@ -6663,19 +6663,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e?with_additional_resources=false
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:53:00.247874236Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:29:18.148808659Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1485"
+      - "1440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:00 GMT
+      - Tue, 07 Nov 2023 16:29:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6685,7 +6685,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 967d1677-2dc5-43eb-a782-e4ee8dbc7cf5
+      - 42eef2df-c8b3-468e-8f67-71d40dbe33b4
     status: 200 OK
     code: 200
     duration: ""
@@ -6696,19 +6696,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:53:00.247874Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:29:18.148809Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:00 GMT
+      - Tue, 07 Nov 2023 16:29:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6718,7 +6718,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac14fbe4-d0dd-484b-9fcc-1f3aaed00107
+      - 3be81e67-ba7e-4712-8bd8-1692f44393aa
     status: 200 OK
     code: 200
     duration: ""
@@ -6729,19 +6729,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-17T16:51:02.154585Z","created_at":"2023-10-18T16:49:44.298737Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.8a1f6b58-25ed-4f8f-b79a-6041da9a2eee.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-10-18T16:53:00.247874Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://00e5aba7-b33a-4429-8a56-beaee51eda5e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-12-07T16:27:02.930081Z","created_at":"2023-11-07T16:25:39.750424Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.00e5aba7-b33a-4429-8a56-beaee51eda5e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud-dedicated-8","updated_at":"2023-11-07T16:29:18.148809Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1482"
+      - "1437"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:05 GMT
+      - Tue, 07 Nov 2023 16:29:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6751,7 +6751,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09545a54-2697-4de0-9cfa-162c7a834933
+      - 73685f9d-6c7b-4f84-870a-1311fb03be83
     status: 200 OK
     code: 200
     duration: ""
@@ -6762,10 +6762,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/8a1f6b58-25ed-4f8f-b79a-6041da9a2eee
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/00e5aba7-b33a-4429-8a56-beaee51eda5e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"8a1f6b58-25ed-4f8f-b79a-6041da9a2eee","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"00e5aba7-b33a-4429-8a56-beaee51eda5e","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -6774,7 +6774,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:10 GMT
+      - Tue, 07 Nov 2023 16:29:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6784,12 +6784,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f48d0aa-8ed5-430e-aa55-0364dda96ad5
+      - 69e6f546-eb61-4d47-80b9-2e2ef6a8eec7
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"multicloud","name":"test-type-change","description":"","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"version":"1.28.2","cni":"kilo","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"auto_upgrade":null,"feature_gates":null,"admission_plugins":null,"open_id_connect_config":null,"apiserver_cert_sans":null,"private_network_id":null}'
+    body: '{"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","type":"multicloud","name":"test-type-change","description":"","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"version":"1.28.2","cni":"kilo","pools":null,"autoscaler_config":{"scale_down_disabled":null,"scale_down_delay_after_add":null,"estimator":"unknown_estimator","expander":"unknown_expander","ignore_daemonsets_utilization":null,"balance_similar_node_groups":null,"expendable_pods_priority_cutoff":0,"scale_down_unneeded_time":null,"scale_down_utilization_threshold":null,"max_graceful_termination_sec":0},"feature_gates":null,"admission_plugins":null,"apiserver_cert_sans":null}'
     form: {}
     headers:
       Content-Type:
@@ -6800,16 +6800,16 @@ interactions:
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://dc078763-4903-4765-8f6f-ee32d81f889e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:53:10.838738055Z","created_at":"2023-10-18T16:53:10.838738055Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.dc078763-4903-4765-8f6f-ee32d81f889e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"dc078763-4903-4765-8f6f-ee32d81f889e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-10-18T16:53:10.850738208Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193112Z","created_at":"2023-11-07T16:29:28.473193112Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123049Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1479"
+      - "1434"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:10 GMT
+      - Tue, 07 Nov 2023 16:29:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6819,7 +6819,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2fd15f9-3eac-4e5e-9235-63a5c615c80b
+      - 712da4b9-1207-4608-8193-5cb1193ed92f
     status: 200 OK
     code: 200
     duration: ""
@@ -6830,19 +6830,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/dc078763-4903-4765-8f6f-ee32d81f889e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://dc078763-4903-4765-8f6f-ee32d81f889e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:53:10.838738Z","created_at":"2023-10-18T16:53:10.838738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.dc078763-4903-4765-8f6f-ee32d81f889e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"dc078763-4903-4765-8f6f-ee32d81f889e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-10-18T16:53:10.850738Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1425"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:11 GMT
+      - Tue, 07 Nov 2023 16:29:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6852,7 +6852,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6186a42-c473-4505-86a1-57cdc77f4795
+      - 4596fc05-38bb-41a4-867c-dbe0245dbd7b
     status: 200 OK
     code: 200
     duration: ""
@@ -6863,19 +6863,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/dc078763-4903-4765-8f6f-ee32d81f889e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://dc078763-4903-4765-8f6f-ee32d81f889e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:53:10.838738Z","created_at":"2023-10-18T16:53:10.838738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.dc078763-4903-4765-8f6f-ee32d81f889e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"dc078763-4903-4765-8f6f-ee32d81f889e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-10-18T16:53:10.850738Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1425"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:16 GMT
+      - Tue, 07 Nov 2023 16:29:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6885,7 +6885,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05f08169-ca5b-42b9-bd42-201eb546a761
+      - c5341cda-8233-44a7-80ce-290228e175b8
     status: 200 OK
     code: 200
     duration: ""
@@ -6896,19 +6896,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/dc078763-4903-4765-8f6f-ee32d81f889e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://dc078763-4903-4765-8f6f-ee32d81f889e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:53:10.838738Z","created_at":"2023-10-18T16:53:10.838738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.dc078763-4903-4765-8f6f-ee32d81f889e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"dc078763-4903-4765-8f6f-ee32d81f889e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-10-18T16:53:10.850738Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1425"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:21 GMT
+      - Tue, 07 Nov 2023 16:29:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6918,7 +6918,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca04c130-a631-44ee-ab0f-8619d88577c0
+      - 0cbc67ce-0e4a-4a4f-9109-b87ff739129d
     status: 200 OK
     code: 200
     duration: ""
@@ -6929,19 +6929,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/dc078763-4903-4765-8f6f-ee32d81f889e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://dc078763-4903-4765-8f6f-ee32d81f889e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:53:10.838738Z","created_at":"2023-10-18T16:53:10.838738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.dc078763-4903-4765-8f6f-ee32d81f889e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"dc078763-4903-4765-8f6f-ee32d81f889e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-10-18T16:53:10.850738Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1425"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:26 GMT
+      - Tue, 07 Nov 2023 16:29:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6951,7 +6951,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2fd9216b-6bdb-42e5-8c18-ca369a52cd55
+      - be3cd6a0-2582-40c2-95da-5518fe22038d
     status: 200 OK
     code: 200
     duration: ""
@@ -6962,19 +6962,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/dc078763-4903-4765-8f6f-ee32d81f889e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://dc078763-4903-4765-8f6f-ee32d81f889e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:53:10.838738Z","created_at":"2023-10-18T16:53:10.838738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.dc078763-4903-4765-8f6f-ee32d81f889e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"dc078763-4903-4765-8f6f-ee32d81f889e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-10-18T16:53:10.850738Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1425"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:31 GMT
+      - Tue, 07 Nov 2023 16:29:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -6984,7 +6984,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9790b98e-d1bb-4740-9d0c-65a2a99c6e8c
+      - a818c2ef-eb6d-4abc-898a-9bd44d188dde
     status: 200 OK
     code: 200
     duration: ""
@@ -6995,19 +6995,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/dc078763-4903-4765-8f6f-ee32d81f889e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://dc078763-4903-4765-8f6f-ee32d81f889e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:53:10.838738Z","created_at":"2023-10-18T16:53:10.838738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.dc078763-4903-4765-8f6f-ee32d81f889e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"dc078763-4903-4765-8f6f-ee32d81f889e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-10-18T16:53:10.850738Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1425"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:36 GMT
+      - Tue, 07 Nov 2023 16:29:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7017,7 +7017,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 748b5f52-bfd9-4cb2-83fc-a5595f52e8e1
+      - c83d2199-e808-4e3d-a790-54b199bdd459
     status: 200 OK
     code: 200
     duration: ""
@@ -7028,19 +7028,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/dc078763-4903-4765-8f6f-ee32d81f889e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://dc078763-4903-4765-8f6f-ee32d81f889e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:53:10.838738Z","created_at":"2023-10-18T16:53:10.838738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.dc078763-4903-4765-8f6f-ee32d81f889e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"dc078763-4903-4765-8f6f-ee32d81f889e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-10-18T16:53:10.850738Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1425"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:41 GMT
+      - Tue, 07 Nov 2023 16:29:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7050,7 +7050,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f68a22d-1ce5-48e8-9c98-2dfbaa72d35a
+      - fcda8eb3-a28e-4e90-aa35-d20adb197875
     status: 200 OK
     code: 200
     duration: ""
@@ -7061,19 +7061,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/dc078763-4903-4765-8f6f-ee32d81f889e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://dc078763-4903-4765-8f6f-ee32d81f889e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:53:10.838738Z","created_at":"2023-10-18T16:53:10.838738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.dc078763-4903-4765-8f6f-ee32d81f889e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"dc078763-4903-4765-8f6f-ee32d81f889e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-10-18T16:53:10.850738Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1425"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:46 GMT
+      - Tue, 07 Nov 2023 16:30:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7083,7 +7083,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96aa6012-3c5e-49f0-a76b-0fc363b5e60d
+      - 7a729333-a936-40bb-964e-9cf1af6a1942
     status: 200 OK
     code: 200
     duration: ""
@@ -7094,19 +7094,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/dc078763-4903-4765-8f6f-ee32d81f889e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://dc078763-4903-4765-8f6f-ee32d81f889e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:53:10.838738Z","created_at":"2023-10-18T16:53:10.838738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.dc078763-4903-4765-8f6f-ee32d81f889e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"dc078763-4903-4765-8f6f-ee32d81f889e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-10-18T16:53:10.850738Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1425"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:52 GMT
+      - Tue, 07 Nov 2023 16:30:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7116,7 +7116,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06a751d2-aa69-4e29-9004-90002cf770f7
+      - 217753dd-36f1-4cda-be18-cd491bac94de
     status: 200 OK
     code: 200
     duration: ""
@@ -7127,19 +7127,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/dc078763-4903-4765-8f6f-ee32d81f889e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://dc078763-4903-4765-8f6f-ee32d81f889e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:53:10.838738Z","created_at":"2023-10-18T16:53:10.838738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.dc078763-4903-4765-8f6f-ee32d81f889e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"dc078763-4903-4765-8f6f-ee32d81f889e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-10-18T16:53:10.850738Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1425"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:53:57 GMT
+      - Tue, 07 Nov 2023 16:30:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7149,7 +7149,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d6e3427-0c4f-4dec-bbac-7a13526b77e5
+      - 73c9f8aa-48d0-4c28-8499-86907af66dd1
     status: 200 OK
     code: 200
     duration: ""
@@ -7160,19 +7160,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/dc078763-4903-4765-8f6f-ee32d81f889e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://dc078763-4903-4765-8f6f-ee32d81f889e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:53:10.838738Z","created_at":"2023-10-18T16:53:10.838738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.dc078763-4903-4765-8f6f-ee32d81f889e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"dc078763-4903-4765-8f6f-ee32d81f889e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-10-18T16:53:10.850738Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1425"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:54:02 GMT
+      - Tue, 07 Nov 2023 16:30:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7182,7 +7182,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1eec862-b33d-4362-b28d-abc59398621f
+      - 90ba11ba-53ae-454a-bd1e-f1550da39bb3
     status: 200 OK
     code: 200
     duration: ""
@@ -7193,19 +7193,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/dc078763-4903-4765-8f6f-ee32d81f889e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://dc078763-4903-4765-8f6f-ee32d81f889e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:53:10.838738Z","created_at":"2023-10-18T16:53:10.838738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.dc078763-4903-4765-8f6f-ee32d81f889e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"dc078763-4903-4765-8f6f-ee32d81f889e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-10-18T16:54:02.715814Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1467"
+      - "1425"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:54:07 GMT
+      - Tue, 07 Nov 2023 16:30:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7215,7 +7215,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5be0588a-90ac-4eb4-8ce3-96416e0080f0
+      - 4a6089d8-ccce-464f-85a8-e9120dc10495
     status: 200 OK
     code: 200
     duration: ""
@@ -7226,19 +7226,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/dc078763-4903-4765-8f6f-ee32d81f889e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://dc078763-4903-4765-8f6f-ee32d81f889e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:53:10.838738Z","created_at":"2023-10-18T16:53:10.838738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.dc078763-4903-4765-8f6f-ee32d81f889e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"dc078763-4903-4765-8f6f-ee32d81f889e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-10-18T16:54:02.715814Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1467"
+      - "1425"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:54:07 GMT
+      - Tue, 07 Nov 2023 16:30:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7248,7 +7248,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ee85e3b-c407-426d-8f78-c1cb9670ae60
+      - f959c79e-3c50-45b1-a943-8ad315a5cd8c
     status: 200 OK
     code: 200
     duration: ""
@@ -7259,19 +7259,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/dc078763-4903-4765-8f6f-ee32d81f889e/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUbFJOZUUxc2IxaEVWRTE2VFZSQmVFNTZSVEpPVkUxNFRXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEc0ckNqRjNVRWxEU0c1UmJFNWpWMlZhWms5M1pqZHZNeXRwTjJ0U2NIZEdhakJUTmxsd05uTlRlSEZ6YlhwNVFrazViVzlIYlhwMGFFWnBNV2hvZERrMk1IY0taek5UVWxkdlptTlBSVFJrV1RsTVZUZEZlSGhIZVdaT1pXTnRSR1lyT0dFMGVtaGxZMFJzU2xSa2NYZDVVRWswZDJoekszVXJXbEpaVldSQ1dVdGFUZ28zYkhvMFNERjVWbVl2T0hjM1VXeHVhbGhLWlU1RFoyOHZiazE1TTFKdWFEWm1WMHcyTVV0aFREaE5SVmM1ZVVwMlUxb3lSamhqVEhOdU5sQjVkVlZQQ25kWE1rOXFOMEUyTm5GWk56TkVNa05QTTFsaWRqSnZaVkZHZURaclNIWnVWU3MzV0N0UldIcDFjM0pSYmpGU2JHcDNSVWhEVW5wblkyVXhTbkZ3VWt3S1dYQlpPVWN5YlZwSmVrZFFTbFpqV0VkWk9YTnNSREkyYUZkeGRuZEVkR1U1WkZwR1NVWjVkMFkyVGtsWk9EUjZiblV4V0V0Tk5VaHJWblpzVFZSeVdBb3djWGREUm10UU9IazJPSGxpUlVGYVFtMUZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZNSGN5YlZKemFGQkxVSEZGZGtNdk9HUm5UbGhhWmtWa2VsaE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRaRUpsUjBGQk0yeFhLMFU0UlN0NVN6aHRTbVZMYW5kQlRFRTJhVGd3Y2xOME1DczVaMXBNVFZCclpUUndVbTlzVVFwdVVuWXplWHAwYUdFMk5tTklZVVZNSzFGU05EWTBMMkZwUkZKelpHdEZTSFpyY1hWdlkzVjBabFJwWm5SRGFUbExNemRMZUhSMVJFSjJVVVEwVmxSUUNuQnpSMkpoWWxWS2NtRlZXazgyTjJKemFTOWFlakJRUlVSdGFHWkxkekpMT1RoeVRrOVhiVVJIT1hWSFRsQTNaV2gzYlVFeVExazNZazVOZDJwWmMwc0tOVEpOVEVSU0wyczNUazh3WVd0NVVtZDVUM0F5T0hwTlIzQlVUbWRPUkhSbmJqQlpjRFJ5WmtSV1dUWmhSWEJHYlVoYVVrcEphMVZFVWtRMFRrbHBad293YzNsVFFYazRhRlpNY0dScWNGTmpiakFyVW1vMmNXNDNNalZKV2tkNmJIVlNMMVoxYlhNeGQzbHpiR1ZHYVhaTVdrOWhLMUpxTUZJMGJHRnhUVGhpQ21GS1kybExjblZKTTNWa1Mxa3JOMkZvTUVsU2NsRnBUbkJ6VlVoTlMyMU5jMGRwUkFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2RjMDc4NzYzLTQ5MDMtNDc2NS04ZjZmLWVlMzJkODFmODg5ZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBKYVJtOUpMNWJtUWJUQU1HenR4WjUwTDh3RmZka2NOSzBtZThCdzJiN0ZTWUxIU0QyUnhhbUVHRw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"creating","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:29:28.482123Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "2622"
+      - "1425"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:54:07 GMT
+      - Tue, 07 Nov 2023 16:30:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7281,7 +7281,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2523ae00-a34c-4ce9-94b7-d47be7fe0f32
+      - 577a0b02-13f3-403c-bc3f-87900531157c
     status: 200 OK
     code: 200
     duration: ""
@@ -7292,19 +7292,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/dc078763-4903-4765-8f6f-ee32d81f889e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://dc078763-4903-4765-8f6f-ee32d81f889e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:53:10.838738Z","created_at":"2023-10-18T16:53:10.838738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.dc078763-4903-4765-8f6f-ee32d81f889e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"dc078763-4903-4765-8f6f-ee32d81f889e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-10-18T16:54:02.715814Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:30:36.894842Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1467"
+      - "1422"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:54:07 GMT
+      - Tue, 07 Nov 2023 16:30:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7314,7 +7314,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0507656e-e2aa-4429-a98f-689073c0a56d
+      - 2bdea557-aa27-453c-b272-6b4a283a8f7c
     status: 200 OK
     code: 200
     duration: ""
@@ -7325,19 +7325,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/dc078763-4903-4765-8f6f-ee32d81f889e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://dc078763-4903-4765-8f6f-ee32d81f889e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:53:10.838738Z","created_at":"2023-10-18T16:53:10.838738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.dc078763-4903-4765-8f6f-ee32d81f889e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"dc078763-4903-4765-8f6f-ee32d81f889e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-10-18T16:54:02.715814Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:30:36.894842Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1467"
+      - "1422"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:54:07 GMT
+      - Tue, 07 Nov 2023 16:30:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7347,7 +7347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8598bc5-7a44-4e12-8473-8799ed64fa28
+      - 6cba6bf6-a53a-42e5-8941-50ec7c1bfab5
     status: 200 OK
     code: 200
     duration: ""
@@ -7358,19 +7358,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/dc078763-4903-4765-8f6f-ee32d81f889e/kubeconfig
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78/kubeconfig
     method: GET
   response:
-    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUVhoT2VrVXlUbFJOZUUxc2IxaEVWRTE2VFZSQmVFNTZSVEpPVkUxNFRXeHZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVEc0ckNqRjNVRWxEU0c1UmJFNWpWMlZhWms5M1pqZHZNeXRwTjJ0U2NIZEdhakJUTmxsd05uTlRlSEZ6YlhwNVFrazViVzlIYlhwMGFFWnBNV2hvZERrMk1IY0taek5UVWxkdlptTlBSVFJrV1RsTVZUZEZlSGhIZVdaT1pXTnRSR1lyT0dFMGVtaGxZMFJzU2xSa2NYZDVVRWswZDJoekszVXJXbEpaVldSQ1dVdGFUZ28zYkhvMFNERjVWbVl2T0hjM1VXeHVhbGhLWlU1RFoyOHZiazE1TTFKdWFEWm1WMHcyTVV0aFREaE5SVmM1ZVVwMlUxb3lSamhqVEhOdU5sQjVkVlZQQ25kWE1rOXFOMEUyTm5GWk56TkVNa05QTTFsaWRqSnZaVkZHZURaclNIWnVWU3MzV0N0UldIcDFjM0pSYmpGU2JHcDNSVWhEVW5wblkyVXhTbkZ3VWt3S1dYQlpPVWN5YlZwSmVrZFFTbFpqV0VkWk9YTnNSREkyYUZkeGRuZEVkR1U1WkZwR1NVWjVkMFkyVGtsWk9EUjZiblV4V0V0Tk5VaHJWblpzVFZSeVdBb3djWGREUm10UU9IazJPSGxpUlVGYVFtMUZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWkZNSGN5YlZKemFGQkxVSEZGZGtNdk9HUm5UbGhhWmtWa2VsaE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkRaRUpsUjBGQk0yeFhLMFU0UlN0NVN6aHRTbVZMYW5kQlRFRTJhVGd3Y2xOME1DczVaMXBNVFZCclpUUndVbTlzVVFwdVVuWXplWHAwYUdFMk5tTklZVVZNSzFGU05EWTBMMkZwUkZKelpHdEZTSFpyY1hWdlkzVjBabFJwWm5SRGFUbExNemRMZUhSMVJFSjJVVVEwVmxSUUNuQnpSMkpoWWxWS2NtRlZXazgyTjJKemFTOWFlakJRUlVSdGFHWkxkekpMT1RoeVRrOVhiVVJIT1hWSFRsQTNaV2gzYlVFeVExazNZazVOZDJwWmMwc0tOVEpOVEVSU0wyczNUazh3WVd0NVVtZDVUM0F5T0hwTlIzQlVUbWRPUkhSbmJqQlpjRFJ5WmtSV1dUWmhSWEJHYlVoYVVrcEphMVZFVWtRMFRrbHBad293YzNsVFFYazRhRlpNY0dScWNGTmpiakFyVW1vMmNXNDNNalZKV2tkNmJIVlNMMVoxYlhNeGQzbHpiR1ZHYVhaTVdrOWhLMUpxTUZJMGJHRnhUVGhpQ21GS1kybExjblZKTTNWa1Mxa3JOMkZvTUVsU2NsRnBUbkJ6VlVoTlMyMU5jMGRwUkFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2RjMDc4NzYzLTQ5MDMtNDc2NS04ZjZmLWVlMzJkODFmODg5ZS5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBKYVJtOUpMNWJtUWJUQU1HenR4WjUwTDh3RmZka2NOSzBtZThCdzJiN0ZTWUxIU0QyUnhhbUVHRw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3ByZWsxR2IxaEVWRTE2VFZSRmQwNXFSVEpOYW10NlRVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVG10UENrNTVjVEIwYmxSVU9VMUpjR2RXUkZkdVIzRTBhVU5EUTJaMmNtMVpabGd2YkRsMllrTnRkVzFhUzFSMFNubzJTMGhVWjI5TVNXTlBlVXBVU2xWdmNGb0thV3RXUzA1WlNGUklLMU5qVGs1cGVrTk1PSGsyYVZoYVRTOXZSa281VURSUGRrTjZNVVpQVEhBNGNYRmtNVVE1YldSTlkyUkdVM05LVW5sVVdXZGFSZ3BFUzJneVIyNVpTR0l2YVVWUWFraFdlRXRwVW5SSmVqWXZaR1JQYjJwMVZYSlNOWE5FUVZCeGMzTnlkMUZpVGpWQ0syWlVORmN2ZEhKNFYyaG1UbmR1Q2xkSU9HeFBNeTlYTW1WSmQwdE9OV2MwWVM5RmFtMTVZa1JSYW5KWVowWlNSbkJCV0U1dmJqQjBVRzgxYjNWU01raHBiR0l3UVVKeVZ6QldjVEYxTTI0S2VuUllTRmxWYW5vclpFbFRSRWN5VHpCWFJrbG9lWGM1VXlzeVFXVm5ORWRvUjB3MVdXdHJSV1pDTVZOaWVFVnhWa3BxZUVkUGVETnNkazB6VjBkb1J3cHdNMjA1UTNCS1NVbERWR1ppUldWcVVIaEZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWlFMeThyY25JeGFESkZNSEIzWjBabmRVeFZXbUV4Y1U4NWFFcE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNSV1p3V0RSNlpuSkRXbnBuWW5oa0x6TlFjV2h5UzNoWVpXcDJXVkZCTWtKcFYwUllhbU5zYlRKd1JFODJOa1l6ZVFvck4ydHFOa2RwZW0xS1lUSjBPR1owVFUxTGVXTlZVbXRYU25OQ1pVRjNUM0EzUkVKVlVrNVllbUV6WkZOWE5UaHFjakp1WVhocFRGSlNWVXhxYkdReUNtNWxlbG92ZWtGSGNEaFJORmN4WVdKSU9FWk5iVlZDV2tOVWN6TmlkRkJRZUVFdldDOXNlRXQyZVVkUlJURjNWa2huVkZWcmRWbHJXRlJ1VkRaWU5FY0tTMjlqYWtoelRucE9WSGxMU2poQlZWVnJRVkZVWlZwUlYzcExhVUppYldaalRteDVSRUowTWtkc1pVSlVhMG81TjBNMU9IQXZlV1EzTVZvNVkxbDFWd280VnpRNE5GcGFXbVpPYWxabWExY3hjMnd6TjJaeFF5dGFVMDE0VEdkWVFsUjZia2hOYTNST1RHSnZUM0ZMTVZKdE1EVnpZVU5hTUVsaVFYWlFaREIzQ2t4cVFUWXpNRTFST1hWNFVXOHpkVlIxWVZwRlNWaFdhRW8zUWs5SFlVbGlkMjkyVUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2Y1MzRlYmVmLTNmZWUtNDAzOC05ZWFiLTYxNWI1NjZjNGU3OC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBhcmszUm56OHpZRnNOVVhvTUpxVlRWZU0zaDhPc3oxSmlDU0lhb1dzY0Rib0pmMUN4T0VGRjRYUw==","content_type":"application/octet-stream","name":"kubeconfig"}'
     headers:
       Content-Length:
-      - "2622"
+      - "2620"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:54:07 GMT
+      - Tue, 07 Nov 2023 16:30:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7380,7 +7380,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da5eb5c2-0260-4937-a633-06b3f7fd6467
+      - adf41e0b-1b4e-43db-9f0e-d54de9219562
     status: 200 OK
     code: 200
     duration: ""
@@ -7391,19 +7391,118 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/dc078763-4903-4765-8f6f-ee32d81f889e?with_additional_resources=false
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:30:36.894842Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1422"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:30:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 410931b9-e7ed-4148-a9a2-71821332f4eb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
+    method: GET
+  response:
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:30:36.894842Z","upgrade_available":false,"version":"1.28.2"}'
+    headers:
+      Content-Length:
+      - "1422"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:30:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 85c39ced-d2a5-4e0a-9da3-8218bb7e4fd6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78/kubeconfig
+    method: GET
+  response:
+    body: '{"content":"YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gbmFtZTogInRlc3QtdHlwZS1jaGFuZ2UiCiAgY2x1c3RlcjoKICAgIGNlcnRpZmljYXRlLWF1dGhvcml0eS1kYXRhOiBMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VNMWVrTkRRV01yWjBGM1NVSkJaMGxDUVVSQlRrSm5hM0ZvYTJsSE9YY3dRa0ZSYzBaQlJFRldUVkpOZDBWUldVUldVVkZFUlhkd2NtUlhTbXdLWTIwMWJHUkhWbnBOUWpSWVJGUkplazFVUlhkT2FrVXlUV3ByZWsxR2IxaEVWRTE2VFZSRmQwNXFSVEpOYW10NlRVWnZkMFpVUlZSTlFrVkhRVEZWUlFwQmVFMUxZVE5XYVZwWVNuVmFXRkpzWTNwRFEwRlRTWGRFVVZsS1MyOWFTV2gyWTA1QlVVVkNRbEZCUkdkblJWQkJSRU5EUVZGdlEyZG5SVUpCVG10UENrNTVjVEIwYmxSVU9VMUpjR2RXUkZkdVIzRTBhVU5EUTJaMmNtMVpabGd2YkRsMllrTnRkVzFhUzFSMFNubzJTMGhVWjI5TVNXTlBlVXBVU2xWdmNGb0thV3RXUzA1WlNGUklLMU5qVGs1cGVrTk1PSGsyYVZoYVRTOXZSa281VURSUGRrTjZNVVpQVEhBNGNYRmtNVVE1YldSTlkyUkdVM05LVW5sVVdXZGFSZ3BFUzJneVIyNVpTR0l2YVVWUWFraFdlRXRwVW5SSmVqWXZaR1JQYjJwMVZYSlNOWE5FUVZCeGMzTnlkMUZpVGpWQ0syWlVORmN2ZEhKNFYyaG1UbmR1Q2xkSU9HeFBNeTlYTW1WSmQwdE9OV2MwWVM5RmFtMTVZa1JSYW5KWVowWlNSbkJCV0U1dmJqQjBVRzgxYjNWU01raHBiR0l3UVVKeVZ6QldjVEYxTTI0S2VuUllTRmxWYW5vclpFbFRSRWN5VHpCWFJrbG9lWGM1VXlzeVFXVm5ORWRvUjB3MVdXdHJSV1pDTVZOaWVFVnhWa3BxZUVkUGVETnNkazB6VjBkb1J3cHdNMjA1UTNCS1NVbERWR1ppUldWcVVIaEZRMEYzUlVGQllVNURUVVZCZDBSbldVUldVakJRUVZGSUwwSkJVVVJCWjB0clRVRTRSMEV4VldSRmQwVkNDaTkzVVVaTlFVMUNRV1k0ZDBoUldVUldVakJQUWtKWlJVWlFMeThyY25JeGFESkZNSEIzWjBabmRVeFZXbUV4Y1U4NWFFcE5RVEJIUTFOeFIxTkpZak1LUkZGRlFrTjNWVUZCTkVsQ1FWRkNSV1p3V0RSNlpuSkRXbnBuWW5oa0x6TlFjV2h5UzNoWVpXcDJXVkZCTWtKcFYwUllhbU5zYlRKd1JFODJOa1l6ZVFvck4ydHFOa2RwZW0xS1lUSjBPR1owVFUxTGVXTlZVbXRYU25OQ1pVRjNUM0EzUkVKVlVrNVllbUV6WkZOWE5UaHFjakp1WVhocFRGSlNWVXhxYkdReUNtNWxlbG92ZWtGSGNEaFJORmN4WVdKSU9FWk5iVlZDV2tOVWN6TmlkRkJRZUVFdldDOXNlRXQyZVVkUlJURjNWa2huVkZWcmRWbHJXRlJ1VkRaWU5FY0tTMjlqYWtoelRucE9WSGxMU2poQlZWVnJRVkZVWlZwUlYzcExhVUppYldaalRteDVSRUowTWtkc1pVSlVhMG81TjBNMU9IQXZlV1EzTVZvNVkxbDFWd280VnpRNE5GcGFXbVpPYWxabWExY3hjMnd6TjJaeFF5dGFVMDE0VEdkWVFsUjZia2hOYTNST1RHSnZUM0ZMTVZKdE1EVnpZVU5hTUVsaVFYWlFaREIzQ2t4cVFUWXpNRTFST1hWNFVXOHpkVlIxWVZwRlNWaFdhRW8zUWs5SFlVbGlkMjkyVUFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovL2Y1MzRlYmVmLTNmZWUtNDAzOC05ZWFiLTYxNWI1NjZjNGU3OC5hcGkuazhzLmZyLXBhci5zY3cuY2xvdWQ6NjQ0Mwpjb250ZXh0czoKLSBuYW1lOiBhZG1pbkB0ZXN0LXR5cGUtY2hhbmdlCiAgY29udGV4dDoKICAgIGNsdXN0ZXI6ICJ0ZXN0LXR5cGUtY2hhbmdlIgogICAgdXNlcjogdGVzdC10eXBlLWNoYW5nZS1hZG1pbgpjdXJyZW50LWNvbnRleHQ6IGFkbWluQHRlc3QtdHlwZS1jaGFuZ2UKa2luZDogQ29uZmlnCnByZWZlcmVuY2VzOiB7fQp1c2VyczoKLSBuYW1lOiB0ZXN0LXR5cGUtY2hhbmdlLWFkbWluCiAgdXNlcjoKICAgIHRva2VuOiBhcmszUm56OHpZRnNOVVhvTUpxVlRWZU0zaDhPc3oxSmlDU0lhb1dzY0Rib0pmMUN4T0VGRjRYUw==","content_type":"application/octet-stream","name":"kubeconfig"}'
+    headers:
+      Content-Length:
+      - "2620"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Nov 2023 16:30:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2068a473-5a11-4d5b-8785-4640504ba5cc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78?with_additional_resources=false
     method: DELETE
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://dc078763-4903-4765-8f6f-ee32d81f889e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:53:10.838738Z","created_at":"2023-10-18T16:53:10.838738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.dc078763-4903-4765-8f6f-ee32d81f889e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"dc078763-4903-4765-8f6f-ee32d81f889e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-10-18T16:54:08.161769815Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:30:40.229640115Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1473"
+      - "1428"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:54:08 GMT
+      - Tue, 07 Nov 2023 16:30:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7413,7 +7512,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e85ce315-9088-492a-8d54-50535121645b
+      - e0047535-320b-473c-9542-8d16c49083d9
     status: 200 OK
     code: 200
     duration: ""
@@ -7424,19 +7523,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/dc078763-4903-4765-8f6f-ee32d81f889e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://dc078763-4903-4765-8f6f-ee32d81f889e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:53:10.838738Z","created_at":"2023-10-18T16:53:10.838738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.dc078763-4903-4765-8f6f-ee32d81f889e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"dc078763-4903-4765-8f6f-ee32d81f889e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-10-18T16:54:08.161770Z","upgrade_available":false,"version":"1.28.2"}'
+    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://f534ebef-3fee-4038-9eab-615b566c4e78.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-11-07T16:29:28.473193Z","created_at":"2023-11-07T16:29:28.473193Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.f534ebef-3fee-4038-9eab-615b566c4e78.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"f534ebef-3fee-4038-9eab-615b566c4e78","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-11-07T16:30:40.229640Z","upgrade_available":false,"version":"1.28.2"}'
     headers:
       Content-Length:
-      - "1470"
+      - "1425"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:54:08 GMT
+      - Tue, 07 Nov 2023 16:30:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7446,7 +7545,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d276085-e1ea-4926-b07e-4037f52363cd
+      - 1a442c09-f1e1-4bf1-872c-e9616fea87be
     status: 200 OK
     code: 200
     duration: ""
@@ -7457,43 +7556,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/dc078763-4903-4765-8f6f-ee32d81f889e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
     method: GET
   response:
-    body: '{"admission_plugins":[],"apiserver_cert_sans":[],"audit_log":false,"auto_upgrade":{"enabled":false,"maintenance_window":{"day":"any","start_hour":0}},"autoscaler_config":{"balance_similar_node_groups":false,"estimator":"binpacking","expander":"random","expendable_pods_priority_cutoff":0,"ignore_daemonsets_utilization":false,"max_graceful_termination_sec":0,"scale_down_delay_after_add":"10m","scale_down_disabled":false,"scale_down_unneeded_time":"10m","scale_down_utilization_threshold":0.5},"cluster_url":"https://dc078763-4903-4765-8f6f-ee32d81f889e.api.k8s.fr-par.scw.cloud:6443","cni":"kilo","commitment_ends_at":"2023-10-18T16:53:10.838738Z","created_at":"2023-10-18T16:53:10.838738Z","dashboard_enabled":false,"description":"","dns_wildcard":"*.dc078763-4903-4765-8f6f-ee32d81f889e.nodes.k8s.fr-par.scw.cloud","feature_gates":[],"id":"dc078763-4903-4765-8f6f-ee32d81f889e","ingress":"none","name":"test-type-change","open_id_connect_config":{"client_id":"","groups_claim":[],"groups_prefix":"","issuer_url":"","required_claim":[],"username_claim":"","username_prefix":""},"organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_id":null,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"deleting","tags":["terraform-test","scaleway_k8s_cluster","type-change"],"type":"multicloud","updated_at":"2023-10-18T16:54:08.161770Z","upgrade_available":false,"version":"1.28.2"}'
-    headers:
-      Content-Length:
-      - "1470"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 18 Oct 2023 16:54:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a67bd479-048a-4cc1-bd23-ca27803e4af4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/dc078763-4903-4765-8f6f-ee32d81f889e
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"dc078763-4903-4765-8f6f-ee32d81f889e","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"f534ebef-3fee-4038-9eab-615b566c4e78","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -7502,7 +7568,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:54:18 GMT
+      - Tue, 07 Nov 2023 16:30:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7512,7 +7578,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e600e8de-a828-40b2-b1bd-9258ef7b9284
+      - 842d216f-946a-4abf-8984-bb9a86d0423c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -7523,10 +7589,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/dc078763-4903-4765-8f6f-ee32d81f889e
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f534ebef-3fee-4038-9eab-615b566c4e78
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"dc078763-4903-4765-8f6f-ee32d81f889e","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"f534ebef-3fee-4038-9eab-615b566c4e78","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -7535,7 +7601,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 18 Oct 2023 16:54:18 GMT
+      - Tue, 07 Nov 2023 16:30:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -7545,7 +7611,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ec0fab1-6a5a-49a0-8dc1-1a4beed6a363
+      - b2b3cef8-d34e-499c-8b96-f630bc860e1b
     status: 404 Not Found
     code: 404
     duration: ""


### PR DESCRIPTION
There is an error 500 in the PoolPublicIPDisabled test that only occurred in the CI and not when recording the cassettes locally. We did not wait for the pool after deleting it, and that could cause issues when recreating a pool with the same name too soon (e.g. in the case of ForceNew)